### PR TITLE
chore: pin lcov-result-merger version

### DIFF
--- a/.github/workflows/code_health.yaml
+++ b/.github/workflows/code_health.yaml
@@ -105,7 +105,7 @@ jobs:
           path: coverage/atlas
       - name: Merge coverage reports
         run: |
-          npx -y lcov-result-merger "coverage/*/lcov.info" "coverage/lcov.info"
+          npx -y lcov-result-merger@5.0.1 "coverage/*/lcov.info" "coverage/lcov.info"
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2.3.6
         with:


### PR DESCRIPTION
Just thought of this, we would probably benefit from pinning the version both for the sake of security and to avoid any hypothetical breaking changes to the API in the future