### PR TITLE
fix: duplicated v on version bump

### DIFF
--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -33,13 +33,13 @@ jobs:
       - name: Create release PR
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # 7.0.8
         with:
-          title: "Release v${{ steps.bump-version.outputs.NEW_VERSION }}"
+          title: "Release ${{ steps.bump-version.outputs.NEW_VERSION }}"
           token: ${{ steps.app-token.outputs.token }}
-          commit-message: "Bump version to v${{ steps.bump-version.outputs.NEW_VERSION }}"
+          commit-message: "Bump version to ${{ steps.bump-version.outputs.NEW_VERSION }}"
           body: |
-            This PR bumps the package version to v${{ steps.bump-version.outputs.NEW_VERSION }}.
+            This PR bumps the package version to ${{ steps.bump-version.outputs.NEW_VERSION }}.
             Once merged, the new version will be published to npm.
           base: main
-          branch: release/v${{ steps.bump-version.outputs.NEW_VERSION }}
+          branch: release/${{ steps.bump-version.outputs.NEW_VERSION }}
           author: "${{ steps.app-token.outputs.app-slug}}[bot] <${{ steps.app-token.outputs.app-email }}>"
           committer: "${{ steps.app-token.outputs.app-slug}}[bot] <${{ steps.app-token.outputs.app-email }}>"


### PR DESCRIPTION
aims to fix duplicated v on release bump process (example https://github.com/mongodb-js/mongodb-mcp-server/pull/124)