### PR TITLE
chore: add assigned teams and description

### DIFF
--- a/.github/workflows/jira-issue.yml
+++ b/.github/workflows/jira-issue.yml
@@ -32,6 +32,7 @@ jobs:
           extra-data: |
             {
               "fields": {
+                # Assigned teams custom field. IDs includes the two owning teams.
                 "customfield_12751": [
                   {
                     "id": "22223"

--- a/.github/workflows/jira-issue.yml
+++ b/.github/workflows/jira-issue.yml
@@ -28,7 +28,20 @@ jobs:
           project-key: MCP
           summary: "HELP: GitHub Issue n. ${{ github.event.issue.number }}"
           issuetype: Bug
-
+          description: "This ticket tracks the following GitHub issue: ${{ github.event.issue.html_url }}."
+          extra-data: |
+            {
+              "fields": {
+                "customfield_12751": [
+                  {
+                    "id": "22223"
+                  },
+                  {
+                    "id": "27326"
+                  }
+                ]
+              }
+            }
       - name: Show result
         run: |
           echo "JIRA action result: ${{ steps.create.outputs.issue-key || 'FAILED' }}"


### PR DESCRIPTION
## Proposed changes

- Adds both teams as assigned for triage
- Adds a link to the description

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
