### PR TITLE
feat: create and update Search Index

### DIFF
--- a/src/tools/mongodb/create/createSearchIndex.ts
+++ b/src/tools/mongodb/create/createSearchIndex.ts
@@ -1,0 +1,38 @@
+import { DbOperationArgs, MongoDBToolBase, SearchIndexArgs } from "../mongodbTool.js";
+
+export class CreateSearchIndexTool extends MongoDBToolBase {
+    constructor() {
+        super(...arguments);
+        this.name = "create-search-index";
+        this.description = "Create an Atlas Search index for a collection";
+        this.argsShape = {
+            ...DbOperationArgs,
+            name: SearchIndexArgs.name,
+            type: SearchIndexArgs.type,
+            analyzer: SearchIndexArgs.analyzer,
+            mappings: SearchIndexArgs.mappings,
+        };
+        this.operationType = "create";
+    }
+    async execute({ database, collection, name, type, analyzer, mappings, }) {
+        const provider = await this.ensureConnected();
+        const indexes = await provider.createSearchIndexes(database, collection, [
+            {
+                name,
+                type,
+                definition: {
+                    analyzer,
+                    mappings,
+                },
+            },
+        ]);
+        return {
+            content: [
+                {
+                    text: `Created the index "${indexes[0]}" on collection "${collection}" in database "${database}"`,
+                    type: "text",
+                },
+            ],
+        };
+    }
+}

--- a/src/tools/mongodb/create/createSearchIndex.ts
+++ b/src/tools/mongodb/create/createSearchIndex.ts
@@ -2,13 +2,14 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase, SearchIndexArgs } from "../mongodbTool.js";
 import { OperationType, ToolArgs } from "../../tool.js";
 
+const SEARCH_INDEX_TYPE = "search";
+
 export class CreateSearchIndexTool extends MongoDBToolBase {
     protected name = "create-search-index";
     protected description = "Create an Atlas Search index for a collection";
     protected argsShape = {
         ...DbOperationArgs,
         name: SearchIndexArgs.name,
-        type: SearchIndexArgs.type,
         analyzer: SearchIndexArgs.analyzer,
         mappings: SearchIndexArgs.mappings,
     };
@@ -19,7 +20,6 @@ export class CreateSearchIndexTool extends MongoDBToolBase {
         database,
         collection,
         name,
-        type,
         analyzer,
         mappings,
     }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
@@ -27,7 +27,7 @@ export class CreateSearchIndexTool extends MongoDBToolBase {
         const indexes = await provider.createSearchIndexes(database, collection, [
             {
                 name,
-                type,
+                type: SEARCH_INDEX_TYPE,
                 definition: {
                     analyzer,
                     mappings,
@@ -38,7 +38,7 @@ export class CreateSearchIndexTool extends MongoDBToolBase {
         return {
             content: [
                 {
-                    text: `Created the index "${indexes[0]}" on collection "${collection}" in database "${database}"`,
+                    text: `Created the search index "${indexes[0]}" on collection "${collection}" in database "${database}"`,
                     type: "text",
                 },
             ],

--- a/src/tools/mongodb/create/createSearchIndex.ts
+++ b/src/tools/mongodb/create/createSearchIndex.ts
@@ -1,20 +1,28 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase, SearchIndexArgs } from "../mongodbTool.js";
+import { OperationType, ToolArgs } from "../../tool.js";
 
 export class CreateSearchIndexTool extends MongoDBToolBase {
-    constructor() {
-        super(...arguments);
-        this.name = "create-search-index";
-        this.description = "Create an Atlas Search index for a collection";
-        this.argsShape = {
-            ...DbOperationArgs,
-            name: SearchIndexArgs.name,
-            type: SearchIndexArgs.type,
-            analyzer: SearchIndexArgs.analyzer,
-            mappings: SearchIndexArgs.mappings,
-        };
-        this.operationType = "create";
-    }
-    async execute({ database, collection, name, type, analyzer, mappings, }) {
+    protected name = "create-search-index";
+    protected description = "Create an Atlas Search index for a collection";
+    protected argsShape = {
+        ...DbOperationArgs,
+        name: SearchIndexArgs.name,
+        type: SearchIndexArgs.type,
+        analyzer: SearchIndexArgs.analyzer,
+        mappings: SearchIndexArgs.mappings,
+    };
+
+    protected operationType: OperationType = "create";
+
+    protected async execute({
+        database,
+        collection,
+        name,
+        type,
+        analyzer,
+        mappings,
+    }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
         const provider = await this.ensureConnected();
         const indexes = await provider.createSearchIndexes(database, collection, [
             {
@@ -26,6 +34,7 @@ export class CreateSearchIndexTool extends MongoDBToolBase {
                 },
             },
         ]);
+
         return {
             content: [
                 {

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -12,7 +12,6 @@ export const DbOperationArgs = {
 
 export const SearchIndexArgs = {
     name: z.string().describe("The name of the index"),
-    type: z.enum(["search", "vectorSearch"]).optional().default("search").describe("The type of the index"),
     analyzer: z
         .string()
         .optional()
@@ -42,7 +41,6 @@ export const SearchIndexArgs = {
                                     "document",
                                     "embeddedDocuments",
                                     "geo",
-                                    "knnVector",
                                     "number",
                                     "objectId",
                                     "string",
@@ -61,7 +59,7 @@ export const SearchIndexArgs = {
                 .describe("The field mapping definitions. If `dynamic` is set to false, this is required."),
         })
         .describe(
-            "Document describing the index to create. The definition syntax depends on whether you create a standard search index or a Vector Search index."
+            "Document describing the index to create."
         ),
 };
 

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -58,9 +58,7 @@ export const SearchIndexArgs = {
                 .optional()
                 .describe("The field mapping definitions. If `dynamic` is set to false, this is required."),
         })
-        .describe(
-            "Document describing the index to create."
-        ),
+        .describe("Document describing the index to create."),
 };
 
 export abstract class MongoDBToolBase extends ToolBase {

--- a/src/tools/mongodb/tools.ts
+++ b/src/tools/mongodb/tools.ts
@@ -18,6 +18,8 @@ import { DropCollectionTool } from "./delete/dropCollection.js";
 import { ExplainTool } from "./metadata/explain.js";
 import { CreateCollectionTool } from "./create/createCollection.js";
 import { LogsTool } from "./metadata/logs.js";
+import { CreateSearchIndexTool } from "./create/createSearchIndex.js";
+import { UpdateSearchIndexTool } from "./update/updateSearchIndex.js";
 
 export const MongoDbTools = [
     ConnectTool,
@@ -40,4 +42,6 @@ export const MongoDbTools = [
     ExplainTool,
     CreateCollectionTool,
     LogsTool,
+    CreateSearchIndexTool,
+    UpdateSearchIndexTool,
 ];

--- a/src/tools/mongodb/update/updateSearchIndex.ts
+++ b/src/tools/mongodb/update/updateSearchIndex.ts
@@ -1,7 +1,6 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase, SearchIndexArgs } from "../mongodbTool.js";
 import { OperationType, ToolArgs } from "../../tool.js";
-import logger, { LogId } from "../../../logger.js";
 
 export class UpdateSearchIndexTool extends MongoDBToolBase {
     protected name = "update-search-index";
@@ -23,11 +22,6 @@ export class UpdateSearchIndexTool extends MongoDBToolBase {
         mappings,
     }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
         const provider = await this.ensureConnected();
-        logger.info(
-            LogId.toolExecute,
-            "server",
-            `Server started with transport ${JSON.stringify({ definition: { analyzer, mappings } })}`
-        );
         // @ts-expect-error: Interface expects a SearchIndexDefinition. However,
         // passing analyzer/mappings at the root for the definition is necessary for the call to succeed.
         await provider.updateSearchIndex(database, collection, name, {

--- a/src/tools/mongodb/update/updateSearchIndex.ts
+++ b/src/tools/mongodb/update/updateSearchIndex.ts
@@ -4,7 +4,7 @@ import { OperationType, ToolArgs } from "../../tool.js";
 
 export class UpdateSearchIndexTool extends MongoDBToolBase {
     protected name = "update-search-index";
-    protected description = "Updates a search index for a collection";
+    protected description = "Updates an Atlas Search index for a collection";
     protected argsShape = {
         ...DbOperationArgs,
         name: SearchIndexArgs.name,
@@ -32,7 +32,7 @@ export class UpdateSearchIndexTool extends MongoDBToolBase {
         return {
             content: [
                 {
-                    text: `Successfully updated index "${name}" on collection "${collection}" in database "${database}"`,
+                    text: `Successfully updated search index "${name}" on collection "${collection}" in database "${database}"`,
                     type: "text",
                 },
             ],

--- a/src/tools/mongodb/update/updateSearchIndex.ts
+++ b/src/tools/mongodb/update/updateSearchIndex.ts
@@ -1,0 +1,47 @@
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { DbOperationArgs, MongoDBToolBase, SearchIndexArgs } from "../mongodbTool.js";
+import { OperationType, ToolArgs } from "../../tool.js";
+import logger, { LogId } from "../../../logger.js";
+
+export class UpdateSearchIndexTool extends MongoDBToolBase {
+    protected name = "update-search-index";
+    protected description = "Updates a search index for a collection";
+    protected argsShape = {
+        ...DbOperationArgs,
+        name: SearchIndexArgs.name,
+        analyzer: SearchIndexArgs.analyzer,
+        mappings: SearchIndexArgs.mappings,
+    };
+
+    protected operationType: OperationType = "update";
+
+    protected async execute({
+        database,
+        collection,
+        name,
+        analyzer,
+        mappings,
+    }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
+        const provider = await this.ensureConnected();
+        logger.info(
+            LogId.toolExecute,
+            "server",
+            `Server started with transport ${JSON.stringify({ definition: { analyzer, mappings } })}`
+        );
+        // @ts-expect-error: Interface expects a SearchIndexDefinition. However,
+        // passing analyzer/mappings at the root for the definition is necessary for the call to succeed.
+        await provider.updateSearchIndex(database, collection, name, {
+            analyzer,
+            mappings,
+        });
+
+        return {
+            content: [
+                {
+                    text: `Successfully updated index "${name}" on collection "${collection}" in database "${database}"`,
+                    type: "text",
+                },
+            ],
+        };
+    }
+}


### PR DESCRIPTION
This is specifically for search indexes. The create vector index definition seems sufficiently different that I think it's worth separating.

VSCode copilot at least from my testing does better at distinguishing the two and understanding the fields to set when they are separate.

Tests will be added in a separate PR.