### PR TITLE
chore: update quickstart with mcpServers

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ export MDB_MCP_LOG_PATH="/path/to/logs"
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "MongoDB": {
       "command": "npx",
       "args": ["-y", "mongodb-mcp-server"],
@@ -274,7 +274,7 @@ export MDB_MCP_LOG_PATH="/path/to/logs"
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "MongoDB": {
       "command": "npx",
       "args": ["-y", "mongodb-mcp-server"],
@@ -301,7 +301,7 @@ npx -y mongodb-mcp-server --apiClientId="your-atlas-client-id" --apiClientSecret
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "MongoDB": {
       "command": "npx",
       "args": [
@@ -319,7 +319,7 @@ npx -y mongodb-mcp-server --apiClientId="your-atlas-client-id" --apiClientSecret
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "MongoDB": {
       "command": "npx",
       "args": [

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Most MCP clients require a configuration file to be created or modified to add t
 - **Claude Desktop**: https://modelcontextprotocol.io/quickstart/user
 - **Cursor**: https://docs.cursor.com/context/model-context-protocol
 
+Note: The configuration file syntax can be different across clients. Please check the MCP client docs to apply the latest expected syntax.
+
 #### Option 1: Connection String args
 
 You can pass your connection string via args, make sure to use a valid username and password.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ Most MCP clients require a configuration file to be created or modified to add t
 - **Claude Desktop**: https://modelcontextprotocol.io/quickstart/user
 - **Cursor**: https://docs.cursor.com/context/model-context-protocol
 
-Note: The configuration file syntax can be different across clients. Please check the MCP client docs to apply the latest expected syntax.
+Note: The configuration file syntax can be different across clients. Please refer to the following links for the latest expected syntax:
+- [Windsurf Documentation](https://docs.windsurf.com/windsurf/mcp)
+- [VSCode Documentation](https://docs.codeium.com/docs/mcp)
+- [Claude Desktop Documentation](https://modelcontextprotocol.io/quickstart/user)
+- [Cursor Documentation](https://docs.cursor.com/context/model-context-protocol)
 
 #### Option 1: Connection String args
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can pass your connection string via args, make sure to use a valid username 
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "MongoDB": {
       "command": "npx",
       "args": [
@@ -69,7 +69,7 @@ Use your Atlas API Service Account credentials. More details in the [Atlas API A
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "MongoDB": {
       "command": "npx",
       "args": [

--- a/README.md
+++ b/README.md
@@ -38,16 +38,12 @@ node -v
 
 Most MCP clients require a configuration file to be created or modified to add the MCP server.
 
+Note: The configuration file syntax can be different across clients. Please refer to the following links for the latest expected syntax:
+
 - **Windsurf**:https://docs.windsurf.com/windsurf/mcp
 - **VSCode**: https://docs.codeium.com/docs/mcp
 - **Claude Desktop**: https://modelcontextprotocol.io/quickstart/user
 - **Cursor**: https://docs.cursor.com/context/model-context-protocol
-
-Note: The configuration file syntax can be different across clients. Please refer to the following links for the latest expected syntax:
-- [Windsurf Documentation](https://docs.windsurf.com/windsurf/mcp)
-- [VSCode Documentation](https://docs.codeium.com/docs/mcp)
-- [Claude Desktop Documentation](https://modelcontextprotocol.io/quickstart/user)
-- [Cursor Documentation](https://docs.cursor.com/context/model-context-protocol)
 
 #### Option 1: Connection String args
 


### PR DESCRIPTION
- defaults docs to mcpServers 
- adds a note about expected syntax discrepancies 