### PR TITLE
chore: skip Atlas Tests and don't track coverage for fork contributions

### DIFF
--- a/.github/workflows/code_health.yaml
+++ b/.github/workflows/code_health.yaml
@@ -112,5 +112,3 @@ jobs:
         uses: coverallsapp/github-action@v2.3.6
         with:
           file: coverage/lcov.info
-          git-branch: ${{ github.head_ref || github.ref_name }}
-          git-commit: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/code_health_fork.yaml
+++ b/.github/workflows/code_health_fork.yaml
@@ -32,7 +32,7 @@ jobs:
 
   run-atlas-tests:
     name: Run Atlas tests
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1
@@ -58,7 +58,7 @@ jobs:
 
   coverage:
     name: Report Coverage
-    if: always() && github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs: [run-tests, run-atlas-tests]
     steps:

--- a/.github/workflows/code_health_fork.yaml
+++ b/.github/workflows/code_health_fork.yaml
@@ -30,65 +30,6 @@ jobs:
           name: test-results
           path: coverage/lcov.info
 
-  run-atlas-tests:
-    name: Run Atlas tests
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: package.json
-          cache: "npm"
-      - name: Install dependencies
-        run: npm ci
-      - name: Run tests
-        env:
-          MDB_MCP_API_CLIENT_ID: ${{ secrets.TEST_ATLAS_CLIENT_ID }}
-          MDB_MCP_API_CLIENT_SECRET: ${{ secrets.TEST_ATLAS_CLIENT_SECRET }}
-          MDB_MCP_API_BASE_URL: ${{ vars.TEST_ATLAS_BASE_URL }}
-        run: npm test -- --testPathIgnorePatterns "tests/integration/tools/mongodb" --testPathIgnorePatterns "tests/integration/[^/]+\.ts"
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: atlas-test-results
-          path: coverage/lcov.info
-
-  coverage:
-    name: Report Coverage
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    needs: [run-tests, run-atlas-tests]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: package.json
-          cache: "npm"
-      - name: Install dependencies
-        run: npm ci
-      - name: Download test results
-        uses: actions/download-artifact@v4
-        with:
-          name: test-results
-          path: coverage/mongodb
-      - name: Download atlas test results
-        uses: actions/download-artifact@v4
-        with:
-          name: atlas-test-results
-          path: coverage/atlas
-      - name: Merge coverage reports
-        run: |
-          npx -y lcov-result-merger@5.0.1 "coverage/*/lcov.info" "coverage/lcov.info"
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v2.3.6
-        with:
-          file: coverage/lcov.info
-          git-branch: ${{ github.head_ref || github.ref_name }}
-          git-commit: ${{ github.event.pull_request.head.sha || github.sha }}
-
   merge-dependabot-pr:
     name: Merge Dependabot PR
     if: github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/code_health_fork.yaml
+++ b/.github/workflows/code_health_fork.yaml
@@ -38,7 +38,7 @@ jobs:
       pull-requests: write
       contents: write
     needs:
-      - coverage
+      - run-tests
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
We expose credentials in Atlas tests at the moment so we will skip them and coverage report checks for external forks and dependabot.