### PR TITLE
fix: dependabot PRs were not running CI after merge

### DIFF
--- a/.github/workflows/code_health_fork.yaml
+++ b/.github/workflows/code_health_fork.yaml
@@ -34,17 +34,3 @@ jobs:
         with:
           name: test-results
           path: coverage/lcov.info
-
-  merge-dependabot-pr:
-    name: Merge Dependabot PR
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot_pr.yaml
+++ b/.github/workflows/dependabot_pr.yaml
@@ -1,0 +1,26 @@
+---
+name: Dependabot PR
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  merge-dependabot-pr:
+    name: Merge Dependabot PR
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mongodb-js/devtools-shared/actions/setup-bot-token@main
+        id: app-token
+        with:
+          app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Proposed changes

fix dependabot PRs not running CI after merge

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
