### PR TITLE
chore: allow workflow to trigger on push to main

### DIFF
--- a/.github/workflows/accuracy-tests.yml
+++ b/.github/workflows/accuracy-tests.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: github.event_name != 'pull_request' || github.event.label.name == 'accuracy-tests'
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'accuracy-tests')
     env:
       MDB_OPEN_AI_API_KEY: ${{ secrets.ACCURACY_OPEN_AI_API_KEY }}
       MDB_GEMINI_API_KEY: ${{ secrets.ACCURACY_GEMINI_API_KEY }}

--- a/.github/workflows/accuracy-tests.yml
+++ b/.github/workflows/accuracy-tests.yml
@@ -16,9 +16,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'accuracy-tests')
+    if: github.event_name != 'pull_request' || github.event.label.name == 'accuracy-tests'
     env:
       MDB_OPEN_AI_API_KEY: ${{ secrets.ACCURACY_OPEN_AI_API_KEY }}
       MDB_GEMINI_API_KEY: ${{ secrets.ACCURACY_GEMINI_API_KEY }}


### PR DESCRIPTION
The workflow earlier was restricted to workflow_dispatch and pull requests with labels accuracy-tests because of the `if` check. This PR, expands the check itself to allow workflow to run on other valid conditions as well.