### PR TITLE
chore: revamp gha workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-    - package-ecosystem: "npm"
-      directory: "/"
-      schedule:
-          interval: "weekly"
-    - package-ecosystem: "github-actions"
-      directory: "/"
-      schedule:
-          interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/code_health_fork.yaml
+++ b/.github/workflows/code_health_fork.yaml
@@ -1,25 +1,19 @@
 ---
 name: Code Health
 on:
-  push:
+  pull_request_target:
     branches:
       - main
-  pull_request:
 
 permissions: {}
 
 jobs:
   run-tests:
     name: Run MongoDB tests
-    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        if: matrix.os != 'windows-latest'
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
@@ -30,7 +24,7 @@ jobs:
       - name: Run tests
         run: npm test
       - name: Upload test results
-        if: always() && matrix.os == 'ubuntu-latest'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results
@@ -38,7 +32,7 @@ jobs:
 
   run-atlas-tests:
     name: Run Atlas tests
-    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1
@@ -63,8 +57,8 @@ jobs:
           path: coverage/lcov.info
 
   coverage:
-    name: Run MongoDB tests
-    if: always() && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    name: Report Coverage
+    if: always() && github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     needs: [run-tests, run-atlas-tests]
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,37 +1,34 @@
 name: "CodeQL Advanced"
 
 on:
-    push:
-        branches: ["main"]
-    pull_request:
-        branches: ["main"]
-    schedule:
-        - cron: "35 4 * * 4"
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "35 4 * * 4"
 
 jobs:
-    analyze:
-        name: Analyze (${{ matrix.language }})
-        runs-on: ubuntu-latest
-        permissions:
-            security-events: write
-            packages: read
-            actions: read
-            contents: read
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
 
-        strategy:
-            fail-fast: false
-            matrix:
-                language:
-                    - actions
-                    - javascript-typescript
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-            - name: Initialize CodeQL
-              uses: github/codeql-action/init@v3
-              with:
-                  languages: ${{ matrix.language }}
-            - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v3
-              with:
-                  category: "/language:${{matrix.language}}"
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+---
+name: Lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  check-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run style check
+        run: npm run check
+
+  check-generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - run: npm run generate

--- a/.github/workflows/prepare_release.yaml
+++ b/.github/workflows/prepare_release.yaml
@@ -10,6 +10,8 @@ on:
         required: true
         default: "patch"
 
+permissions: {}
+
 jobs:
   create-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-permissions:
-  contents: write
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       VERSION_EXISTS: ${{ steps.check-version.outputs.VERSION_EXISTS }}
       VERSION: ${{ steps.get-version.outputs.VERSION }}
@@ -45,7 +45,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: Production
-    needs: check
+    permissions:
+      contents: write
+    needs:
+      - check
     if: needs.check.outputs.VERSION_EXISTS == 'false'
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -27,7 +27,7 @@
       }
     },
     {
-      "files": "*.yaml",
+      "files": ["*.yaml", "*.yml"],
       "options": {
         "tabWidth": 2,
         "printWidth": 80


### PR DESCRIPTION
This PR introduces the following changes:
- Separates the linting jobs into a `lint` workflow
- Adds a `code_health_fork` workflow that will be run on `pull_request_target` whenever the PR is from a fork or from dependabot
- Adds permissions to all workflows
- Reformats workflows (previously we had different styles for yaml vs yml)

The impetus for this change is to allow dependabot PRs to pass.