### PR TITLE
fix: turn atlas-connect-cluster async

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,6 +17,8 @@ export const LogId = {
     atlasDeleteDatabaseUserFailure: mongoLogId(1_001_002),
     atlasConnectFailure: mongoLogId(1_001_003),
     atlasInspectFailure: mongoLogId(1_001_004),
+    atlasConnectAttempt: mongoLogId(1_001_005),
+    atlasConnectSuccessed: mongoLogId(1_001_006),
 
     telemetryDisabled: mongoLogId(1_002_001),
     telemetryEmitFailure: mongoLogId(1_002_002),

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -18,7 +18,7 @@ export const LogId = {
     atlasConnectFailure: mongoLogId(1_001_003),
     atlasInspectFailure: mongoLogId(1_001_004),
     atlasConnectAttempt: mongoLogId(1_001_005),
-    atlasConnectSuccessed: mongoLogId(1_001_006),
+    atlasConnectSucceeded: mongoLogId(1_001_006),
 
     telemetryDisabled: mongoLogId(1_002_001),
     telemetryEmitFailure: mongoLogId(1_002_002),

--- a/src/session.ts
+++ b/src/session.ts
@@ -67,30 +67,27 @@ export class Session extends EventEmitter<{
             }
             this.serviceProvider = undefined;
         }
-        if (!this.connectedAtlasCluster) {
-            this.emit("disconnect");
-            return;
-        }
-        void this.apiClient
-            .deleteDatabaseUser({
-                params: {
-                    path: {
-                        groupId: this.connectedAtlasCluster.projectId,
-                        username: this.connectedAtlasCluster.username,
-                        databaseName: "admin",
+        if (this.connectedAtlasCluster?.username && this.connectedAtlasCluster?.projectId) {
+            void this.apiClient
+                .deleteDatabaseUser({
+                    params: {
+                        path: {
+                            groupId: this.connectedAtlasCluster.projectId,
+                            username: this.connectedAtlasCluster.username,
+                            databaseName: "admin",
+                        },
                     },
-                },
-            })
-            .catch((err: unknown) => {
-                const error = err instanceof Error ? err : new Error(String(err));
-                logger.error(
-                    LogId.atlasDeleteDatabaseUserFailure,
-                    "atlas-connect-cluster",
-                    `Error deleting previous database user: ${error.message}`
-                );
-            });
-        this.connectedAtlasCluster = undefined;
-
+                })
+                .catch((err: unknown) => {
+                    const error = err instanceof Error ? err : new Error(String(err));
+                    logger.error(
+                        LogId.atlasDeleteDatabaseUserFailure,
+                        "atlas-connect-cluster",
+                        `Error deleting previous database user: ${error.message}`
+                    );
+                });
+            this.connectedAtlasCluster = undefined;
+        }
         this.emit("disconnect");
     }
 

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -142,8 +142,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                 this.session.connectedAtlasCluster.projectId != projectId ||
                 this.session.connectedAtlasCluster.clusterName != clusterName
             ) {
-                lastError = new Error("Cluster connection aborted");
-                break;
+                throw new Error("Cluster connection aborted");
             }
 
             try {
@@ -167,7 +166,7 @@ export class ConnectClusterTool extends AtlasToolBase {
         }
 
         if (lastError) {
-            if (this.session.connectedAtlasCluster?.projectId && this.session.connectedAtlasCluster?.username) {
+            if (this.session.connectedAtlasCluster?.projectId == projectId && this.session.connectedAtlasCluster?.clusterName == clusterName && this.session.connectedAtlasCluster?.username) {
                 void this.session.apiClient
                     .deleteDatabaseUser({
                         params: {

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -223,7 +223,7 @@ export class ConnectClusterTool extends AtlasToolBase {
             content: [
                 {
                     type: "text",
-                    text: `Connecting to cluster "${clusterName}"...`,
+                    text: `Attempting to connect to cluster "${clusterName}"...`,
                 },
             ],
         };

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -14,7 +14,7 @@ function sleep(ms: number): Promise<void> {
 
 export class ConnectClusterTool extends AtlasToolBase {
     protected name = "atlas-connect-cluster";
-    protected description = "Connect to / Inspect connection of MongoDB Atlas cluster";
+    protected description = "Connect to MongoDB Atlas cluster";
     protected operationType: OperationType = "metadata";
     protected argsShape = {
         projectId: z.string().describe("Atlas project ID"),

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -122,11 +122,7 @@ export class ConnectClusterTool extends AtlasToolBase {
         return cn.toString();
     }
 
-    private async connectToCluster(
-        projectId: string,
-        clusterName: string,
-        connectionString: string
-    ): Promise<void> {
+    private async connectToCluster(projectId: string, clusterName: string, connectionString: string): Promise<void> {
         let lastError: Error | undefined = undefined;
 
         logger.debug(
@@ -166,7 +162,11 @@ export class ConnectClusterTool extends AtlasToolBase {
         }
 
         if (lastError) {
-            if (this.session.connectedAtlasCluster?.projectId == projectId && this.session.connectedAtlasCluster?.clusterName == clusterName && this.session.connectedAtlasCluster?.username) {
+            if (
+                this.session.connectedAtlasCluster?.projectId == projectId &&
+                this.session.connectedAtlasCluster?.clusterName == clusterName &&
+                this.session.connectedAtlasCluster?.username
+            ) {
                 void this.session.apiClient
                     .deleteDatabaseUser({
                         params: {
@@ -218,7 +218,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                 default:
                     await this.session.disconnect();
                     const connectionString = await this.prepareClusterConnection(projectId, clusterName);
-                    
+
                     // try to connect for about 5 minutes asynchronously
                     void this.connectToCluster(projectId, clusterName, connectionString).catch((err: unknown) => {
                         const error = err instanceof Error ? err : new Error(String(err));

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -201,7 +201,7 @@ export class ConnectClusterTool extends AtlasToolBase {
         for (let i = 0; i < 60; i++) {
             const state = await this.queryConnection(projectId, clusterName);
             switch (state) {
-                case "connected":
+                case "connected": {
                     return {
                         content: [
                             {
@@ -210,12 +210,14 @@ export class ConnectClusterTool extends AtlasToolBase {
                             },
                         ],
                     };
-                case "connecting":
+                }
+                case "connecting": {
                     break;
+                }
                 case "connected-to-other-cluster":
                 case "disconnected":
                 case "unknown":
-                default:
+                default: {
                     await this.session.disconnect();
                     const connectionString = await this.prepareClusterConnection(projectId, clusterName);
 
@@ -229,6 +231,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                         );
                     });
                     break;
+                }
             }
 
             await sleep(500);

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -47,8 +47,6 @@ export class ConnectClusterTool extends AtlasToolBase {
     }
 
     private async prepareClusterConnection(projectId: string, clusterName: string): Promise<string> {
-        await this.session.disconnect();
-
         const cluster = await inspectCluster(this.session.apiClient, projectId, clusterName);
 
         if (!cluster.connectionString) {
@@ -194,6 +192,11 @@ export class ConnectClusterTool extends AtlasToolBase {
                             },
                         ],
                     };
+                case "connected-to-other-cluster":
+                case "disconnected":
+                default:
+                    // fall through to create new connection
+                    break;
             }
         } catch (err: unknown) {
             const error = err instanceof Error ? err : new Error(String(err));
@@ -205,6 +208,7 @@ export class ConnectClusterTool extends AtlasToolBase {
             // fall through to create new connection
         }
 
+        await this.session.disconnect();
         const connectionString = await this.prepareClusterConnection(projectId, clusterName);
         process.nextTick(async () => {
             try {

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -105,9 +105,7 @@ export class ConnectClusterTool extends AtlasToolBase {
         cn.username = username;
         cn.password = password;
         cn.searchParams.set("authSource", "admin");
-        const connectionString = cn.toString();
-
-        return connectionString;
+        return cn.toString();
     }
 
     private async connectToCluster(connectionString: string): Promise<void> {
@@ -141,24 +139,26 @@ export class ConnectClusterTool extends AtlasToolBase {
         }
 
         if (lastError) {
-            void this.session.apiClient
-                .deleteDatabaseUser({
-                    params: {
-                        path: {
-                            groupId: this.session.connectedAtlasCluster?.projectId || "",
-                            username: this.session.connectedAtlasCluster?.username || "",
-                            databaseName: "admin",
+            if (this.session.connectedAtlasCluster?.projectId && this.session.connectedAtlasCluster?.username) {
+                void this.session.apiClient
+                    .deleteDatabaseUser({
+                        params: {
+                            path: {
+                                groupId: this.session.connectedAtlasCluster.projectId,
+                                username: this.session.connectedAtlasCluster.username,
+                                databaseName: "admin",
+                            },
                         },
-                    },
-                })
-                .catch((err: unknown) => {
-                    const error = err instanceof Error ? err : new Error(String(err));
-                    logger.debug(
-                        LogId.atlasConnectFailure,
-                        "atlas-connect-cluster",
-                        `error deleting database user: ${error.message}`
-                    );
-                });
+                    })
+                    .catch((err: unknown) => {
+                        const error = err instanceof Error ? err : new Error(String(err));
+                        logger.debug(
+                            LogId.atlasConnectFailure,
+                            "atlas-connect-cluster",
+                            `error deleting database user: ${error.message}`
+                        );
+                    });
+            }
             this.session.connectedAtlasCluster = undefined;
             throw lastError;
         }

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -5,7 +5,6 @@ import { ToolArgs, OperationType } from "../../tool.js";
 import { generateSecurePassword } from "../../../common/atlas/generatePassword.js";
 import logger, { LogId } from "../../../logger.js";
 import { inspectCluster } from "../../../common/atlas/cluster.js";
-import { error } from "console";
 
 const EXPIRY_MS = 1000 * 60 * 60 * 12; // 12 hours
 

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -14,7 +14,7 @@ function sleep(ms: number): Promise<void> {
 
 export class ConnectClusterTool extends AtlasToolBase {
     protected name = "atlas-connect-cluster";
-    protected description = "Connect to/Query status of MongoDB Atlas cluster";
+    protected description = "Connect to MongoDB Atlas cluster";
     protected operationType: OperationType = "metadata";
     protected argsShape = {
         projectId: z.string().describe("Atlas project ID"),

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -244,6 +244,10 @@ export class ConnectClusterTool extends AtlasToolBase {
                     type: "text" as const,
                     text: `Warning: Provisioning a user and connecting to the cluster may take more time, please check again in a few seconds.`,
                 },
+                {
+                    type: "text" as const,
+                    text: `Warning: Make sure your IP address is whitelisted in the Atlas cluster settings.`,
+                },
             ],
         };
     }

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -5,6 +5,7 @@ import { ToolArgs, OperationType } from "../../tool.js";
 import { generateSecurePassword } from "../../../common/atlas/generatePassword.js";
 import logger, { LogId } from "../../../logger.js";
 import { inspectCluster } from "../../../common/atlas/cluster.js";
+import { error } from "console";
 
 const EXPIRY_MS = 1000 * 60 * 60 * 12; // 12 hours
 
@@ -115,6 +116,12 @@ export class ConnectClusterTool extends AtlasToolBase {
     private async connectToCluster(connectionString: string): Promise<void> {
         let lastError: Error | undefined = undefined;
 
+        logger.debug(
+            LogId.atlasConnectAttempt,
+            "atlas-connect-cluster",
+            `attempting to connect to cluster: ${this.session.connectedAtlasCluster?.clusterName}`
+        );
+
         for (let i = 0; i < 600; i++) {
             // try for 5 minutes
             try {
@@ -158,6 +165,12 @@ export class ConnectClusterTool extends AtlasToolBase {
             this.session.connectedAtlasCluster = undefined;
             throw lastError;
         }
+
+        logger.debug(
+            LogId.atlasConnectSuccessed,
+            "atlas-connect-cluster",
+            `connected to cluster: ${this.session.connectedAtlasCluster?.clusterName}`
+        );
     }
 
     protected async execute({ projectId, clusterName }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -11,16 +11,36 @@ const EXPIRY_MS = 1000 * 60 * 60 * 12; // 12 hours
 function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
 export class ConnectClusterTool extends AtlasToolBase {
     protected name = "atlas-connect-cluster";
-    protected description = "Connect to MongoDB Atlas cluster";
+    protected description = "Connect to/Query status of MongoDB Atlas cluster";
     protected operationType: OperationType = "metadata";
     protected argsShape = {
         projectId: z.string().describe("Atlas project ID"),
         clusterName: z.string().describe("Atlas cluster name"),
     };
 
-    protected async execute({ projectId, clusterName }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
+    private async queryConnection(projectId: string, clusterName: string) : Promise<"connected" | "disconnected" | "connecting" | "connected-to-other-cluster"> {
+        if (!this.session.connectedAtlasCluster) {
+            return "disconnected";
+        }
+
+        if (this.session.connectedAtlasCluster.projectId !== projectId || this.session.connectedAtlasCluster.clusterName !== clusterName) {
+            return "connected-to-other-cluster";
+        }
+
+        if (!this.session.serviceProvider) {
+            return "connecting";
+        }
+
+        await this.session.serviceProvider.runCommand("admin", {
+            ping: 1,
+        });
+        return "connected";
+    }
+
+    private async prepareClusterConnection(projectId: string, clusterName: string) : Promise<string> {
         await this.session.disconnect();
 
         const cluster = await inspectCluster(this.session.apiClient, projectId, clusterName);
@@ -83,9 +103,13 @@ export class ConnectClusterTool extends AtlasToolBase {
         cn.searchParams.set("authSource", "admin");
         const connectionString = cn.toString();
 
+        return connectionString;
+    }
+
+    private async connectToCluster(connectionString: string): Promise<void> {
         let lastError: Error | undefined = undefined;
 
-        for (let i = 0; i < 20; i++) {
+        for (let i = 0; i < 600; i++) { // try for 5 minutes
             try {
                 await this.session.connectToMongoDB(connectionString, this.config.connectOptions);
                 lastError = undefined;
@@ -104,16 +128,81 @@ export class ConnectClusterTool extends AtlasToolBase {
                 await sleep(500); // wait for 500ms before retrying
             }
         }
-
+    
         if (lastError) {
+            void this.session.apiClient.deleteDatabaseUser({
+                params: {
+                    path: {
+                        groupId: this.session.connectedAtlasCluster?.projectId || "",
+                        username: this.session.connectedAtlasCluster?.username || "",
+                        databaseName: "admin",
+                    },
+                },
+            }).catch((err: unknown) => {
+                const error = err instanceof Error ? err : new Error(String(err));
+                logger.debug(
+                    LogId.atlasConnectFailure,
+                    "atlas-connect-cluster",
+                    `error deleting database user: ${error.message}`
+                );
+            });
+            this.session.connectedAtlasCluster = undefined;
             throw lastError;
         }
+    }
+    
+    protected async execute({ projectId, clusterName }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
+        try {
+            const state = await this.queryConnection(projectId, clusterName);
+            switch (state) {
+                case "connected":
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: "Cluster is already connected.",
+                            },
+                        ],
+                    };
+                case "connecting":
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: "Cluster is connecting...",
+                            },
+                        ],
+                    };
+            }
+        } catch (err: unknown) {
+            const error = err instanceof Error ? err : new Error(String(err));
+            logger.debug(
+                LogId.atlasConnectFailure,
+                "atlas-connect-cluster",
+                `error querying cluster: ${error.message}`
+            );
+            // fall through to create new connection
+        }
+
+        const connectionString = await this.prepareClusterConnection(projectId, clusterName);
+        process.nextTick(async () => {
+            try {
+                await this.connectToCluster(connectionString);
+            } catch (err: unknown) {
+                const error = err instanceof Error ? err : new Error(String(err));
+                logger.debug(
+                    LogId.atlasConnectFailure,
+                    "atlas-connect-cluster",
+                    `error connecting to cluster: ${error.message}`
+                );
+            }
+        });
 
         return {
             content: [
                 {
                     type: "text",
-                    text: `Connected to cluster "${clusterName}"`,
+                    text: `Connecting to cluster "${clusterName}"...`,
                 },
             ],
         };

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -14,7 +14,7 @@ function sleep(ms: number): Promise<void> {
 
 export class ConnectClusterTool extends AtlasToolBase {
     protected name = "atlas-connect-cluster";
-    protected description = "Connect to MongoDB Atlas cluster";
+    protected description = "Connect to / Inspect connection of MongoDB Atlas cluster";
     protected operationType: OperationType = "metadata";
     protected argsShape = {
         projectId: z.string().describe("Atlas project ID"),
@@ -164,7 +164,7 @@ export class ConnectClusterTool extends AtlasToolBase {
         }
 
         logger.debug(
-            LogId.atlasConnectSuccessed,
+            LogId.atlasConnectSucceeded,
             "atlas-connect-cluster",
             `connected to cluster: ${this.session.connectedAtlasCluster?.clusterName}`
         );
@@ -228,6 +228,10 @@ export class ConnectClusterTool extends AtlasToolBase {
                 {
                     type: "text",
                     text: `Attempting to connect to cluster "${clusterName}"...`,
+                },
+                {
+                    type: "text",
+                    text: `Warning: Check again in a few seconds.`,
                 },
             ],
         };

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -243,7 +243,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                 `error connecting to cluster: ${error.message}`
             );
 
-            // We couldn't connect in ~30 seconds, likely because user creation is taking longer  
+            // We couldn't connect in ~30 seconds, likely because user creation is taking longer.
             // Retry the connection with longer timeout (~5 minutes), while also returning a response
             // to the client. Many clients will have a 1 minute timeout for tool calls, so we want to
             // return well before that.

--- a/src/tools/atlas/metadata/connectCluster.ts
+++ b/src/tools/atlas/metadata/connectCluster.ts
@@ -246,7 +246,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                 },
                 {
                     type: "text" as const,
-                    text: `Warning: Make sure your IP address is whitelisted in the Atlas cluster settings.`,
+                    text: `Warning: Make sure your IP address was enabled in the allow list setting of the Atlas cluster.`,
                 },
             ],
         };

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -14,20 +14,27 @@ export abstract class MongoDBToolBase extends ToolBase {
     protected category: ToolCategory = "mongodb";
 
     protected async ensureConnected(): Promise<NodeDriverServiceProvider> {
-        if (!this.session.serviceProvider && this.config.connectionString) {
-            try {
-                await this.connectToMongoDB(this.config.connectionString);
-            } catch (error) {
-                logger.error(
-                    LogId.mongodbConnectFailure,
-                    "mongodbTool",
-                    `Failed to connect to MongoDB instance using the connection string from the config: ${error as string}`
-                );
-                throw new MongoDBError(ErrorCodes.MisconfiguredConnectionString, "Not connected to MongoDB.");
-            }
-        }
-
         if (!this.session.serviceProvider) {
+            if (this.session.connectedAtlasCluster) {
+                throw new MongoDBError(
+                    ErrorCodes.NotConnectedToMongoDB,
+                    `Attempting to connect to Atlas cluster "${this.session.connectedAtlasCluster.clusterName}", try again in a few seconds.`
+                );
+            }
+
+            if (this.config.connectionString) {
+                try {
+                    await this.connectToMongoDB(this.config.connectionString);
+                } catch (error) {
+                    logger.error(
+                        LogId.mongodbConnectFailure,
+                        "mongodbTool",
+                        `Failed to connect to MongoDB instance using the connection string from the config: ${error as string}`
+                    );
+                    throw new MongoDBError(ErrorCodes.MisconfiguredConnectionString, "Not connected to MongoDB.");
+                }
+            }
+
             throw new MongoDBError(ErrorCodes.NotConnectedToMongoDB, "Not connected to MongoDB");
         }
 

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -22,23 +22,23 @@ export abstract class MongoDBToolBase extends ToolBase {
                 );
             }
 
-            if (this.config.connectionString) {
-                try {
-                    await this.connectToMongoDB(this.config.connectionString);
-                } catch (error) {
-                    logger.error(
-                        LogId.mongodbConnectFailure,
-                        "mongodbTool",
-                        `Failed to connect to MongoDB instance using the connection string from the config: ${error as string}`
-                    );
-                    throw new MongoDBError(ErrorCodes.MisconfiguredConnectionString, "Not connected to MongoDB.");
-                }
+            if (!this.config.connectionString) {
+                throw new MongoDBError(ErrorCodes.NotConnectedToMongoDB, "Not connected to MongoDB");
             }
 
-            throw new MongoDBError(ErrorCodes.NotConnectedToMongoDB, "Not connected to MongoDB");
+            try {
+                await this.connectToMongoDB(this.config.connectionString);
+            } catch (error) {
+                logger.error(
+                    LogId.mongodbConnectFailure,
+                    "mongodbTool",
+                    `Failed to connect to MongoDB instance using the connection string from the config: ${error as string}`
+                );
+                throw new MongoDBError(ErrorCodes.MisconfiguredConnectionString, "Not connected to MongoDB.");
+            }
         }
 
-        return this.session.serviceProvider;
+        return this.session.serviceProvider!;
     }
 
     protected handleError(

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -40,7 +40,7 @@ export abstract class MongoDBToolBase extends ToolBase {
             throw new MongoDBError(ErrorCodes.NotConnectedToMongoDB, "Not connected to MongoDB");
         }
 
-        return this.session.serviceProvider!;
+        return this.session.serviceProvider;
     }
 
     protected handleError(

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -22,20 +22,22 @@ export abstract class MongoDBToolBase extends ToolBase {
                 );
             }
 
-            if (!this.config.connectionString) {
-                throw new MongoDBError(ErrorCodes.NotConnectedToMongoDB, "Not connected to MongoDB");
+            if (this.config.connectionString) {
+                try {
+                    await this.connectToMongoDB(this.config.connectionString);
+                } catch (error) {
+                    logger.error(
+                        LogId.mongodbConnectFailure,
+                        "mongodbTool",
+                        `Failed to connect to MongoDB instance using the connection string from the config: ${error as string}`
+                    );
+                    throw new MongoDBError(ErrorCodes.MisconfiguredConnectionString, "Not connected to MongoDB.");
+                }
             }
+        }
 
-            try {
-                await this.connectToMongoDB(this.config.connectionString);
-            } catch (error) {
-                logger.error(
-                    LogId.mongodbConnectFailure,
-                    "mongodbTool",
-                    `Failed to connect to MongoDB instance using the connection string from the config: ${error as string}`
-                );
-                throw new MongoDBError(ErrorCodes.MisconfiguredConnectionString, "Not connected to MongoDB.");
-            }
+        if (!this.session.serviceProvider) {
+            throw new MongoDBError(ErrorCodes.NotConnectedToMongoDB, "Not connected to MongoDB");
         }
 
         return this.session.serviceProvider!;

--- a/tests/integration/tools/atlas/clusters.test.ts
+++ b/tests/integration/tools/atlas/clusters.test.ts
@@ -183,26 +183,24 @@ describeWithAtlas("clusters", (integration) => {
             it("connects to cluster", async () => {
                 const projectId = getProjectId();
 
-                const response = (await integration.mcpClient().callTool({
-                    name: "atlas-connect-cluster",
-                    arguments: { projectId, clusterName },
-                })) as CallToolResult;
-                expect(response.content).toBeArray();
-                expect(response.content).toHaveLength(2);
-                expect(response.content[0]?.type).toEqual("text");
-                expect(response.content[0]?.text).toContain(`Attempting to connect to cluster "${clusterName}"...`);
-
                 for (let i = 0; i < 600; i++) {
                     const response = (await integration.mcpClient().callTool({
                         name: "atlas-connect-cluster",
                         arguments: { projectId, clusterName },
                     })) as CallToolResult;
                     expect(response.content).toBeArray();
-                    expect(response.content).toHaveLength(1);
+                    expect(response.content.length).toBeGreaterThanOrEqual(1);
                     expect(response.content[0]?.type).toEqual("text");
                     const c = response.content[0] as { text: string };
-                    if (c.text.includes("Cluster is already connected.")) {
+                    if (
+                        c.text.includes("Cluster is already connected.") ||
+                        c.text.includes(`Connected to cluster "${clusterName}"`)
+                    ) {
                         break; // success
+                    } else {
+                        expect(response.content[0]?.text).toContain(
+                            `Attempting to connect to cluster "${clusterName}"...`
+                        );
                     }
                     await sleep(500);
                 }

--- a/tests/integration/tools/atlas/clusters.test.ts
+++ b/tests/integration/tools/atlas/clusters.test.ts
@@ -179,7 +179,7 @@ describeWithAtlas("clusters", (integration) => {
                 expect(response.content).toBeArray();
                 expect(response.content).toHaveLength(1);
                 expect(response.content[0]?.type).toEqual("text");
-                expect(response.content[0]?.text).toContain(`Connecting to cluster "${clusterName}"...`);
+                expect(response.content[0]?.text).toContain(`Attempting to connect to cluster "${clusterName}"...`);
 
                 for (let i = 0; i < 600; i++) {
                     const response = (await integration.mcpClient().callTool({

--- a/tests/integration/tools/atlas/clusters.test.ts
+++ b/tests/integration/tools/atlas/clusters.test.ts
@@ -183,7 +183,7 @@ describeWithAtlas("clusters", (integration) => {
             it("connects to cluster", async () => {
                 const projectId = getProjectId();
 
-                for (let i = 0; i < 600; i++) {
+                for (let i = 0; i < 10; i++) {
                     const response = (await integration.mcpClient().callTool({
                         name: "atlas-connect-cluster",
                         arguments: { projectId, clusterName },

--- a/tests/integration/tools/atlas/clusters.test.ts
+++ b/tests/integration/tools/atlas/clusters.test.ts
@@ -188,7 +188,7 @@ describeWithAtlas("clusters", (integration) => {
                     arguments: { projectId, clusterName },
                 })) as CallToolResult;
                 expect(response.content).toBeArray();
-                expect(response.content).toHaveLength(1);
+                expect(response.content).toHaveLength(2);
                 expect(response.content[0]?.type).toEqual("text");
                 expect(response.content[0]?.text).toContain(`Attempting to connect to cluster "${clusterName}"...`);
 

--- a/tests/integration/tools/atlas/clusters.test.ts
+++ b/tests/integration/tools/atlas/clusters.test.ts
@@ -178,7 +178,23 @@ describeWithAtlas("clusters", (integration) => {
                 })) as CallToolResult;
                 expect(response.content).toBeArray();
                 expect(response.content).toHaveLength(1);
-                expect(response.content[0]?.text).toContain(`Connected to cluster "${clusterName}"`);
+                expect(response.content[0]?.type).toEqual("text");
+                expect(response.content[0]?.text).toContain(`Connecting to cluster "${clusterName}"...`);
+
+                for (let i = 0; i < 600; i++) {
+                    const response = (await integration.mcpClient().callTool({
+                        name: "atlas-connect-cluster",
+                        arguments: { projectId, clusterName },
+                    })) as CallToolResult;
+                    expect(response.content).toBeArray();
+                    expect(response.content).toHaveLength(1);
+                    expect(response.content[0]?.type).toEqual("text");
+                    const c = response.content[0] as { text: string };
+                    if (c.text.includes("Cluster is already connected.")) {
+                        break; // success
+                    }
+                    await sleep(500);
+                }
             });
         });
     });


### PR DESCRIPTION
fixes https://github.com/mongodb-js/mongodb-mcp-server/issues/321

## Proposed changes

turn `atlas-connect-cluster` tool into an async tool. Unfortunately, rely on atlas user creation api to connect, sometimes the propagation time of the user from control plane to the data plane can take time, there is no state to query other than check if user has access to DB.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
