### PR TITLE
chore: Reactive resource support for debugging connectivity MCP-80

### DIFF
--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -14,7 +14,7 @@ export interface SessionOptions {
 }
 
 export type SessionEvents = {
-    connected: [];
+    connect: [];
     close: [];
     disconnect: [];
     "connection-error": [string];
@@ -130,6 +130,6 @@ export class Session extends EventEmitter<SessionEvents> {
             throw error;
         }
 
-        this.emit("connected");
+        this.emit("connect");
     }
 }

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -122,6 +122,8 @@ export class Session extends EventEmitter<SessionEvents> {
                 proxy: { useEnvironmentVariableProxies: true },
                 applyProxyToOIDC: true,
             });
+
+            await this.serviceProvider?.runCommand?.("admin", { hello: 1 });
         } catch (error: unknown) {
             const message = error instanceof Error ? error.message : `${error}`;
             this.emit("connection-error", message);

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -13,10 +13,13 @@ export interface SessionOptions {
     apiClientSecret?: string;
 }
 
-export class Session extends EventEmitter<{
+export type SessionEvents = {
+    connected: [];
     close: [];
     disconnect: [];
-}> {
+};
+
+export class Session extends EventEmitter<SessionEvents> {
     sessionId?: string;
     serviceProvider?: NodeDriverServiceProvider;
     apiClient: ApiClient;
@@ -116,5 +119,7 @@ export class Session extends EventEmitter<{
             proxy: { useEnvironmentVariableProxies: true },
             applyProxyToOIDC: true,
         });
+
+        this.emit("connected");
     }
 }

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -125,7 +125,7 @@ export class Session extends EventEmitter<SessionEvents> {
 
             await this.serviceProvider?.runCommand?.("admin", { hello: 1 });
         } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : `${error}`;
+            const message = error instanceof Error ? error.message : `${error as string}`;
             this.emit("connection-error", message);
             throw error;
         }

--- a/src/resources/common/config.ts
+++ b/src/resources/common/config.ts
@@ -1,0 +1,40 @@
+import { ReactiveResource } from "../resource.js";
+import { config } from "../../common/config.js";
+import type { UserConfig } from "../../common/config.js";
+
+export class ConfigResource extends ReactiveResource(
+    {
+        name: "config",
+        uri: "config://config",
+        config: {
+            description:
+                "Server configuration, supplied by the user either as environment variables or as startup arguments",
+        },
+    },
+    {
+        initial: { ...config },
+        events: [],
+    }
+) {
+    reduce(previous: UserConfig, eventName: undefined, event: undefined): UserConfig {
+        void event;
+        return previous;
+    }
+
+    toOutput(state: UserConfig): string {
+        const result = {
+            telemetry: state.telemetry,
+            logPath: state.logPath,
+            connectionString: state.connectionString
+                ? "set; access to MongoDB tools are currently available to use"
+                : "not set; before using any MongoDB tool, you need to configure a connection string, alternatively you can setup MongoDB Atlas access, more info at 'https://github.com/mongodb-js/mongodb-mcp-server'.",
+            connectOptions: state.connectOptions,
+            atlas:
+                state.apiClientId && state.apiClientSecret
+                    ? "set; MongoDB Atlas tools are currently available to use"
+                    : "not set; MongoDB Atlas tools are currently unavailable, to have access to MongoDB Atlas tools like creating clusters or connecting to clusters make sure to setup credentials, more info at 'https://github.com/mongodb-js/mongodb-mcp-server'.",
+        };
+
+        return JSON.stringify(result);
+    }
+}

--- a/src/resources/common/config.ts
+++ b/src/resources/common/config.ts
@@ -16,21 +16,23 @@ export class ConfigResource extends ReactiveResource(
         events: [],
     }
 ) {
-    reduce(previous: UserConfig, eventName: undefined, event: undefined): UserConfig {
+    reduce(eventName: undefined, event: undefined): UserConfig {
+        void eventName;
         void event;
-        return previous;
+
+        return this.current;
     }
 
-    toOutput(state: UserConfig): string {
+    toOutput(): string {
         const result = {
-            telemetry: state.telemetry,
-            logPath: state.logPath,
-            connectionString: state.connectionString
+            telemetry: this.current.telemetry,
+            logPath: this.current.logPath,
+            connectionString: this.current.connectionString
                 ? "set; access to MongoDB tools are currently available to use"
                 : "not set; before using any MongoDB tool, you need to configure a connection string, alternatively you can setup MongoDB Atlas access, more info at 'https://github.com/mongodb-js/mongodb-mcp-server'.",
-            connectOptions: state.connectOptions,
+            connectOptions: this.current.connectOptions,
             atlas:
-                state.apiClientId && state.apiClientSecret
+                this.current.apiClientId && this.current.apiClientSecret
                     ? "set; MongoDB Atlas tools are currently available to use"
                     : "not set; MongoDB Atlas tools are currently unavailable, to have access to MongoDB Atlas tools like creating clusters or connecting to clusters make sure to setup credentials, more info at 'https://github.com/mongodb-js/mongodb-mcp-server'.",
         };

--- a/src/resources/common/debug.ts
+++ b/src/resources/common/debug.ts
@@ -1,0 +1,50 @@
+import { ReactiveResource } from "../resource.js";
+import { config } from "../../common/config.js";
+import type { UserConfig } from "../../common/config.js";
+
+type ConnectionStateDebuggingInformation = {
+    readonly tag: "connected" | "connecting" | "disconnected" | "errored";
+    readonly connectionStringAuthType?: "scram" | "ldap" | "kerberos" | "oidc-auth-flow" | "oidc-device-flow" | "x.509";
+    readonly oidcLoginUrl?: string;
+    readonly oidcUserCode?: string;
+    readonly errorReason?: string;
+};
+
+export class DebugResource extends ReactiveResource(
+    {
+        name: "debug",
+        uri: "config://debug",
+        config: {
+            description: "Debugging information for connectivity issues.",
+        },
+    },
+    {
+        initial: { tag: "disconnected" },
+        events: ["connected", "disconnect", "close"],
+    }
+) {
+    reduce(
+        previous: ConnectionStateDebuggingInformation,
+        eventName: "connected" | "disconnect" | "close",
+        event: undefined
+    ): ConnectionStateDebuggingInformation {
+        void event;
+
+        switch (eventName) {
+            case "connected":
+                return { tag: "connected" };
+            case "disconnect":
+                return { tag: "disconnected" };
+            case "close":
+                return { tag: "disconnected" };
+        }
+    }
+
+    toOutput(state: ConnectionStateDebuggingInformation): string {
+        const result = {
+            connectionStatus: state.tag,
+        };
+
+        return JSON.stringify(result);
+    }
+}

--- a/src/resources/common/debug.ts
+++ b/src/resources/common/debug.ts
@@ -49,6 +49,7 @@ export class DebugResource extends ReactiveResource(
                 result += `The user is not connected to a MongoDB cluster because of an error.\n`;
                 result += `<error>${this.current.errorReason}</error>`;
                 break;
+            case "connecting":
             case "disconnected":
                 result += "The user is not connected to a MongoDB cluster.";
                 break;

--- a/src/resources/common/debug.ts
+++ b/src/resources/common/debug.ts
@@ -18,17 +18,17 @@ export class DebugResource extends ReactiveResource(
     },
     {
         initial: { tag: "disconnected" } as ConnectionStateDebuggingInformation,
-        events: ["connected", "disconnect", "close", "connection-error"],
+        events: ["connect", "disconnect", "close", "connection-error"],
     }
 ) {
     reduce(
-        eventName: "connected" | "disconnect" | "close" | "connection-error",
+        eventName: "connect" | "disconnect" | "close" | "connection-error",
         event: string | undefined
     ): ConnectionStateDebuggingInformation {
         void event;
 
         switch (eventName) {
-            case "connected":
+            case "connect":
                 return { tag: "connected" };
             case "connection-error":
                 return { tag: "errored", errorReason: event };

--- a/src/resources/common/debug.ts
+++ b/src/resources/common/debug.ts
@@ -10,8 +10,8 @@ type ConnectionStateDebuggingInformation = {
 
 export class DebugResource extends ReactiveResource(
     {
-        name: "debug",
-        uri: "config://debug",
+        name: "debug-mongodb-connectivity",
+        uri: "debug://mongodb-connectivity",
         config: {
             description: "Debugging information for connectivity issues.",
         },

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -1,0 +1,73 @@
+import { Server } from "../server.js";
+import { Session } from "../common/session.js";
+import { UserConfig } from "../common/config.js";
+import { Telemetry } from "../telemetry/telemetry.js";
+import type { SessionEvents } from "../common/session.js";
+import { ReadResourceCallback, RegisteredResource, ResourceMetadata } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+type PayloadOf<K extends keyof SessionEvents> = SessionEvents[K][0];
+
+type ResourceConfiguration = { name: string; uri: string; config: ResourceMetadata };
+
+export function ReactiveResource<V, KE extends readonly (keyof SessionEvents)[]>(
+    { name, uri, config: resourceConfig }: ResourceConfiguration,
+    {
+        initial,
+        events,
+    }: {
+        initial: V;
+        events: KE;
+    }
+) {
+    type E = KE[number];
+
+    abstract class NewReactiveResource {
+        private registeredResource?: RegisteredResource;
+
+        constructor(
+            protected readonly server: Server,
+            protected readonly session: Session,
+            protected readonly config: UserConfig,
+            protected readonly telemetry: Telemetry,
+            private current?: V
+        ) {
+            this.current = initial;
+
+            for (const event of events) {
+                this.session.on(event, (...args: SessionEvents[typeof event]) => {
+                    this.current = this.reduce(this.current, event, (args as unknown[])[0] as PayloadOf<typeof event>);
+                    this.triggerUpdate();
+                });
+            }
+        }
+
+        public register(): void {
+            this.registeredResource = this.server.mcpServer.registerResource(
+                name,
+                uri,
+                resourceConfig,
+                this.resourceCallback
+            );
+        }
+
+        private resourceCallback: ReadResourceCallback = (uri) => ({
+            contents: [
+                {
+                    text: this.toOutput(this.current),
+                    mimeType: "application/json",
+                    uri: uri.href,
+                },
+            ],
+        });
+
+        private triggerUpdate() {
+            this.registeredResource?.update({});
+            this.server.mcpServer.sendResourceListChanged();
+        }
+
+        abstract reduce(previous: V | undefined, eventName: E, ...event: PayloadOf<E>[]): V;
+        abstract toOutput(state: V | undefined): string;
+    }
+
+    return NewReactiveResource;
+}

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -29,9 +29,10 @@ export function ReactiveResource<V, KE extends readonly (keyof SessionEvents)[]>
 
         constructor(
             protected readonly server: Server,
-            protected readonly telemetry: Telemetry
+            protected readonly telemetry: Telemetry,
+            current?: V
         ) {
-            this.current = initial;
+            this.current = current ?? initial;
             this.session = server.session;
             this.config = server.userConfig;
 

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -38,7 +38,7 @@ export function ReactiveResource<Value, RelevantEvents extends readonly (keyof S
             for (const event of events) {
                 this.session.on(event, (...args: SessionEvents[typeof event]) => {
                     this.reduceApply(event, (args as unknown[])[0] as PayloadOf<typeof event>);
-                    this.triggerUpdate();
+                    void this.triggerUpdate();
                 });
             }
         }
@@ -57,8 +57,9 @@ export function ReactiveResource<Value, RelevantEvents extends readonly (keyof S
             ],
         });
 
-        private triggerUpdate() {
-            void this.server.mcpServer.server.sendResourceUpdated({ uri });
+        private async triggerUpdate() {
+            await this.server.mcpServer.server.sendResourceUpdated({ uri });
+            this.server.mcpServer.sendResourceListChanged();
         }
 
         reduceApply(eventName: SomeEvent, ...event: PayloadOf<SomeEvent>[]): void {

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -25,11 +25,11 @@ export function ReactiveResource<V, KE extends readonly (keyof SessionEvents)[]>
         private registeredResource?: RegisteredResource;
         protected readonly session: Session;
         protected readonly config: UserConfig;
+        protected current: V;
 
         constructor(
             protected readonly server: Server,
-            protected readonly telemetry: Telemetry,
-            protected current: V
+            protected readonly telemetry: Telemetry
         ) {
             this.current = initial;
             this.session = server.session;

--- a/src/resources/resources.ts
+++ b/src/resources/resources.ts
@@ -1,0 +1,4 @@
+import { ConfigResource } from "./common/config.js";
+import { DebugResource } from "./common/debug.js";
+
+export const Resources = [ConfigResource, DebugResource] as const;

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { Session } from "./common/session.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { AtlasTools } from "./tools/atlas/tools.js";
 import { MongoDbTools } from "./tools/mongodb/tools.js";
+import { Resources } from "./resources/resources.js";
 import logger, { LogId, LoggerBase, McpLogger, DiskLogger, ConsoleLogger } from "./common/logger.js";
 import { ObjectId } from "mongodb";
 import { Telemetry } from "./telemetry/telemetry.js";
@@ -155,37 +156,10 @@ export class Server {
     }
 
     private registerResources() {
-        this.mcpServer.resource(
-            "config",
-            "config://config",
-            {
-                description:
-                    "Server configuration, supplied by the user either as environment variables or as startup arguments",
-            },
-            (uri) => {
-                const result = {
-                    telemetry: this.userConfig.telemetry,
-                    logPath: this.userConfig.logPath,
-                    connectionString: this.userConfig.connectionString
-                        ? "set; access to MongoDB tools are currently available to use"
-                        : "not set; before using any MongoDB tool, you need to configure a connection string, alternatively you can setup MongoDB Atlas access, more info at 'https://github.com/mongodb-js/mongodb-mcp-server'.",
-                    connectOptions: this.userConfig.connectOptions,
-                    atlas:
-                        this.userConfig.apiClientId && this.userConfig.apiClientSecret
-                            ? "set; MongoDB Atlas tools are currently available to use"
-                            : "not set; MongoDB Atlas tools are currently unavailable, to have access to MongoDB Atlas tools like creating clusters or connecting to clusters make sure to setup credentials, more info at 'https://github.com/mongodb-js/mongodb-mcp-server'.",
-                };
-                return {
-                    contents: [
-                        {
-                            text: JSON.stringify(result),
-                            mimeType: "application/json",
-                            uri: uri.href,
-                        },
-                    ],
-                };
-            }
-        );
+        for (const resourceConstructor of Resources) {
+            const resource = new resourceConstructor(this, this.session, this.userConfig, this.telemetry);
+            resource.register();
+        }
     }
 
     private async validateConfig(): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -157,7 +157,7 @@ export class Server {
 
     private registerResources() {
         for (const resourceConstructor of Resources) {
-            const resource = new resourceConstructor(this, this.session, this.userConfig, this.telemetry);
+            const resource = new resourceConstructor(this, this.telemetry);
             resource.register();
         }
     }

--- a/tests/unit/resources/common/debug.test.ts
+++ b/tests/unit/resources/common/debug.test.ts
@@ -19,7 +19,7 @@ describe("debug resource", () => {
     });
 
     it("should be connected when a connected event happens", () => {
-        debugResource.reduceApply("connected", undefined);
+        debugResource.reduceApply("connect", undefined);
         const output = debugResource.toOutput();
 
         expect(output).toContain(`The user is connected to the MongoDB cluster.`);

--- a/tests/unit/resources/common/debug.test.ts
+++ b/tests/unit/resources/common/debug.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DebugResource } from "../../../../src/resources/common/debug.js";
+import { Session } from "../../../../src/common/session.js";
+import { Server } from "../../../../src/server.js";
+import { Telemetry } from "../../../../src/telemetry/telemetry.js";
+import { config } from "../../../../src/common/config.js";
+
+describe("debug resource", () => {
+    let session = new Session({} as any);
+    let server = new Server({ session } as any);
+    let telemetry = Telemetry.create(session, { ...config, telemetry: "disabled" });
+
+    let debugResource: DebugResource = new DebugResource(server, telemetry, { tag: "disconnected" });
+
+    it("should be connected when a connected event happens", () => {
+        debugResource.reduceApply("connected", undefined);
+        const output = debugResource.toOutput();
+
+        expect(output).toContain(`The user is connected to the MongoDB cluster.`);
+    });
+
+    it("should be disconnected when a disconnect event happens", () => {
+        debugResource.reduceApply("disconnect", undefined);
+        const output = debugResource.toOutput();
+
+        expect(output).toContain(`The user is not connected to a MongoDB cluster.`);
+    });
+
+    it("should be disconnected when a close event happens", () => {
+        debugResource.reduceApply("close", undefined);
+        const output = debugResource.toOutput();
+
+        expect(output).toContain(`The user is not connected to a MongoDB cluster.`);
+    });
+
+    it("should be disconnected and contain an error when an error event occurred", () => {
+        debugResource.reduceApply("connection-error", "Error message from the server");
+        const output = debugResource.toOutput();
+
+        expect(output).toContain(`The user is not connected to a MongoDB cluster because of an error.`);
+        expect(output).toContain(`<error>Error message from the server</error>`);
+    });
+});

--- a/tests/unit/resources/common/debug.test.ts
+++ b/tests/unit/resources/common/debug.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { DebugResource } from "../../../../src/resources/common/debug.js";
 import { Session } from "../../../../src/common/session.js";
 import { Server } from "../../../../src/server.js";
@@ -6,11 +6,17 @@ import { Telemetry } from "../../../../src/telemetry/telemetry.js";
 import { config } from "../../../../src/common/config.js";
 
 describe("debug resource", () => {
-    let session = new Session({} as any);
-    let server = new Server({ session } as any);
-    let telemetry = Telemetry.create(session, { ...config, telemetry: "disabled" });
+    // eslint-disable-next-line
+    const session = new Session({} as any);
+    // eslint-disable-next-line
+    const server = new Server({ session } as any);
+    const telemetry = Telemetry.create(session, { ...config, telemetry: "disabled" });
 
-    let debugResource: DebugResource = new DebugResource(server, telemetry, { tag: "disconnected" });
+    let debugResource: DebugResource = new DebugResource(server, telemetry);
+
+    beforeEach(() => {
+        debugResource = new DebugResource(server, telemetry);
+    });
 
     it("should be connected when a connected event happens", () => {
         debugResource.reduceApply("connected", undefined);


### PR DESCRIPTION
## Proposed changes
Resources can listen to events on the session and their arguments, and reduces the current state with the argument to provide a new state.

This way this is type safe and declarative, mimicking how tools work.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
