### PR TITLE
chore: refactor integration test setup

### DIFF
--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -1,29 +1,29 @@
-import { jestTestMCPClient } from "./helpers.js";
+import { setupIntegrationTest } from "./helpers";
 
 describe("Server integration test", () => {
-    const client = jestTestMCPClient();
+    const integration = setupIntegrationTest();
 
     describe("list capabilities", () => {
         it("should return positive number of tools", async () => {
-            const tools = await client().listTools();
+            const tools = await integration.mcpClient().listTools();
             expect(tools).toBeDefined();
             expect(tools.tools.length).toBeGreaterThan(0);
         });
 
         it("should return no resources", async () => {
-            await expect(() => client().listResources()).rejects.toMatchObject({
+            await expect(() => integration.mcpClient().listResources()).rejects.toMatchObject({
                 message: "MCP error -32601: Method not found",
             });
         });
 
         it("should return no prompts", async () => {
-            await expect(() => client().listPrompts()).rejects.toMatchObject({
+            await expect(() => integration.mcpClient().listPrompts()).rejects.toMatchObject({
                 message: "MCP error -32601: Method not found",
             });
         });
 
         it("should return capabilities", async () => {
-            const capabilities = client().getServerCapabilities();
+            const capabilities = integration.mcpClient().getServerCapabilities();
             expect(capabilities).toBeDefined();
             expect(capabilities?.completions).toBeUndefined();
             expect(capabilities?.experimental).toBeUndefined();


### PR DESCRIPTION
Noticed that we're always running all the setup functions, so it made sense to just combine them into one.