### PR TITLE
fix: test fails with the latest sdk

### DIFF
--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -47,11 +47,12 @@ describe("Server integration test", () => {
             it("should return capabilities", () => {
                 const capabilities = integration.mcpClient().getServerCapabilities();
                 expectDefined(capabilities);
-                expect(capabilities.completions).toBeUndefined();
-                expect(capabilities.experimental).toBeUndefined();
-                expectDefined(capabilities?.tools);
                 expectDefined(capabilities?.logging);
-                expect(capabilities?.prompts).toBeUndefined();
+                expectDefined(capabilities?.completions);
+                expectDefined(capabilities?.tools);
+                expectDefined(capabilities?.resources);
+                expect(capabilities.experimental).toBeUndefined();
+                expect(capabilities.prompts).toBeUndefined();
             });
         });
     });


### PR DESCRIPTION
It seems that after the SDK update there is one test that fails because the protocol default values have changed. For some reason this has not been catched by the PR automated tests.