### PR TITLE
chore: reinstate telemetry/docker change after revert MCP-49

### DIFF
--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -18,7 +18,7 @@ export const DEVICE_ID_TIMEOUT = 3000;
 
 export class Telemetry {
     private isBufferingEvents: boolean = true;
-    /** Resolves when the device ID is retrieved or timeout occurs */
+    /** Resolves when the setup is complete or a timeout occurs */
     public setupPromise: Promise<[string, boolean]> | undefined;
     private deviceIdAbortController = new AbortController();
     private eventCache: EventCache;

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -19,7 +19,7 @@ export const DEVICE_ID_TIMEOUT = 3000;
 export class Telemetry {
     private isBufferingEvents: boolean = true;
     /** Resolves when the device ID is retrieved or timeout occurs */
-    public dataPromise: Promise<[string, boolean]> | undefined;
+    public setupPromise: Promise<[string, boolean]> | undefined;
     private deviceIdAbortController = new AbortController();
     private eventCache: EventCache;
     private getRawMachineId: () => Promise<string>;
@@ -49,7 +49,7 @@ export class Telemetry {
     ): Telemetry {
         const instance = new Telemetry(session, userConfig, commonProperties, { eventCache, getRawMachineId });
 
-        void instance.start();
+        void instance.setup();
         return instance;
     }
 
@@ -76,11 +76,11 @@ export class Telemetry {
         return exists.includes(true);
     }
 
-    private async start(): Promise<void> {
+    private async setup(): Promise<void> {
         if (!this.isTelemetryEnabled()) {
             return;
         }
-        this.dataPromise = Promise.all([
+        this.setupPromise = Promise.all([
             getDeviceId({
                 getMachineId: () => this.getRawMachineId(),
                 onError: (reason, error) => {
@@ -101,7 +101,7 @@ export class Telemetry {
             this.isContainerEnv(),
         ]);
 
-        const [deviceId, containerEnv] = await this.dataPromise;
+        const [deviceId, containerEnv] = await this.setupPromise;
 
         this.commonProperties.device_id = deviceId;
         this.commonProperties.is_container_env = containerEnv;

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -66,6 +66,7 @@ export type CommonStaticProperties = {
  */
 export type CommonProperties = {
     device_id?: string;
+    is_container_env?: boolean;
     mcp_client_version?: string;
     mcp_client_name?: string;
     config_atlas_auth?: TelemetryBoolSet;

--- a/tests/integration/telemetry.test.ts
+++ b/tests/integration/telemetry.test.ts
@@ -20,7 +20,7 @@ describe("Telemetry", () => {
         expect(telemetry.getCommonProperties().device_id).toBe(undefined);
         expect(telemetry["isBufferingEvents"]).toBe(true);
 
-        await telemetry.dataPromise;
+        await telemetry.setupPromise;
 
         expect(telemetry.getCommonProperties().device_id).toBe(actualHashedId);
         expect(telemetry["isBufferingEvents"]).toBe(false);

--- a/tests/integration/telemetry.test.ts
+++ b/tests/integration/telemetry.test.ts
@@ -20,7 +20,7 @@ describe("Telemetry", () => {
         expect(telemetry.getCommonProperties().device_id).toBe(undefined);
         expect(telemetry["isBufferingEvents"]).toBe(true);
 
-        await telemetry.deviceIdPromise;
+        await telemetry.dataPromise;
 
         expect(telemetry.getCommonProperties().device_id).toBe(actualHashedId);
         expect(telemetry["isBufferingEvents"]).toBe(false);

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -138,7 +138,7 @@ describe("Telemetry", () => {
             it("should send events successfully", async () => {
                 const testEvent = createTestEvent();
 
-                await telemetry.dataPromise;
+                await telemetry.setupPromise;
 
                 await telemetry.emitEvents([testEvent]);
 
@@ -154,7 +154,7 @@ describe("Telemetry", () => {
 
                 const testEvent = createTestEvent();
 
-                await telemetry.dataPromise;
+                await telemetry.setupPromise;
 
                 await telemetry.emitEvents([testEvent]);
 
@@ -179,7 +179,7 @@ describe("Telemetry", () => {
                 // Set up mock to return cached events
                 mockEventCache.getEvents.mockReturnValueOnce([cachedEvent]);
 
-                await telemetry.dataPromise;
+                await telemetry.setupPromise;
 
                 await telemetry.emitEvents([newEvent]);
 
@@ -191,7 +191,7 @@ describe("Telemetry", () => {
             });
 
             it("should correctly add common properties to events", async () => {
-                await telemetry.dataPromise;
+                await telemetry.setupPromise;
 
                 const commonProps = telemetry.getCommonProperties();
 
@@ -227,7 +227,7 @@ describe("Telemetry", () => {
                     expect(telemetry["isBufferingEvents"]).toBe(true);
                     expect(telemetry.getCommonProperties().device_id).toBe(undefined);
 
-                    await telemetry.dataPromise;
+                    await telemetry.setupPromise;
 
                     expect(telemetry["isBufferingEvents"]).toBe(false);
                     expect(telemetry.getCommonProperties().device_id).toBe(hashedMachineId);
@@ -243,7 +243,7 @@ describe("Telemetry", () => {
                     expect(telemetry["isBufferingEvents"]).toBe(true);
                     expect(telemetry.getCommonProperties().device_id).toBe(undefined);
 
-                    await telemetry.dataPromise;
+                    await telemetry.setupPromise;
 
                     expect(telemetry["isBufferingEvents"]).toBe(false);
                     expect(telemetry.getCommonProperties().device_id).toBe("unknown");
@@ -271,7 +271,7 @@ describe("Telemetry", () => {
 
                     jest.advanceTimersByTime(DEVICE_ID_TIMEOUT);
 
-                    await telemetry.dataPromise;
+                    await telemetry.setupPromise;
 
                     expect(telemetry.getCommonProperties().device_id).toBe("unknown");
                     expect(telemetry["isBufferingEvents"]).toBe(false);

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -219,7 +219,7 @@ describe("Telemetry", () => {
                     expect(telemetry["isBufferingEvents"]).toBe(true);
                     expect(telemetry.getCommonProperties().device_id).toBe(undefined);
 
-                    await telemetry.deviceIdPromise;
+                    await telemetry.dataPromise;
 
                     expect(telemetry["isBufferingEvents"]).toBe(false);
                     expect(telemetry.getCommonProperties().device_id).toBe(hashedMachineId);
@@ -235,7 +235,7 @@ describe("Telemetry", () => {
                     expect(telemetry["isBufferingEvents"]).toBe(true);
                     expect(telemetry.getCommonProperties().device_id).toBe(undefined);
 
-                    await telemetry.deviceIdPromise;
+                    await telemetry.dataPromise;
 
                     expect(telemetry["isBufferingEvents"]).toBe(false);
                     expect(telemetry.getCommonProperties().device_id).toBe("unknown");
@@ -263,7 +263,7 @@ describe("Telemetry", () => {
 
                     jest.advanceTimersByTime(DEVICE_ID_TIMEOUT);
 
-                    await telemetry.deviceIdPromise;
+                    await telemetry.dataPromise;
 
                     expect(telemetry.getCommonProperties().device_id).toBe("unknown");
                     expect(telemetry["isBufferingEvents"]).toBe(false);

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -138,6 +138,8 @@ describe("Telemetry", () => {
             it("should send events successfully", async () => {
                 const testEvent = createTestEvent();
 
+                await telemetry.dataPromise;
+
                 await telemetry.emitEvents([testEvent]);
 
                 verifyMockCalls({
@@ -151,6 +153,8 @@ describe("Telemetry", () => {
                 mockApiClient.sendEvents.mockRejectedValueOnce(new Error("API error"));
 
                 const testEvent = createTestEvent();
+
+                await telemetry.dataPromise;
 
                 await telemetry.emitEvents([testEvent]);
 
@@ -175,6 +179,8 @@ describe("Telemetry", () => {
                 // Set up mock to return cached events
                 mockEventCache.getEvents.mockReturnValueOnce([cachedEvent]);
 
+                await telemetry.dataPromise;
+
                 await telemetry.emitEvents([newEvent]);
 
                 verifyMockCalls({
@@ -184,7 +190,9 @@ describe("Telemetry", () => {
                 });
             });
 
-            it("should correctly add common properties to events", () => {
+            it("should correctly add common properties to events", async () => {
+                await telemetry.dataPromise;
+
                 const commonProps = telemetry.getCommonProperties();
 
                 // Use explicit type assertion


### PR DESCRIPTION
## Proposed changes

changes were initially introduced at https://github.com/mongodb-js/mongodb-mcp-server/pull/298 which caused https://github.com/mongodb-js/mongodb-mcp-server/issues/320 and reverted at https://github.com/mongodb-js/mongodb-mcp-server/pull/330, I'm adding it back without any refactorings

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
