### PR TITLE
chore: Enable proxy for OIDC and MongoDB connections

### DIFF
--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -113,6 +113,8 @@ export class Session extends EventEmitter<{
                 w: connectOptions.writeConcern,
             },
             timeoutMS: connectOptions.timeoutMS,
+            proxy: { useEnvironmentVariableProxies: true },
+            applyProxyToOIDC: true,
         });
     }
 }

--- a/tests/unit/common/session.test.ts
+++ b/tests/unit/common/session.test.ts
@@ -56,5 +56,17 @@ describe("Session", () => {
                 }
             });
         }
+
+        it("should configure the proxy to use environment variables", async () => {
+            await session.connectToMongoDB("mongodb://localhost", config.connectOptions);
+            expect(session.serviceProvider).toBeDefined();
+
+            const connectMock = MockNodeDriverServiceProvider.connect;
+            expect(connectMock).toHaveBeenCalledOnce();
+
+            const connectionConfig = connectMock.mock.calls[0]?.[1];
+            expect(connectionConfig?.proxy).toEqual({ useEnvironmentVariableProxies: true });
+            expect(connectionConfig?.applyProxyToOIDC).toEqual(true);
+        });
     });
 });


### PR DESCRIPTION
## Proposed changes

By providing { useEnvironmentVariableProxies: true } the NodeDriverServiceProvider already reads the relevant environment variables and sets up the proxy internally.

This is as specified in the section `Setting up the proxy for NodeDriverServiceProvider (MongoDB + OIDC)` from the Technical Design.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
