### PR TITLE
fix: use record instead of a passthrough object

### DIFF
--- a/src/tools/mongodb/create/insertMany.ts
+++ b/src/tools/mongodb/create/insertMany.ts
@@ -9,7 +9,7 @@ export class InsertManyTool extends MongoDBToolBase {
     protected argsShape = {
         ...DbOperationArgs,
         documents: z
-            .array(z.object({}).passthrough().describe("An individual MongoDB document"))
+            .array(z.record(z.string(), z.unknown()).describe("An individual MongoDB document"))
             .describe(
                 "The array of documents to insert, matching the syntax of the document argument of db.collection.insertMany()"
             ),

--- a/src/tools/mongodb/delete/deleteMany.ts
+++ b/src/tools/mongodb/delete/deleteMany.ts
@@ -9,8 +9,7 @@ export class DeleteManyTool extends MongoDBToolBase {
     protected argsShape = {
         ...DbOperationArgs,
         filter: z
-            .object({})
-            .passthrough()
+            .record(z.string(), z.unknown())
             .optional()
             .describe(
                 "The query filter, specifying the deletion criteria. Matches the syntax of the filter argument of db.collection.deleteMany()"

--- a/src/tools/mongodb/read/aggregate.ts
+++ b/src/tools/mongodb/read/aggregate.ts
@@ -5,7 +5,7 @@ import { ToolArgs, OperationType } from "../../tool.js";
 import { EJSON } from "bson";
 
 export const AggregateArgs = {
-    pipeline: z.array(z.object({}).passthrough()).describe("An array of aggregation stages to execute"),
+    pipeline: z.array(z.record(z.string(), z.unknown())).describe("An array of aggregation stages to execute"),
 };
 
 export class AggregateTool extends MongoDBToolBase {

--- a/src/tools/mongodb/read/count.ts
+++ b/src/tools/mongodb/read/count.ts
@@ -5,8 +5,7 @@ import { z } from "zod";
 
 export const CountArgs = {
     query: z
-        .object({})
-        .passthrough()
+        .record(z.string(), z.unknown())
         .optional()
         .describe(
             "The query filter to count documents. Matches the syntax of the filter argument of db.collection.count()"

--- a/src/tools/mongodb/read/find.ts
+++ b/src/tools/mongodb/read/find.ts
@@ -7,13 +7,11 @@ import { EJSON } from "bson";
 
 export const FindArgs = {
     filter: z
-        .object({})
-        .passthrough()
+        .record(z.string(), z.unknown())
         .optional()
         .describe("The query filter, matching the syntax of the query argument of db.collection.find()"),
     projection: z
-        .object({})
-        .passthrough()
+        .record(z.string(), z.unknown())
         .optional()
         .describe("The projection, matching the syntax of the projection argument of db.collection.find()"),
     limit: z.number().optional().default(10).describe("The maximum number of documents to return"),

--- a/src/tools/mongodb/update/updateMany.ts
+++ b/src/tools/mongodb/update/updateMany.ts
@@ -9,15 +9,13 @@ export class UpdateManyTool extends MongoDBToolBase {
     protected argsShape = {
         ...DbOperationArgs,
         filter: z
-            .object({})
-            .passthrough()
+            .record(z.string(), z.unknown())
             .optional()
             .describe(
                 "The selection criteria for the update, matching the syntax of the filter argument of db.collection.updateOne()"
             ),
         update: z
-            .object({})
-            .passthrough()
+            .record(z.string(), z.unknown())
             .describe("An update document describing the modifications to apply using update operator expressions"),
         upsert: z
             .boolean()


### PR DESCRIPTION
Fixes #139.
Needs additional testing with other editors to ensure a record of unknowns is similarly respected. Tested with Claude.