### PR TITLE
fix: use proper ESM with jest

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,7 +48,7 @@ export default defineConfig([
         "coverage",
         "global.d.ts",
         "eslint.config.js",
-        "jest.config.js",
+        "jest.config.ts",
     ]),
     eslintPluginPrettierRecommended,
 ]);

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,7 +12,7 @@ export default {
             "ts-jest",
             {
                 useESM: true,
-                tsconfig: "tsconfig.jest.json", // Use specific tsconfig file for Jest
+                tsconfig: "tsconfig.jest.json",
             },
         ],
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "check:types": "tsc --noEmit --project tsconfig.json",
     "reformat": "prettier --write .",
     "generate": "./scripts/generate.sh",
-    "test": "jest --coverage"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/tests/integration/tools/mongodb/mongodbHelpers.ts
+++ b/tests/integration/tools/mongodb/mongodbHelpers.ts
@@ -1,9 +1,12 @@
 import { MongoCluster } from "mongodb-runner";
 import path from "path";
+import { fileURLToPath } from "url";
 import fs from "fs/promises";
 import { MongoClient, ObjectId } from "mongodb";
 import { getResponseContent, IntegrationTest, setupIntegrationTest } from "../../helpers.js";
 import { config, UserConfig } from "../../../../src/config.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 interface MongoDBIntegrationTest {
     mongoClient: () => MongoClient;

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -4,6 +4,7 @@ import { Telemetry } from "../../src/telemetry/telemetry.js";
 import { BaseEvent, TelemetryResult } from "../../src/telemetry/types.js";
 import { EventCache } from "../../src/telemetry/eventCache.js";
 import { config } from "../../src/config.js";
+import { jest } from "@jest/globals";
 
 // Mock the ApiClient to avoid real API calls
 jest.mock("../../src/common/atlas/apiClient.js");
@@ -93,14 +94,19 @@ describe("Telemetry", () => {
 
         // Setup mocked API client
         mockApiClient = new MockApiClient({ baseUrl: "" }) as jest.Mocked<ApiClient>;
-        mockApiClient.sendEvents = jest.fn().mockResolvedValue(undefined);
-        mockApiClient.hasCredentials = jest.fn().mockReturnValue(true);
+        //@ts-expect-error This is a workaround
+        mockApiClient.sendEvents = jest.fn<() => undefined>().mockResolvedValue(undefined);
+        mockApiClient.hasCredentials = jest.fn<() => boolean>().mockReturnValue(true);
 
         // Setup mocked EventCache
         mockEventCache = new MockEventCache() as jest.Mocked<EventCache>;
+        //@ts-expect-error This is a workaround
         mockEventCache.getEvents = jest.fn().mockReturnValue([]);
+        //@ts-expect-error This is a workaround
         mockEventCache.clearEvents = jest.fn().mockResolvedValue(undefined);
+        //@ts-expect-error This is a workaround
         mockEventCache.appendEvents = jest.fn().mockResolvedValue(undefined);
+        //@ts-expect-error This is a workaround
         MockEventCache.getInstance = jest.fn().mockReturnValue(mockEventCache);
 
         // Create a simplified session with our mocked API client
@@ -108,7 +114,9 @@ describe("Telemetry", () => {
             apiClient: mockApiClient,
             sessionId: "test-session-id",
             agentRunner: { name: "test-agent", version: "1.0.0" } as const,
+            //@ts-expect-error This is a workaround
             close: jest.fn().mockResolvedValue(undefined),
+            //@ts-expect-error This is a workaround
             setAgentRunner: jest.fn().mockResolvedValue(undefined),
         } as unknown as Session;
 

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,8 +1,6 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "module": "esnext",
-    "target": "esnext",
     "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "types": ["jest", "jest-extended"]


### PR DESCRIPTION
We did not have a full ESM configuration for jest and therefore had a discrepancy between our build vs test. This discrepancy leads to issues with CommonJS modules.