### PR TITLE
chore: adds PlaygroundClient client and tests for RunPipeline tool

### DIFF
--- a/src/common/playground/playgroundClient.ts
+++ b/src/common/playground/playgroundClient.ts
@@ -1,0 +1,88 @@
+const PLAYGROUND_SEARCH_URL = "https://search-playground.mongodb.com/api/tools/code-playground/search";
+
+/**
+ * Payload for the Playground endpoint.
+ */
+export interface PlaygroundRunRequest {
+    documents: string;
+    aggregationPipeline: string;
+    indexDefinition: string;
+    synonyms: string;
+}
+
+/**
+ * Successful response from Playground server.
+ */
+export interface PlaygroundRunResponse {
+    documents: Array<Record<string, unknown>>;
+}
+
+/**
+ * Error response from Playground server.
+ */
+interface PlaygroundRunErrorResponse {
+    code: string;
+    message: string;
+}
+
+/**
+ * MCP specific Playground error public for tools.
+ */
+export class PlaygroundRunError extends Error implements PlaygroundRunErrorResponse {
+    constructor(
+        public message: string,
+        public code: string
+    ) {
+        super(message);
+    }
+}
+
+export enum RunErrorCode {
+    NETWORK_ERROR = "NETWORK_ERROR",
+    UNKNOWN = "UNKNOWN",
+}
+
+/**
+ * Handles Search Playground requests, abstracting low-level details from MCP tools.
+ * https://search-playground.mongodb.com
+ */
+export class PlaygroundClient {
+    async run(request: PlaygroundRunRequest): Promise<PlaygroundRunResponse> {
+        const options: RequestInit = {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(request),
+        };
+
+        let response: Response;
+        try {
+            response = await fetch(PLAYGROUND_SEARCH_URL, options);
+        } catch {
+            throw new PlaygroundRunError("Cannot run pipeline.", RunErrorCode.NETWORK_ERROR);
+        }
+
+        if (!response.ok) {
+            const runErrorResponse = await this.getRunErrorResponse(response);
+            throw new PlaygroundRunError(runErrorResponse.message, runErrorResponse.code);
+        }
+
+        try {
+            return (await response.json()) as PlaygroundRunResponse;
+        } catch {
+            throw new PlaygroundRunError("Response is not valid JSON.", RunErrorCode.UNKNOWN);
+        }
+    }
+
+    private async getRunErrorResponse(response: Response): Promise<PlaygroundRunErrorResponse> {
+        try {
+            return (await response.json()) as PlaygroundRunErrorResponse;
+        } catch {
+            return {
+                message: `HTTP ${response.status} ${response.statusText}.`,
+                code: RunErrorCode.UNKNOWN,
+            };
+        }
+    }
+}

--- a/tests/integration/tools/playground/runPipeline.test.ts
+++ b/tests/integration/tools/playground/runPipeline.test.ts
@@ -1,9 +1,28 @@
+import { jest } from "@jest/globals";
 import { describeWithMongoDB } from "../mongodb/mongodbHelpers.js";
 import { getResponseElements } from "../../helpers.js";
+import { PlaygroundRunError } from "../../../../src/common/playground/playgroundClient.js";
+
+const setupMockPlaygroundClient = (implementation: unknown) => {
+    // mock ESM modules https://jestjs.io/docs/ecmascript-modules#module-mocking-in-esm
+    jest.unstable_mockModule("../../../../src/common/playground/playgroundClient.js", () => ({
+        PlaygroundClient: implementation,
+    }));
+};
 
 describeWithMongoDB("runPipeline tool", (integration) => {
+    beforeEach(() => {
+        jest.resetModules();
+    });
+
     it("should return results", async () => {
-        await integration.connectMcpClient();
+        class PlaygroundClientMock {
+            run = () => ({
+                documents: [{ name: "First document" }],
+            });
+        }
+        setupMockPlaygroundClient(PlaygroundClientMock);
+
         const response = await integration.mcpClient().callTool({
             name: "run-pipeline",
             arguments: {
@@ -20,12 +39,6 @@ describeWithMongoDB("runPipeline tool", (integration) => {
                             },
                         },
                     },
-                    {
-                        $project: {
-                            _id: 0,
-                            name: 1,
-                        },
-                    },
                 ],
             },
         });
@@ -38,6 +51,29 @@ describeWithMongoDB("runPipeline tool", (integration) => {
             {
                 text: '{"name":"First document"}',
                 type: "text",
+            },
+        ]);
+    });
+
+    it("should return error", async () => {
+        class PlaygroundClientMock {
+            run = () => {
+                throw new PlaygroundRunError("Test error message", "TEST_CODE");
+            };
+        }
+        setupMockPlaygroundClient(PlaygroundClientMock);
+
+        const response = await integration.mcpClient().callTool({
+            name: "run-pipeline",
+            arguments: {
+                documents: [],
+                aggregationPipeline: [],
+            },
+        });
+        expect(response.content).toEqual([
+            {
+                type: "text",
+                text: "Error running run-pipeline: Error code: TEST_CODE. Error message: Test error message.",
             },
         ]);
     });


### PR DESCRIPTION
Adds `PlaygroundClient` class that handles Search Playground requests, abstracting low-level details from MCP tools.

Mocks `PlaygroundClient` in the tests. Adds success and error tests.

No changes to tool behavior.