### PR TITLE
chore: move --readOnly to env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ docker run --rm -i \
 docker run --rm -i \
   -e MDB_MCP_API_CLIENT_ID="your-atlas-service-accounts-client-id" \
   -e MDB_MCP_API_CLIENT_SECRET="your-atlas-service-accounts-client-secret" \
-  mongodb/mongodb-mcp-server:latest --readOnly
+  -e MDB_MCP_READ_ONLY="true" \
+  mongodb/mongodb-mcp-server:latest
 ```
 
 ##### Docker in MCP Configuration File


### PR DESCRIPTION
## Proposed changes

Didn't notice https://github.com/mongodb-js/mongodb-mcp-server/pull/347 was set to auto-merge prior to approving.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
