### PR TITLE
chore: follow tools structure in atlas tools

### DIFF
--- a/src/tools/atlas/create/createAccessList.ts
+++ b/src/tools/atlas/create/createAccessList.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { AtlasToolBase } from "./atlasTool.js";
-import { ToolArgs, OperationType } from "../tool.js";
+import { AtlasToolBase } from "../atlasTool.js";
+import { ToolArgs, OperationType } from "../../tool.js";
 
 const DEFAULT_COMMENT = "Added by Atlas MCP";
 

--- a/src/tools/atlas/create/createDBUser.ts
+++ b/src/tools/atlas/create/createDBUser.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { AtlasToolBase } from "./atlasTool.js";
-import { ToolArgs, OperationType } from "../tool.js";
-import { CloudDatabaseUser, DatabaseUserRole } from "../../common/atlas/openapi.js";
+import { AtlasToolBase } from "../atlasTool.js";
+import { ToolArgs, OperationType } from "../../tool.js";
+import { CloudDatabaseUser, DatabaseUserRole } from "../../../common/atlas/openapi.js";
 
 export class CreateDBUserTool extends AtlasToolBase {
     protected name = "atlas-create-db-user";

--- a/src/tools/atlas/create/createFreeCluster.ts
+++ b/src/tools/atlas/create/createFreeCluster.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { AtlasToolBase } from "./atlasTool.js";
-import { ToolArgs, OperationType } from "../tool.js";
-import { ClusterDescription20240805 } from "../../common/atlas/openapi.js";
+import { AtlasToolBase } from "../atlasTool.js";
+import { ToolArgs, OperationType } from "../../tool.js";
+import { ClusterDescription20240805 } from "../../../common/atlas/openapi.js";
 
 export class CreateFreeClusterTool extends AtlasToolBase {
     protected name = "atlas-create-free-cluster";

--- a/src/tools/atlas/create/createProject.ts
+++ b/src/tools/atlas/create/createProject.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { AtlasToolBase } from "./atlasTool.js";
-import { ToolArgs, OperationType } from "../tool.js";
-import { Group } from "../../common/atlas/openapi.js";
+import { AtlasToolBase } from "../atlasTool.js";
+import { ToolArgs, OperationType } from "../../tool.js";
+import { Group } from "../../../common/atlas/openapi.js";
 
 export class CreateProjectTool extends AtlasToolBase {
     protected name = "atlas-create-project";

--- a/src/tools/atlas/read/inspectAccessList.ts
+++ b/src/tools/atlas/read/inspectAccessList.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { AtlasToolBase } from "./atlasTool.js";
-import { ToolArgs, OperationType } from "../tool.js";
+import { AtlasToolBase } from "../atlasTool.js";
+import { ToolArgs, OperationType } from "../../tool.js";
 
 export class InspectAccessListTool extends AtlasToolBase {
     protected name = "atlas-inspect-access-list";

--- a/src/tools/atlas/read/inspectCluster.ts
+++ b/src/tools/atlas/read/inspectCluster.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { AtlasToolBase } from "./atlasTool.js";
-import { ToolArgs, OperationType } from "../tool.js";
-import { ClusterDescription20240805 } from "../../common/atlas/openapi.js";
+import { AtlasToolBase } from "../atlasTool.js";
+import { ToolArgs, OperationType } from "../../tool.js";
+import { ClusterDescription20240805 } from "../../../common/atlas/openapi.js";
 
 export class InspectClusterTool extends AtlasToolBase {
     protected name = "atlas-inspect-cluster";

--- a/src/tools/atlas/read/listClusters.ts
+++ b/src/tools/atlas/read/listClusters.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { AtlasToolBase } from "./atlasTool.js";
-import { ToolArgs, OperationType } from "../tool.js";
-import { PaginatedClusterDescription20240805, PaginatedOrgGroupView, Group } from "../../common/atlas/openapi.js";
+import { AtlasToolBase } from "../atlasTool.js";
+import { ToolArgs, OperationType } from "../../tool.js";
+import { PaginatedClusterDescription20240805, PaginatedOrgGroupView, Group } from "../../../common/atlas/openapi.js";
 
 export class ListClustersTool extends AtlasToolBase {
     protected name = "atlas-list-clusters";

--- a/src/tools/atlas/read/listDBUsers.ts
+++ b/src/tools/atlas/read/listDBUsers.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { AtlasToolBase } from "./atlasTool.js";
-import { ToolArgs, OperationType } from "../tool.js";
-import { DatabaseUserRole, UserScope } from "../../common/atlas/openapi.js";
+import { AtlasToolBase } from "../atlasTool.js";
+import { ToolArgs, OperationType } from "../../tool.js";
+import { DatabaseUserRole, UserScope } from "../../../common/atlas/openapi.js";
 
 export class ListDBUsersTool extends AtlasToolBase {
     protected name = "atlas-list-db-users";

--- a/src/tools/atlas/read/listOrgs.ts
+++ b/src/tools/atlas/read/listOrgs.ts
@@ -1,6 +1,6 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { AtlasToolBase } from "./atlasTool.js";
-import { OperationType } from "../tool.js";
+import { AtlasToolBase } from "../atlasTool.js";
+import { OperationType } from "../../tool.js";
 
 export class ListOrganizationsTool extends AtlasToolBase {
     protected name = "atlas-list-orgs";

--- a/src/tools/atlas/read/listProjects.ts
+++ b/src/tools/atlas/read/listProjects.ts
@@ -1,8 +1,8 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { AtlasToolBase } from "./atlasTool.js";
-import { OperationType } from "../tool.js";
+import { AtlasToolBase } from "../atlasTool.js";
+import { OperationType } from "../../tool.js";
 import { z } from "zod";
-import { ToolArgs } from "../tool.js";
+import { ToolArgs } from "../../tool.js";
 
 export class ListProjectsTool extends AtlasToolBase {
     protected name = "atlas-list-projects";

--- a/src/tools/atlas/tools.ts
+++ b/src/tools/atlas/tools.ts
@@ -1,13 +1,13 @@
-import { ListClustersTool } from "./listClusters.js";
-import { ListProjectsTool } from "./listProjects.js";
-import { InspectClusterTool } from "./inspectCluster.js";
-import { CreateFreeClusterTool } from "./createFreeCluster.js";
-import { CreateAccessListTool } from "./createAccessList.js";
-import { InspectAccessListTool } from "./inspectAccessList.js";
-import { ListDBUsersTool } from "./listDBUsers.js";
-import { CreateDBUserTool } from "./createDBUser.js";
-import { CreateProjectTool } from "./createProject.js";
-import { ListOrganizationsTool } from "./listOrgs.js";
+import { ListClustersTool } from "./read/listClusters.js";
+import { ListProjectsTool } from "./read/listProjects.js";
+import { InspectClusterTool } from "./read/inspectCluster.js";
+import { CreateFreeClusterTool } from "./create/createFreeCluster.js";
+import { CreateAccessListTool } from "./create/createAccessList.js";
+import { InspectAccessListTool } from "./read/inspectAccessList.js";
+import { ListDBUsersTool } from "./read/listDBUsers.js";
+import { CreateDBUserTool } from "./create/createDBUser.js";
+import { CreateProjectTool } from "./create/createProject.js";
+import { ListOrganizationsTool } from "./read/listOrgs.js";
 
 export const AtlasTools = [
     ListClustersTool,


### PR DESCRIPTION
renaming files to follow same coding standards between atlas and mongodb