### PR TITLE
chore: use pull_request_target for dependabot prs

### DIFF
--- a/.github/workflows/dependabot_pr.yaml
+++ b/.github/workflows/dependabot_pr.yaml
@@ -1,7 +1,7 @@
 ---
 name: Dependabot PR
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     branches:
       - main


### PR DESCRIPTION
## Proposed changes

Dependabot doesn't have access to repo secrets, which is why we must use `pull_request_target` event trigger.