### PR TITLE
feat: add support for supplying config options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "mongodb-log-writer": "^2.4.1",
         "mongodb-redact": "^1.1.6",
         "mongodb-schema": "^12.6.2",
+        "yargs-parser": "^21.1.1",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -29,6 +30,7 @@
         "@redocly/cli": "^1.34.2",
         "@types/node": "^22.14.0",
         "@types/simple-oauth2": "^5.0.7",
+        "@types/yargs-parser": "^21.0.3",
         "eslint": "^9.24.0",
         "eslint-config-prettier": "^10.1.1",
         "globals": "^16.0.0",
@@ -4768,6 +4770,13 @@
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.29.1",
@@ -11218,7 +11227,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@redocly/cli": "^1.34.2",
     "@types/node": "^22.14.0",
     "@types/simple-oauth2": "^5.0.7",
+    "@types/yargs-parser": "^21.0.3",
     "eslint": "^9.24.0",
     "eslint-config-prettier": "^10.1.1",
     "globals": "^16.0.0",
@@ -58,6 +59,7 @@
     "mongodb-log-writer": "^2.4.1",
     "mongodb-redact": "^1.1.6",
     "mongodb-schema": "^12.6.2",
+    "yargs-parser": "^21.1.1",
     "zod": "^3.24.2"
   },
   "engines": {

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -91,7 +91,7 @@ export class ApiClient {
             throw new Error("Not authenticated. Please run the auth tool first.");
         }
 
-        const url = new URL(`api/atlas/v2${endpoint}`, `${config.apiBaseURL}`);
+        const url = new URL(`api/atlas/v2${endpoint}`, `${config.apiBaseUrl}`);
 
         if (!this.checkTokenExpiry()) {
             await this.refreshToken();
@@ -119,7 +119,7 @@ export class ApiClient {
     async authenticate(): Promise<OauthDeviceCode> {
         const endpoint = "api/private/unauth/account/device/authorize";
 
-        const authUrl = new URL(endpoint, config.apiBaseURL);
+        const authUrl = new URL(endpoint, config.apiBaseUrl);
 
         const response = await fetch(authUrl, {
             method: "POST",
@@ -128,7 +128,7 @@ export class ApiClient {
                 Accept: "application/json",
             },
             body: new URLSearchParams({
-                client_id: config.clientID,
+                client_id: config.clientId,
                 scope: "openid profile offline_access",
                 grant_type: "urn:ietf:params:oauth:grant-type:device_code",
             }).toString(),
@@ -143,14 +143,14 @@ export class ApiClient {
 
     async retrieveToken(device_code: string): Promise<OAuthToken> {
         const endpoint = "api/private/unauth/account/device/token";
-        const url = new URL(endpoint, config.apiBaseURL);
+        const url = new URL(endpoint, config.apiBaseUrl);
         const response = await fetch(url, {
             method: "POST",
             headers: {
                 "Content-Type": "application/x-www-form-urlencoded",
             },
             body: new URLSearchParams({
-                client_id: config.clientID,
+                client_id: config.clientId,
                 device_code: device_code,
                 grant_type: "urn:ietf:params:oauth:grant-type:device_code",
             }).toString(),
@@ -179,7 +179,7 @@ export class ApiClient {
 
     async refreshToken(token?: OAuthToken): Promise<OAuthToken | null> {
         const endpoint = "api/private/unauth/account/device/token";
-        const url = new URL(endpoint, config.apiBaseURL);
+        const url = new URL(endpoint, config.apiBaseUrl);
         const response = await fetch(url, {
             method: "POST",
             headers: {
@@ -187,7 +187,7 @@ export class ApiClient {
                 Accept: "application/json",
             },
             body: new URLSearchParams({
-                client_id: config.clientID,
+                client_id: config.clientId,
                 refresh_token: (token || this.token)?.refresh_token || "",
                 grant_type: "refresh_token",
                 scope: "openid profile offline_access",
@@ -213,7 +213,7 @@ export class ApiClient {
 
     async revokeToken(token?: OAuthToken): Promise<void> {
         const endpoint = "api/private/unauth/account/device/token";
-        const url = new URL(endpoint, config.apiBaseURL);
+        const url = new URL(endpoint, config.apiBaseUrl);
         const response = await fetch(url, {
             method: "POST",
             headers: {
@@ -222,7 +222,7 @@ export class ApiClient {
                 "User-Agent": config.userAgent,
             },
             body: new URLSearchParams({
-                client_id: config.clientID,
+                client_id: config.clientId,
                 token: (token || this.token)?.access_token || "",
                 token_type_hint: "refresh_token",
             }).toString(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,17 +13,20 @@ interface UserConfig extends Record<string, string> {
     apiBaseUrl: string;
     clientId: string;
     stateFile: string;
-    projectId: string;
 }
 
 const defaults: UserConfig = {
     apiBaseUrl: "https://cloud.mongodb.com/",
     clientId: "0oabtxactgS3gHIR0297",
     stateFile: path.join(localDataPath, "state.json"),
-    projectId: "",
 };
 
-const mergedUserConfig = Object.assign({}, defaults, getFileConfig(), getEnvConfig(), getCliConfig());
+const mergedUserConfig = {
+    ...defaults,
+    ...getFileConfig(),
+    ...getEnvConfig(),
+    ...getCliConfig(),
+};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -68,12 +71,12 @@ function getEnvConfig(): Partial<UserConfig> {
     };
 
     const result: Partial<UserConfig> = {};
-    Object.keys(defaults).forEach((key) => {
+    for (const key of Object.keys(defaults)) {
         const envVarName = `MDB_MCP_${camelCaseToSNAKE_UPPER_CASE(key)}`;
         if (process.env[envVarName]) {
-            result[key as keyof UserConfig] = process.env[envVarName];
+            result[key] = process.env[envVarName];
         }
-    });
+    }
 
     return result;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,25 +3,45 @@ import fs from "fs";
 import { fileURLToPath } from "url";
 import os from "os";
 
+import argv from "yargs-parser";
+
+// If we decide to support non-string config options, we'll need to extend the mechanism for parsing
+// env variables.
+interface UserConfig extends Record<string, string> {
+    apiBaseUrl: string;
+    clientId: string;
+    stateFile: string;
+    projectId: string;
+}
+
+const cliConfig = argv(process.argv.slice(2)) as unknown as Partial<UserConfig>;
+
+const defaults: UserConfig = {
+    apiBaseUrl: "https://cloud.mongodb.com/",
+    clientId: "0oabtxactgS3gHIR0297",
+    stateFile: path.resolve("./state.json"),
+    projectId: "",
+};
+
+const mergedUserConfig = mergeConfigs(defaults, getFileConfig(), getEnvConfig(), cliConfig);
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const packageMetadata = fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8");
 const packageJson = JSON.parse(packageMetadata);
 
-export const config = {
+const config = {
+    ...mergedUserConfig,
     atlasApiVersion: `2025-03-12`,
     version: packageJson.version,
-    apiBaseURL: process.env.API_BASE_URL || "https://cloud.mongodb.com/",
-    clientID: process.env.CLIENT_ID || "0oabtxactgS3gHIR0297",
-    stateFile: process.env.STATE_FILE || path.resolve("./state.json"),
     userAgent: `AtlasMCP/${packageJson.version} (${process.platform}; ${process.arch}; ${process.env.HOSTNAME || "unknown"})`,
     localDataPath: getLocalDataPath(),
 };
 
 export default config;
 
-function getLocalDataPath() {
+function getLocalDataPath(): string {
     if (process.platform === "win32") {
         const appData = process.env.APPDATA;
         const localAppData = process.env.LOCALAPPDATA ?? process.env.APPDATA;
@@ -31,4 +51,51 @@ function getLocalDataPath() {
     }
 
     return path.join(os.homedir(), ".mongodb", "mongodb-mcp");
+}
+
+// Gets the config supplied by the user as environment variables. The variable names
+// are prefixed with `MDB_MCP_` and the keys match the UserConfig keys, but are converted
+// to SNAKE_UPPER_CASE.
+function getEnvConfig(): Partial<UserConfig> {
+    const camelCaseToSNAKE_UPPER_CASE = (str: string): string => {
+        return str.replace(/([a-z])([A-Z])/g, "$1_$2").toUpperCase();
+    };
+
+    const result: Partial<UserConfig> = {};
+    Object.keys(defaults).forEach((key) => {
+        const envVarName = `MDB_MCP_${camelCaseToSNAKE_UPPER_CASE(key)}`;
+        if (process.env[envVarName]) {
+            result[key as keyof UserConfig] = process.env[envVarName];
+        }
+    });
+
+    return result;
+}
+
+// Gets the config supplied by the user as a JSON file. The file is expected to be located in the local data path
+// and named `config.json`.
+function getFileConfig(): Partial<UserConfig> {
+    const configPath = path.join(getLocalDataPath(), "config.json");
+
+    try {
+        const config = fs.readFileSync(configPath, "utf8");
+        return JSON.parse(config);
+    } catch {
+        return {};
+    }
+}
+
+// Merges several user-supplied configs into one. The precedence is from right to left where the last
+// config in the `partialConfigs` array overrides the previous ones. The `defaults` config is used as a base.
+function mergeConfigs(defaults: UserConfig, ...partialConfigs: Array<Partial<UserConfig>>): UserConfig {
+    const mergedConfig: UserConfig = { ...defaults };
+    for (const key of Object.keys(defaults)) {
+        for (const partialConfig of partialConfigs) {
+            if (partialConfig[key]) {
+                mergedConfig[key] = partialConfig[key];
+            }
+        }
+    }
+
+    return mergedConfig;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ function getLocalDataPath(): { localDataPath: string; configPath: string } {
         const localAppData = process.env.LOCALAPPDATA ?? process.env.APPDATA;
         if (localAppData && appData) {
             localDataPath = path.join(localAppData, "mongodb", "mongodb-mcp");
-            configPath = path.join(localAppData, "mongodb", "mongodb-mcp.conf");
+            configPath = path.join(localDataPath, "mongodb-mcp.conf");
         }
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,8 +16,6 @@ interface UserConfig extends Record<string, string> {
     projectId: string;
 }
 
-const cliConfig = argv(process.argv.slice(2)) as unknown as Partial<UserConfig>;
-
 const defaults: UserConfig = {
     apiBaseUrl: "https://cloud.mongodb.com/",
     clientId: "0oabtxactgS3gHIR0297",
@@ -25,7 +23,7 @@ const defaults: UserConfig = {
     projectId: "",
 };
 
-const mergedUserConfig = mergeConfigs(defaults, getFileConfig(), getEnvConfig(), cliConfig);
+const mergedUserConfig = Object.assign({}, defaults, getFileConfig(), getEnvConfig(), getCliConfig());
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -93,17 +91,7 @@ function getFileConfig(): Partial<UserConfig> {
     }
 }
 
-// Merges several user-supplied configs into one. The precedence is from right to left where the last
-// config in the `partialConfigs` array overrides the previous ones. The `defaults` config is used as a base.
-function mergeConfigs(defaults: UserConfig, ...partialConfigs: Array<Partial<UserConfig>>): UserConfig {
-    const mergedConfig: UserConfig = { ...defaults };
-    for (const key of Object.keys(defaults)) {
-        for (const partialConfig of partialConfigs) {
-            if (partialConfig[key]) {
-                mergedConfig[key] = partialConfig[key];
-            }
-        }
-    }
-
-    return mergedConfig;
+// Reads the cli args and parses them into a UserConfig object.
+function getCliConfig() {
+    return argv(process.argv.slice(2)) as unknown as Partial<UserConfig>;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ const cliConfig = argv(process.argv.slice(2)) as unknown as Partial<UserConfig>;
 const defaults: UserConfig = {
     apiBaseUrl: "https://cloud.mongodb.com/",
     clientId: "0oabtxactgS3gHIR0297",
-    stateFile: path.resolve("./state.json"),
+    stateFile: path.join(getLocalDataPath(), "state.json"),
     projectId: "",
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,14 +21,14 @@ export class Server {
 
         this.apiClient = new ApiClient({
             token: this.state?.auth.token,
-            saveToken: (token) => {
+            saveToken: async (token) => {
                 if (!this.state) {
                     throw new Error("State is not initialized");
                 }
                 this.state.auth.code = undefined;
                 this.state.auth.token = token;
                 this.state.auth.status = "issued";
-                saveState(this.state);
+                await saveState(this.state);
             },
         });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import { State, saveState, loadState } from "./state.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { registerAtlasTools } from "./tools/atlas/tools.js";
 import { registerMongoDBTools } from "./tools/mongodb/index.js";
-import { config } from "./config.js";
+import config from "./config.js";
 import logger, { initializeLogger } from "./logger.js";
 import { mongoLogId } from "mongodb-log-writer";
 

--- a/src/tools/atlas/auth.ts
+++ b/src/tools/atlas/auth.ts
@@ -11,7 +11,7 @@ export class AuthTool extends AtlasToolBase {
     protected argsShape = {};
 
     private async isAuthenticated(): Promise<boolean> {
-        return isAuthenticated(this.state!, this.apiClient);
+        return isAuthenticated(this.state, this.apiClient);
     }
 
     async execute(): Promise<CallToolResult> {
@@ -25,11 +25,11 @@ export class AuthTool extends AtlasToolBase {
         try {
             const code = await this.apiClient.authenticate();
 
-            this.state!.auth.status = "requested";
-            this.state!.auth.code = code;
-            this.state!.auth.token = undefined;
+            this.state.auth.status = "requested";
+            this.state.auth.code = code;
+            this.state.auth.token = undefined;
 
-            await saveState(this.state!);
+            await saveState(this.state);
 
             return {
                 content: [

--- a/src/tools/mongodb/connect.ts
+++ b/src/tools/mongodb/connect.ts
@@ -4,6 +4,7 @@ import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver
 import { DbOperationType, MongoDBToolBase } from "./mongodbTool.js";
 import { ToolArgs } from "../tool";
 import { ErrorCodes, MongoDBError } from "../../errors.js";
+import { saveState } from "../../state.js";
 
 export class ConnectTool extends MongoDBToolBase {
     protected name = "connect";
@@ -20,8 +21,8 @@ export class ConnectTool extends MongoDBToolBase {
     protected async execute({
         connectionStringOrClusterName,
     }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
+        connectionStringOrClusterName ??= this.state.connectionString;
         if (!connectionStringOrClusterName) {
-            // TODO: try reconnecting to the default connection
             return {
                 content: [
                     { type: "text", text: "No connection details provided." },
@@ -71,5 +72,7 @@ export class ConnectTool extends MongoDBToolBase {
         });
 
         this.mongodbState.serviceProvider = provider;
+        this.state.connectionString = connectionString;
+        await saveState(this.state);
     }
 }


### PR DESCRIPTION
Adds the following mechanisms for supplying config (in order of precedence):
- cli args
- environment variables (field names are converted to `MDB_MCP_UPPER_SNAKE_CASE`
- `mongodb-mcp.conf` placed in the `/etc` folder on Unix or `%LOCAL_APP_DATA%\mongodb\mongodb-mcp`.

Fixes #21 

