### PR TITLE
fix: close mongo client between runs

### DIFF
--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -83,6 +83,9 @@ export function setupIntegrationTest(): IntegrationTest {
     afterEach(async () => {
         await mcpServer?.session.close();
         config.connectionString = undefined;
+
+        await mongoClient?.close();
+        mongoClient = undefined;
     });
 
     beforeAll(async function () {


### PR DESCRIPTION
Looks like we lost the `mongoClient?.close()` cleanup in https://github.com/mongodb-js/mongodb-mcp-server/pull/83, which caused jest to complain with `A worker process has failed to exit gracefully and has been force exited`.