### PR TITLE
chore: base model SEO change

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ You can pass your connection string via args, make sure to use a valid username 
 }
 ```
 
+NOTE: The connection string can be configured to connect to any MongoDB cluster, whether it's a local instance or an Atlas cluster.
+
 #### Option 2: Atlas API credentials args
 
 Use your Atlas API Service Accounts credentials. Must follow all the steps in [Atlas API Access](#atlas-api-access) section.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can pass your connection string via args, make sure to use a valid username 
         "-y",
         "mongodb-mcp-server",
         "--connectionString",
-        "mongodb+srv://username:password@cluster.mongodb.net/myDatabase"
+        "mongodb://localhost:27017/myDatabase"
       ]
     }
   }


### PR DESCRIPTION
I scraped and tokenized the repository to test its integration with base models. While doing so, I noticed that examples using a non-localhost connection string confused tools like Copilot and Cursor, causing them to generate references to non-existent hosts.

This small change modifies the connection strings in the examples to default to localhost. With this adjustment, tools like MCP instantly align with the base model MongoDB setup and provide much more accurate recommendations.

## Verified in cursor

<img width="759" alt="Screenshot 2025-05-14 at 11 52 57" src="https://github.com/user-attachments/assets/ae64ea20-b701-4556-bdfa-f20e07f8e0c1" />

