### PR TITLE
feat: listSearchIndexes now lists index status info

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,19 +142,26 @@ NOTE: atlas tools are only available when you set credentials on [configuration]
 - `insert-one` - Insert a single document into a MongoDB collection
 - `insert-many` - Insert multiple documents into a MongoDB collection
 - `create-index` - Create an index for a MongoDB collection
+- `create-search-index` - Create a search index for a MongoDB collection
+- `create-vector-index` - Create a vector search index for a MongoDB collection
 - `update-one` - Update a single document in a MongoDB collection
 - `update-many` - Update multiple documents in a MongoDB collection
+- `update-search-index` - Update a search index for a MongoDB collection
+- `update-vector-index` - Update a vector search index for a MongoDB collection
 - `rename-collection` - Rename a MongoDB collection
 - `delete-one` - Delete a single document from a MongoDB collection
 - `delete-many` - Delete multiple documents from a MongoDB collection
 - `drop-collection` - Remove a collection from a MongoDB database
 - `drop-database` - Remove a MongoDB database
+- `drop-search-index` - Remove a search or vector search index from a MongoDB collection
 - `list-databases` - List all databases for a MongoDB connection
 - `list-collections` - List all collections for a given database
 - `collection-indexes` - Describe the indexes for a collection
+- `collection-search-indexes` - Describe the search indexes for a collection
 - `collection-schema` - Describe the schema for a collection
 - `collection-storage-size` - Get the size of a collection in MB
 - `db-stats` - Return statistics about a MongoDB database
+- `run-pipeline` - Run an aggregation against JSON documents (Atlas account not required)
 
 ## Configuration
 

--- a/src/common/search/listSearchIndexesOutput.ts
+++ b/src/common/search/listSearchIndexesOutput.ts
@@ -1,0 +1,49 @@
+export interface IndexDefinitionVersion {
+    version: number;
+    createdAt: string; // ISO 8601 date string
+}
+
+export interface IndexDefinition {
+    [key: string]: unknown;
+}
+
+export interface SynonymMappingStatusDetails {
+    status: string;
+    queryable: boolean;
+    message?: string;
+}
+
+export interface IndexStatusInfo {
+    status: string;
+    queryable: boolean;
+    synonymMappingStatus?: string;
+    synonymMappingStatusDetails?: SynonymMappingStatusDetails;
+    definitionVersion: IndexDefinitionVersion;
+    definition: IndexDefinition;
+}
+
+export interface SearchIndexStatusDetail {
+    hostname: string;
+    status: string;
+    queryable: boolean;
+    mainIndex: IndexStatusInfo;
+    stagedIndex?: IndexStatusInfo;
+}
+
+export interface SynonymMappingStatusDetail {
+    status: string;
+    queryable: boolean;
+    message?: string;
+}
+
+export interface ListSearchIndexOutput {
+    id: string;
+    name: string;
+    status: string;
+    queryable: boolean;
+    latestDefinitionVersion: IndexDefinitionVersion;
+    latestDefinition: IndexDefinition;
+    statusDetail: SearchIndexStatusDetail[];
+    synonymMappingStatus?: "BUILDING" | "FAILED" | "READY";
+    synonymMappingStatusDetail?: SynonymMappingStatusDetail[];
+}

--- a/src/tools/mongodb/read/collectionSearchIndexes.ts
+++ b/src/tools/mongodb/read/collectionSearchIndexes.ts
@@ -2,6 +2,7 @@ import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ToolArgs, OperationType } from "../../tool.js";
 import { z } from "zod";
+import { ListSearchIndexOutput } from "../../../common/search/listSearchIndexesOutput.js";
 
 export const ListSearchIndexesArgs = {
     indexName: z
@@ -12,10 +13,6 @@ export const ListSearchIndexesArgs = {
             "The name of the index to return information about. Returns all indexes on collection if not provided."
         ),
 };
-export interface SearchIndex {
-    name: string;
-    latestDefinition: Record<string, unknown>;
-}
 
 export class CollectionSearchIndexesTool extends MongoDBToolBase {
     protected name = "collection-search-indexes";
@@ -33,12 +30,18 @@ export class CollectionSearchIndexesTool extends MongoDBToolBase {
         indexName,
     }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
         const provider = await this.ensureConnected();
-
-        const indexes: SearchIndex[] = (
-            (await provider.getSearchIndexes(database, collection, indexName)) as SearchIndex[]
+        const indexes: ListSearchIndexOutput[] = (
+            (await provider.getSearchIndexes(database, collection, indexName)) as ListSearchIndexOutput[]
         ).map((doc) => ({
+            id: doc.id,
             name: doc.name,
+            status: doc.status,
+            queryable: doc.queryable,
+            latestDefinitionVersion: doc.latestDefinitionVersion,
             latestDefinition: doc.latestDefinition,
+            statusDetail: doc.statusDetail,
+            synonymMappingStatus: doc.synonymMappingStatus,
+            synonymMappingStatusDetail: doc.synonymMappingStatusDetail,
         }));
 
         return {
@@ -51,7 +54,17 @@ export class CollectionSearchIndexesTool extends MongoDBToolBase {
                 },
                 ...(indexes.map((indexDefinition) => {
                     return {
-                        text: `\nName: "${indexDefinition.name}"\nDefinition: ${JSON.stringify(indexDefinition.latestDefinition, null, 2)}\n`,
+                        text: [
+                            `Name: "${indexDefinition.name}"`,
+                            `Definition: ${JSON.stringify(indexDefinition.latestDefinition, null, 2)}`,
+                            `Queryable: ${indexDefinition.queryable}`,
+                            `Status: "${indexDefinition.status}"`,
+                            `Status Detail: ${JSON.stringify(indexDefinition.statusDetail, null, 2)}`,
+                            `Definition Version: ${JSON.stringify(indexDefinition.latestDefinitionVersion, null, 2)}`,
+                            `Synonym Mapping Status: ${indexDefinition.synonymMappingStatus}`,
+                            `Synonym Mapping Status Detail: ${JSON.stringify(indexDefinition.synonymMappingStatusDetail, null, 2)}`,
+                            `ID: ${indexDefinition.id}`,
+                        ].join("\n"),
                         type: "text",
                     };
                 }) as { text: string; type: "text" }[]),


### PR DESCRIPTION
# Description

## Before
List search indexes provided name and index definition

## After
List search indexes returns a lot more information including status and queryability etc.