### PR TITLE
fix: Broken internal urls in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ With Atlas API credentials:
 }
 ```
 
-## 🛠️ Supported Tools {#supported-tools}
+## 🛠️ Supported Tools
 
 ### Tool List
 
@@ -488,6 +488,6 @@ npx -y mongodb-mcp-server --apiClientId="your-atlas-service-accounts-client-id" 
 }
 ```
 
-## 🤝 Contributing <a name="contributing"></a>
+## 🤝 Contributing
 
 Interested in contributing? Great! Please check our [Contributing Guide](CONTRIBUTING.md) for guidelines on code contributions, standards, adding new tools, and troubleshooting information.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A Model Context Protocol server for interacting with MongoDB Databases and Mongo
 - [🤝 Contributing](#contributing)
 
 <a name="getting-started"></a>
+
 ## Prerequisites
 
 - Node.js (v20.10.0 or later)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Model Context Protocol server for interacting with MongoDB Databases and MongoDB Atlas.
 
-## 📚 Table of Contents {#getting-started}
+## 📚 Table of Contents
 
 - [🚀 Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
@@ -15,15 +15,16 @@ A Model Context Protocol server for interacting with MongoDB Databases and Mongo
 - [🛠️ Supported Tools](#supported-tools)
   - [MongoDB Atlas Tools](#mongodb-atlas-tools)
   - [MongoDB Database Tools](#mongodb-database-tools)
-- [⚙️ Configuration](#configuration)
+- [⚙️ Configuration](#-configuration)
   - [Configuration Options](#configuration-options)
   - [Atlas API Access](#atlas-api-access)
   - [Configuration Methods](#configuration-methods)
     - [Environment Variables](#environment-variables)
     - [Command-Line Arguments](#command-line-arguments)
     - [MCP Client Configuration](#mcp-configuration-file-examples)
-- [🤝 Contributing](#contributing)
+- [🤝 Contributing](#-contributing)
 
+<a name="getting-started"></a>
 ## Prerequisites
 
 - Node.js (v20.10.0 or later)
@@ -487,6 +488,6 @@ npx -y mongodb-mcp-server --apiClientId="your-atlas-service-accounts-client-id" 
 }
 ```
 
-## 🤝 Contributing {#contributing}
+## 🤝 Contributing <a name="contributing"></a>
 
 Interested in contributing? Great! Please check our [Contributing Guide](CONTRIBUTING.md) for guidelines on code contributions, standards, adding new tools, and troubleshooting information.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Model Context Protocol server for interacting with MongoDB Databases and MongoDB Atlas.
 
-## 📚 Table of Contents
+## 📚 Table of Contents {#getting-started}
 
 - [🚀 Getting Started](#getting-started)
   - [Prerequisites](#prerequisites)
@@ -46,7 +46,7 @@ Most MCP clients require a configuration file to be created or modified to add t
 
 Note: The configuration file syntax can be different across clients. Please refer to the following links for the latest expected syntax:
 
-- **Windsurf**:https://docs.windsurf.com/windsurf/mcp
+- **Windsurf**: https://docs.windsurf.com/windsurf/mcp
 - **VSCode**: https://code.visualstudio.com/docs/copilot/chat/mcp-servers
 - **Claude Desktop**: https://modelcontextprotocol.io/quickstart/user
 - **Cursor**: https://docs.cursor.com/context/model-context-protocol
@@ -206,7 +206,7 @@ With Atlas API credentials:
 }
 ```
 
-## 🛠️ Supported Tools
+## 🛠️ Supported Tools {#supported-tools}
 
 ### Tool List
 
@@ -487,6 +487,6 @@ npx -y mongodb-mcp-server --apiClientId="your-atlas-service-accounts-client-id" 
 }
 ```
 
-## 🤝 Contributing
+## 🤝 Contributing {#contributing}
 
 Interested in contributing? Great! Please check our [Contributing Guide](CONTRIBUTING.md) for guidelines on code contributions, standards, adding new tools, and troubleshooting information.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol server for interacting with MongoDB Databases and Mongo
 - [🛠️ Supported Tools](#supported-tools)
   - [MongoDB Atlas Tools](#mongodb-atlas-tools)
   - [MongoDB Database Tools](#mongodb-database-tools)
-- [⚙️ Configuration](#-configuration)
+- [⚙️ Configuration](#configuration)
   - [Configuration Options](#configuration-options)
   - [Atlas API Access](#atlas-api-access)
   - [Configuration Methods](#configuration-methods)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Model Context Protocol server for interacting with MongoDB Databases and Mongo
     - [Environment Variables](#environment-variables)
     - [Command-Line Arguments](#command-line-arguments)
     - [MCP Client Configuration](#mcp-configuration-file-examples)
-- [🤝 Contributing](#-contributing)
+- [🤝 Contributing](#contributing)
 
 <a name="getting-started"></a>
 ## Prerequisites
@@ -488,6 +488,6 @@ npx -y mongodb-mcp-server --apiClientId="your-atlas-service-accounts-client-id" 
 }
 ```
 
-## 🤝 Contributing
+## 🤝Contributing
 
 Interested in contributing? Great! Please check our [Contributing Guide](CONTRIBUTING.md) for guidelines on code contributions, standards, adding new tools, and troubleshooting information.


### PR DESCRIPTION
## Proposed changes
When I opened the readme page in Windsurf, I noticed a few broken links.

Fixed broken internal links in the readme:
- `#getting-started` did not exist, put an anchor under the table of contents
- The `contributing` link was broken because there was a space between `🤝` and `Contributing` in the title

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
