### PR TITLE
chore: revoke access tokens on server shutdown [MCP-53]

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,15 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Launch Tests",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["test", "--", "tests/integration/tools/atlas/clusters.test.ts"],
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Launch Program",
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/dist/index.js",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "request": "launch",
       "name": "Launch Tests",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["test", "--", "tests/integration/tools/atlas/clusters.test.ts"],
+      "runtimeArgs": ["test"],
       "cwd": "${workspaceFolder}",
       "envFile": "${workspaceFolder}/.env"
     },

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -5,6 +5,7 @@ import { ApiClientError } from "./apiClientError.js";
 import { paths, operations } from "./openapi.js";
 import { CommonProperties, TelemetryEvent } from "../../telemetry/types.js";
 import { packageInfo } from "../../helpers/packageInfo.js";
+import logger, { LogId } from "../../logger.js";
 
 const ATLAS_API_VERSION = "2025-03-12";
 
@@ -34,9 +35,7 @@ export class ApiClient {
 
     private getAccessToken = async () => {
         if (this.oauth2Client && (!this.accessToken || this.accessToken.expired())) {
-            this.accessToken = await this.oauth2Client.getToken({
-                agent: this.options.userAgent,
-            });
+            this.accessToken = await this.oauth2Client.getToken({});
         }
         return this.accessToken?.token.access_token as string | undefined;
     };
@@ -49,7 +48,9 @@ export class ApiClient {
 
             try {
                 const accessToken = await this.getAccessToken();
-                request.headers.set("Authorization", `Bearer ${accessToken}`);
+                if (accessToken) {
+                    request.headers.set("Authorization", `Bearer ${accessToken}`);
+                }
                 return request;
             } catch {
                 // ignore not availble tokens, API will return 401
@@ -81,6 +82,12 @@ export class ApiClient {
                 auth: {
                     tokenHost: this.options.baseUrl,
                     tokenPath: "/api/oauth/token",
+                    revokePath: "/api/oauth/revoke",
+                },
+                http: {
+                    headers: {
+                        "User-Agent": this.options.userAgent,
+                    },
                 },
             });
             this.client.use(this.authMiddleware);
@@ -88,7 +95,7 @@ export class ApiClient {
     }
 
     public hasCredentials(): boolean {
-        return !!(this.oauth2Client && this.accessToken);
+        return !!this.oauth2Client;
     }
 
     public async validateAccessToken(): Promise<void> {
@@ -97,7 +104,13 @@ export class ApiClient {
 
     public async close(): Promise<void> {
         if (this.accessToken) {
-            await this.accessToken.revokeAll();
+            try {
+                await this.accessToken.revoke("access_token");
+            } catch (error: unknown) {
+                const err = error instanceof Error ? error : new Error(String(error));
+                logger.error(LogId.atlasApiRevokeFailure, "apiClient", `Failed to revoke access token: ${err.message}`);
+            }
+            this.accessToken = undefined;
         }
     }
 

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -95,6 +95,12 @@ export class ApiClient {
         await this.getAccessToken();
     }
 
+    public async close(): Promise<void> {
+        if (this.accessToken) {
+            await this.accessToken.revokeAll();
+        }
+    }
+
     public async getIpInfo(): Promise<{
         currentIpv4Address: string;
     }> {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -19,6 +19,7 @@ export const LogId = {
     atlasInspectFailure: mongoLogId(1_001_004),
     atlasConnectAttempt: mongoLogId(1_001_005),
     atlasConnectSucceeded: mongoLogId(1_001_006),
+    atlasApiRevokeFailure: mongoLogId(1_001_007),
 
     telemetryDisabled: mongoLogId(1_002_001),
     telemetryEmitFailure: mongoLogId(1_002_002),

--- a/src/server.ts
+++ b/src/server.ts
@@ -101,9 +101,9 @@ export class Server {
     }
 
     async close(): Promise<void> {
+        await this.mcpServer.close();
         await this.telemetry.close();
         await this.session.close();
-        await this.mcpServer.close();
     }
 
     /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -101,9 +101,9 @@ export class Server {
     }
 
     async close(): Promise<void> {
-        await this.mcpServer.close();
         await this.telemetry.close();
         await this.session.close();
+        await this.mcpServer.close();
     }
 
     /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -93,6 +93,7 @@ export class Session extends EventEmitter<{
 
     async close(): Promise<void> {
         await this.disconnect();
+        await this.apiClient.close();
         this.emit("close");
     }
 

--- a/src/tools/mongodb/metadata/connect.ts
+++ b/src/tools/mongodb/metadata/connect.ts
@@ -46,7 +46,7 @@ export class ConnectTool extends MongoDBToolBase {
 
     constructor(session: Session, config: UserConfig, telemetry: Telemetry) {
         super(session, config, telemetry);
-        session.on("close", () => {
+        session.on("disconnect", () => {
             this.updateMetadata();
         });
     }

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -84,8 +84,9 @@ export function setupIntegrationTest(getUserConfig: () => UserConfig): Integrati
     });
 
     afterEach(async () => {
-        if (mcpServer) {
-            await mcpServer.session.close();
+        if (mcpServer && !mcpServer.session.connectedAtlasCluster) {
+            await mcpServer.session.disconnect();
+            mcpServer.session.emit("close");
         }
     });
 

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -86,7 +86,6 @@ export function setupIntegrationTest(getUserConfig: () => UserConfig): Integrati
     afterEach(async () => {
         if (mcpServer && !mcpServer.session.connectedAtlasCluster) {
             await mcpServer.session.disconnect();
-            mcpServer.session.emit("close");
         }
     });
 


### PR DESCRIPTION
## Proposed changes
 revoke atlas access tokens on server shutdown [MCP-53]

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
