### PR TITLE
chore: allow logging unredacted messages

### DIFF
--- a/src/common/atlas/accessListUtils.ts
+++ b/src/common/atlas/accessListUtils.ts
@@ -30,25 +30,25 @@ export async function ensureCurrentIpInAccessList(apiClient: ApiClient, projectI
             params: { path: { groupId: projectId } },
             body: [entry],
         });
-        logger.debug(
-            LogId.atlasIpAccessListAdded,
-            "accessListUtils",
-            `IP access list created: ${JSON.stringify(entry)}`
-        );
+        logger.debug({
+            id: LogId.atlasIpAccessListAdded,
+            context: "accessListUtils",
+            message: `IP access list created: ${JSON.stringify(entry)}`,
+        });
     } catch (err) {
         if (err instanceof ApiClientError && err.response?.status === 409) {
             // 409 Conflict: entry already exists, log info
-            logger.debug(
-                LogId.atlasIpAccessListAdded,
-                "accessListUtils",
-                `IP address ${entry.ipAddress} is already present in the access list for project ${projectId}.`
-            );
+            logger.debug({
+                id: LogId.atlasIpAccessListAdded,
+                context: "accessListUtils",
+                message: `IP address ${entry.ipAddress} is already present in the access list for project ${projectId}.`,
+            });
             return;
         }
-        logger.warning(
-            LogId.atlasIpAccessListAddFailure,
-            "accessListUtils",
-            `Error adding IP access list: ${err instanceof Error ? err.message : String(err)}`
-        );
+        logger.warning({
+            id: LogId.atlasIpAccessListAddFailure,
+            context: "accessListUtils",
+            message: `Error adding IP access list: ${err instanceof Error ? err.message : String(err)}`,
+        });
     }
 }

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -179,7 +179,11 @@ export class ApiClient {
                 };
             } catch (error: unknown) {
                 const err = error instanceof Error ? error : new Error(String(error));
-                logger.error(LogId.atlasConnectFailure, "apiClient", `Failed to request access token: ${err.message}`);
+                logger.error({
+                    id: LogId.atlasConnectFailure,
+                    context: "apiClient",
+                    message: `Failed to request access token: ${err.message}`,
+                });
             }
             return this.accessToken;
         }
@@ -197,7 +201,11 @@ export class ApiClient {
             }
         } catch (error: unknown) {
             const err = error instanceof Error ? error : new Error(String(error));
-            logger.error(LogId.atlasApiRevokeFailure, "apiClient", `Failed to revoke access token: ${err.message}`);
+            logger.error({
+                id: LogId.atlasApiRevokeFailure,
+                context: "apiClient",
+                message: `Failed to revoke access token: ${err.message}`,
+            });
         }
         this.accessToken = undefined;
     }

--- a/src/common/atlas/cluster.ts
+++ b/src/common/atlas/cluster.ts
@@ -87,7 +87,11 @@ export async function inspectCluster(apiClient: ApiClient, projectId: string, cl
             return formatFlexCluster(cluster);
         } catch (flexError) {
             const err = flexError instanceof Error ? flexError : new Error(String(flexError));
-            logger.error(LogId.atlasInspectFailure, "inspect-cluster", `error inspecting cluster: ${err.message}`);
+            logger.error({
+                id: LogId.atlasInspectFailure,
+                context: "inspect-cluster",
+                message: `error inspecting cluster: ${err.message}`,
+            });
             throw error;
         }
     }

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -67,7 +67,11 @@ export class Session extends EventEmitter<SessionEvents> {
                 await this.serviceProvider.close(true);
             } catch (err: unknown) {
                 const error = err instanceof Error ? err : new Error(String(err));
-                logger.error(LogId.mongodbDisconnectFailure, "Error closing service provider:", error.message);
+                logger.error({
+                    id: LogId.mongodbDisconnectFailure,
+                    context: "session",
+                    message: `Error closing service provider: ${error.message}`,
+                });
             }
             this.serviceProvider = undefined;
         }
@@ -84,11 +88,11 @@ export class Session extends EventEmitter<SessionEvents> {
                 })
                 .catch((err: unknown) => {
                     const error = err instanceof Error ? err : new Error(String(err));
-                    logger.error(
-                        LogId.atlasDeleteDatabaseUserFailure,
-                        "atlas-connect-cluster",
-                        `Error deleting previous database user: ${error.message}`
-                    );
+                    logger.error({
+                        id: LogId.atlasDeleteDatabaseUserFailure,
+                        context: "session",
+                        message: `Error deleting previous database user: ${error.message}`,
+                    });
                 });
             this.connectedAtlasCluster = undefined;
         }

--- a/src/common/sessionStore.ts
+++ b/src/common/sessionStore.ts
@@ -47,18 +47,18 @@ export class SessionStore {
     private sendNotification(sessionId: string): void {
         const session = this.sessions[sessionId];
         if (!session) {
-            logger.warning(
-                LogId.streamableHttpTransportSessionCloseNotificationFailure,
-                "sessionStore",
-                `session ${sessionId} not found, no notification delivered`
-            );
+            logger.warning({
+                id: LogId.streamableHttpTransportSessionCloseNotificationFailure,
+                context: "sessionStore",
+                message: `session ${sessionId} not found, no notification delivered`,
+            });
             return;
         }
-        session.logger.info(
-            LogId.streamableHttpTransportSessionCloseNotification,
-            "sessionStore",
-            "Session is about to be closed due to inactivity"
-        );
+        session.logger.info({
+            id: LogId.streamableHttpTransportSessionCloseNotification,
+            context: "sessionStore",
+            message: "Session is about to be closed due to inactivity",
+        });
     }
 
     setSession(sessionId: string, transport: StreamableHTTPServerTransport, mcpServer: McpServer): void {
@@ -68,11 +68,11 @@ export class SessionStore {
         }
         const abortTimeout = setManagedTimeout(async () => {
             if (this.sessions[sessionId]) {
-                this.sessions[sessionId].logger.info(
-                    LogId.streamableHttpTransportSessionCloseNotification,
-                    "sessionStore",
-                    "Session closed due to inactivity"
-                );
+                this.sessions[sessionId].logger.info({
+                    id: LogId.streamableHttpTransportSessionCloseNotification,
+                    context: "sessionStore",
+                    message: "Session closed due to inactivity",
+                });
 
                 await this.closeSession(sessionId);
             }
@@ -95,11 +95,11 @@ export class SessionStore {
             try {
                 await session.transport.close();
             } catch (error) {
-                logger.error(
-                    LogId.streamableHttpTransportSessionCloseFailure,
-                    "streamableHttpTransport",
-                    `Error closing transport ${sessionId}: ${error instanceof Error ? error.message : String(error)}`
-                );
+                logger.error({
+                    id: LogId.streamableHttpTransportSessionCloseFailure,
+                    context: "streamableHttpTransport",
+                    message: `Error closing transport ${sessionId}: ${error instanceof Error ? error.message : String(error)}`,
+                });
             }
         }
         delete this.sessions[sessionId];

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,16 +9,28 @@ async function main() {
     const transportRunner = config.transport === "stdio" ? new StdioRunner(config) : new StreamableHttpRunner(config);
 
     const shutdown = () => {
-        logger.info(LogId.serverCloseRequested, "server", `Server close requested`);
+        logger.info({
+            id: LogId.serverCloseRequested,
+            context: "server",
+            message: `Server close requested`,
+        });
 
         transportRunner
             .close()
             .then(() => {
-                logger.info(LogId.serverClosed, "server", `Server closed`);
+                logger.info({
+                    id: LogId.serverClosed,
+                    context: "server",
+                    message: `Server closed`,
+                });
                 process.exit(0);
             })
             .catch((error: unknown) => {
-                logger.error(LogId.serverCloseFailure, "server", `Error closing server: ${error as string}`);
+                logger.error({
+                    id: LogId.serverCloseFailure,
+                    context: "server",
+                    message: `Error closing server: ${error as string}`,
+                });
                 process.exit(1);
             });
     };
@@ -31,18 +43,34 @@ async function main() {
     try {
         await transportRunner.start();
     } catch (error: unknown) {
-        logger.info(LogId.serverCloseRequested, "server", "Closing server");
+        logger.info({
+            id: LogId.serverCloseRequested,
+            context: "server",
+            message: "Closing server",
+        });
         try {
             await transportRunner.close();
-            logger.info(LogId.serverClosed, "server", "Server closed");
+            logger.info({
+                id: LogId.serverClosed,
+                context: "server",
+                message: "Server closed",
+            });
         } catch (error: unknown) {
-            logger.error(LogId.serverCloseFailure, "server", `Error closing server: ${error as string}`);
+            logger.error({
+                id: LogId.serverCloseFailure,
+                context: "server",
+                message: `Error closing server: ${error as string}`,
+            });
         }
         throw error;
     }
 }
 
 main().catch((error: unknown) => {
-    logger.emergency(LogId.serverStartFailure, "server", `Fatal error running server: ${error as string}`);
+    logger.emergency({
+        id: LogId.serverStartFailure,
+        context: "server",
+        message: `Fatal error running server: ${error as string}`,
+    });
     process.exit(1);
 });

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -63,11 +63,11 @@ export function ReactiveResource<Value, RelevantEvents extends readonly (keyof S
                 await this.server.mcpServer.server.sendResourceUpdated({ uri });
                 this.server.mcpServer.sendResourceListChanged();
             } catch (error: unknown) {
-                logger.warning(
-                    LogId.resourceUpdateFailure,
-                    "Could not send the latest resources to the client.",
-                    error as string
-                );
+                logger.warning({
+                    id: LogId.resourceUpdateFailure,
+                    context: "resource",
+                    message: `Could not send the latest resources to the client: ${error as string}`,
+                });
             }
         }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -84,11 +84,11 @@ export class Server {
             this.session.setAgentRunner(this.mcpServer.server.getClientVersion());
             this.session.sessionId = new ObjectId().toString();
 
-            logger.info(
-                LogId.serverInitialized,
-                "server",
-                `Server started with transport ${transport.constructor.name} and agent runner ${this.session.agentRunner?.name}`
-            );
+            logger.info({
+                id: LogId.serverInitialized,
+                context: "server",
+                message: `Server started with transport ${transport.constructor.name} and agent runner ${this.session.agentRunner?.name}`,
+            });
 
             this.emitServerEvent("start", Date.now() - this.startTime);
         };

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -63,10 +63,19 @@ export class Telemetry {
                 onError: (reason, error) => {
                     switch (reason) {
                         case "resolutionError":
-                            logger.debug(LogId.telemetryDeviceIdFailure, "telemetry", String(error));
+                            logger.debug({
+                                id: LogId.telemetryDeviceIdFailure,
+                                context: "telemetry",
+                                message: String(error),
+                            });
                             break;
                         case "timeout":
-                            logger.debug(LogId.telemetryDeviceIdTimeout, "telemetry", "Device ID retrieval timed out");
+                            logger.debug({
+                                id: LogId.telemetryDeviceIdTimeout,
+                                context: "telemetry",
+                                message: "Device ID retrieval timed out",
+                                noRedaction: true,
+                            });
                             break;
                         case "abort":
                             // No need to log in the case of aborts
@@ -99,13 +108,23 @@ export class Telemetry {
     public async emitEvents(events: BaseEvent[]): Promise<void> {
         try {
             if (!this.isTelemetryEnabled()) {
-                logger.info(LogId.telemetryEmitFailure, "telemetry", `Telemetry is disabled.`);
+                logger.info({
+                    id: LogId.telemetryEmitFailure,
+                    context: "telemetry",
+                    message: "Telemetry is disabled.",
+                    noRedaction: true,
+                });
                 return;
             }
 
             await this.emit(events);
         } catch {
-            logger.debug(LogId.telemetryEmitFailure, "telemetry", `Error emitting telemetry events.`);
+            logger.debug({
+                id: LogId.telemetryEmitFailure,
+                context: "telemetry",
+                message: "Error emitting telemetry events.",
+                noRedaction: true,
+            });
         }
     }
 
@@ -155,28 +174,28 @@ export class Telemetry {
         const cachedEvents = this.eventCache.getEvents();
         const allEvents = [...cachedEvents, ...events];
 
-        logger.debug(
-            LogId.telemetryEmitStart,
-            "telemetry",
-            `Attempting to send ${allEvents.length} events (${cachedEvents.length} cached)`
-        );
+        logger.debug({
+            id: LogId.telemetryEmitStart,
+            context: "telemetry",
+            message: `Attempting to send ${allEvents.length} events (${cachedEvents.length} cached)`,
+        });
 
         const result = await this.sendEvents(this.session.apiClient, allEvents);
         if (result.success) {
             this.eventCache.clearEvents();
-            logger.debug(
-                LogId.telemetryEmitSuccess,
-                "telemetry",
-                `Sent ${allEvents.length} events successfully: ${JSON.stringify(allEvents, null, 2)}`
-            );
+            logger.debug({
+                id: LogId.telemetryEmitSuccess,
+                context: "telemetry",
+                message: `Sent ${allEvents.length} events successfully: ${JSON.stringify(allEvents, null, 2)}`,
+            });
             return;
         }
 
-        logger.debug(
-            LogId.telemetryEmitFailure,
-            "telemetry",
-            `Error sending event to client: ${result.error instanceof Error ? result.error.message : String(result.error)}`
-        );
+        logger.debug({
+            id: LogId.telemetryEmitFailure,
+            context: "telemetry",
+            message: `Error sending event to client: ${result.error instanceof Error ? result.error.message : String(result.error)}`,
+        });
         this.eventCache.appendEvents(events);
     }
 

--- a/src/tools/atlas/atlasTool.ts
+++ b/src/tools/atlas/atlasTool.ts
@@ -79,11 +79,11 @@ For more information on Atlas API access roles, visit: https://www.mongodb.com/d
         const parsedResult = argsShape.safeParse(args[0]);
 
         if (!parsedResult.success) {
-            logger.debug(
-                LogId.telemetryMetadataError,
-                "tool",
-                `Error parsing tool arguments: ${parsedResult.error.message}`
-            );
+            logger.debug({
+                id: LogId.telemetryMetadataError,
+                context: "tool",
+                message: `Error parsing tool arguments: ${parsedResult.error.message}`,
+            });
             return toolMetadata;
         }
 

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -52,11 +52,11 @@ export class ConnectClusterTool extends AtlasToolBase {
             return "connected";
         } catch (err: unknown) {
             const error = err instanceof Error ? err : new Error(String(err));
-            logger.debug(
-                LogId.atlasConnectFailure,
-                "atlas-connect-cluster",
-                `error querying cluster: ${error.message}`
-            );
+            logger.debug({
+                id: LogId.atlasConnectFailure,
+                context: "atlas-connect-cluster",
+                message: `error querying cluster: ${error.message}`,
+            });
             return "unknown";
         }
     }
@@ -126,11 +126,12 @@ export class ConnectClusterTool extends AtlasToolBase {
     private async connectToCluster(projectId: string, clusterName: string, connectionString: string): Promise<void> {
         let lastError: Error | undefined = undefined;
 
-        logger.debug(
-            LogId.atlasConnectAttempt,
-            "atlas-connect-cluster",
-            `attempting to connect to cluster: ${this.session.connectedAtlasCluster?.clusterName}`
-        );
+        logger.debug({
+            id: LogId.atlasConnectAttempt,
+            context: "atlas-connect-cluster",
+            message: `attempting to connect to cluster: ${this.session.connectedAtlasCluster?.clusterName}`,
+            noRedaction: true,
+        });
 
         // try to connect for about 5 minutes
         for (let i = 0; i < 600; i++) {
@@ -152,11 +153,11 @@ export class ConnectClusterTool extends AtlasToolBase {
 
                 lastError = error;
 
-                logger.debug(
-                    LogId.atlasConnectFailure,
-                    "atlas-connect-cluster",
-                    `error connecting to cluster: ${error.message}`
-                );
+                logger.debug({
+                    id: LogId.atlasConnectFailure,
+                    context: "atlas-connect-cluster",
+                    message: `error connecting to cluster: ${error.message}`,
+                });
 
                 await sleep(500); // wait for 500ms before retrying
             }
@@ -180,22 +181,23 @@ export class ConnectClusterTool extends AtlasToolBase {
                     })
                     .catch((err: unknown) => {
                         const error = err instanceof Error ? err : new Error(String(err));
-                        logger.debug(
-                            LogId.atlasConnectFailure,
-                            "atlas-connect-cluster",
-                            `error deleting database user: ${error.message}`
-                        );
+                        logger.debug({
+                            id: LogId.atlasConnectFailure,
+                            context: "atlas-connect-cluster",
+                            message: `error deleting database user: ${error.message}`,
+                        });
                     });
             }
             this.session.connectedAtlasCluster = undefined;
             throw lastError;
         }
 
-        logger.debug(
-            LogId.atlasConnectSucceeded,
-            "atlas-connect-cluster",
-            `connected to cluster: ${this.session.connectedAtlasCluster?.clusterName}`
-        );
+        logger.debug({
+            id: LogId.atlasConnectSucceeded,
+            context: "atlas-connect-cluster",
+            message: `connected to cluster: ${this.session.connectedAtlasCluster?.clusterName}`,
+            noRedaction: true,
+        });
     }
 
     protected async execute({ projectId, clusterName }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
@@ -226,11 +228,11 @@ export class ConnectClusterTool extends AtlasToolBase {
                     // try to connect for about 5 minutes asynchronously
                     void this.connectToCluster(projectId, clusterName, connectionString).catch((err: unknown) => {
                         const error = err instanceof Error ? err : new Error(String(err));
-                        logger.error(
-                            LogId.atlasConnectFailure,
-                            "atlas-connect-cluster",
-                            `error connecting to cluster: ${error.message}`
-                        );
+                        logger.error({
+                            id: LogId.atlasConnectFailure,
+                            context: "atlas-connect-cluster",
+                            message: `error connecting to cluster: ${error.message}`,
+                        });
                     });
                     break;
                 }

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -28,11 +28,11 @@ export abstract class MongoDBToolBase extends ToolBase {
                 try {
                     await this.connectToMongoDB(this.config.connectionString);
                 } catch (error) {
-                    logger.error(
-                        LogId.mongodbConnectFailure,
-                        "mongodbTool",
-                        `Failed to connect to MongoDB instance using the connection string from the config: ${error as string}`
-                    );
+                    logger.error({
+                        id: LogId.mongodbConnectFailure,
+                        context: "mongodbTool",
+                        message: `Failed to connect to MongoDB instance using the connection string from the config: ${error as string}`,
+                    });
                     throw new MongoDBError(ErrorCodes.MisconfiguredConnectionString, "Not connected to MongoDB.");
                 }
             }

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -73,13 +73,22 @@ export abstract class ToolBase {
         const callback: ToolCallback<typeof this.argsShape> = async (...args) => {
             const startTime = Date.now();
             try {
-                logger.debug(LogId.toolExecute, "tool", `Executing tool ${this.name}`);
+                logger.debug({
+                    id: LogId.toolExecute,
+                    context: "tool",
+                    message: `Executing tool ${this.name}`,
+                    noRedaction: true,
+                });
 
                 const result = await this.execute(...args);
                 await this.emitToolEvent(startTime, result, ...args).catch(() => {});
                 return result;
             } catch (error: unknown) {
-                logger.error(LogId.toolExecuteFailure, "tool", `Error executing ${this.name}: ${error as string}`);
+                logger.error({
+                    id: LogId.toolExecuteFailure,
+                    context: "tool",
+                    message: `Error executing ${this.name}: ${error as string}`,
+                });
                 const toolResult = await this.handleError(error, args[0] as ToolArgs<typeof this.argsShape>);
                 await this.emitToolEvent(startTime, toolResult, ...args).catch(() => {});
                 return toolResult;
@@ -98,7 +107,12 @@ export abstract class ToolBase {
             const existingTool = tools[this.name];
 
             if (!existingTool) {
-                logger.warning(LogId.toolUpdateFailure, "tool", `Tool ${this.name} not found in update`);
+                logger.warning({
+                    id: LogId.toolUpdateFailure,
+                    context: "tool",
+                    message: `Tool ${this.name} not found in update`,
+                    noRedaction: true,
+                });
                 return;
             }
 
@@ -145,11 +159,12 @@ export abstract class ToolBase {
         }
 
         if (errorClarification) {
-            logger.debug(
-                LogId.toolDisabled,
-                "tool",
-                `Prevented registration of ${this.name} because ${errorClarification} is disabled in the config`
-            );
+            logger.debug({
+                id: LogId.toolDisabled,
+                context: "tool",
+                message: `Prevented registration of ${this.name} because ${errorClarification} is disabled in the config`,
+                noRedaction: true,
+            });
 
             return false;
         }

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -65,7 +65,11 @@ export class StdioRunner extends TransportRunnerBase {
 
             await this.server.connect(transport);
         } catch (error: unknown) {
-            logger.emergency(LogId.serverStartFailure, "server", `Fatal error running server: ${error as string}`);
+            logger.emergency({
+                id: LogId.serverStartFailure,
+                context: "server",
+                message: `Fatal error running server: ${error as string}`,
+            });
             process.exit(1);
         }
     }

--- a/src/transports/streamableHttp.ts
+++ b/src/transports/streamableHttp.ts
@@ -19,11 +19,11 @@ function withErrorHandling(
 ) {
     return (req: express.Request, res: express.Response, next: express.NextFunction) => {
         fn(req, res, next).catch((error) => {
-            logger.error(
-                LogId.streamableHttpTransportRequestFailure,
-                "streamableHttpTransport",
-                `Error handling request: ${error instanceof Error ? error.message : String(error)}`
-            );
+            logger.error({
+                id: LogId.streamableHttpTransportRequestFailure,
+                context: "streamableHttpTransport",
+                message: `Error handling request: ${error instanceof Error ? error.message : String(error)}`,
+            });
             res.status(400).json({
                 jsonrpc: "2.0",
                 error: {
@@ -116,22 +116,22 @@ export class StreamableHttpRunner extends TransportRunnerBase {
                         try {
                             await this.sessionStore.closeSession(sessionId, false);
                         } catch (error) {
-                            logger.error(
-                                LogId.streamableHttpTransportSessionCloseFailure,
-                                "streamableHttpTransport",
-                                `Error closing session: ${error instanceof Error ? error.message : String(error)}`
-                            );
+                            logger.error({
+                                id: LogId.streamableHttpTransportSessionCloseFailure,
+                                context: "streamableHttpTransport",
+                                message: `Error closing session: ${error instanceof Error ? error.message : String(error)}`,
+                            });
                         }
                     },
                 });
 
                 transport.onclose = () => {
                     server.close().catch((error) => {
-                        logger.error(
-                            LogId.streamableHttpTransportCloseFailure,
-                            "streamableHttpTransport",
-                            `Error closing server: ${error instanceof Error ? error.message : String(error)}`
-                        );
+                        logger.error({
+                            id: LogId.streamableHttpTransportCloseFailure,
+                            context: "streamableHttpTransport",
+                            message: `Error closing server: ${error instanceof Error ? error.message : String(error)}`,
+                        });
                     });
                 };
 
@@ -154,11 +154,12 @@ export class StreamableHttpRunner extends TransportRunnerBase {
             });
         });
 
-        logger.info(
-            LogId.streamableHttpTransportStarted,
-            "streamableHttpTransport",
-            `Server started on http://${this.userConfig.httpHost}:${this.userConfig.httpPort}`
-        );
+        logger.info({
+            id: LogId.streamableHttpTransportStarted,
+            context: "streamableHttpTransport",
+            message: `Server started on http://${this.userConfig.httpHost}:${this.userConfig.httpPort}`,
+            noRedaction: true,
+        });
     }
 
     async close(): Promise<void> {


### PR DESCRIPTION
## Proposed changes

This is a refactoring of the logger interface to allow consumers to opt out of the automatic redacting logic. It enables a blanket opt out or opting out for specific logger type(s).

This should only be used where the messages are safe to log or where not logging the unredacted messages makes the logs meaningless. The impetus for this change is logging by the HTTP transport, which would otherwise log things like `Server started on http://<ip-address>:3000`.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
