### PR TITLE
chore: refactor connections to use the new ConnectionManager to isolate long running processes like OIDC connections MCP-81

### DIFF
--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -21,7 +21,7 @@ export interface ConnectionSettings extends ConnectOptions {
 
 type ConnectionTag = "connected" | "connecting" | "disconnected" | "errored";
 type OIDCConnectionAuthType = "oidc-auth-flow" | "oidc-device-flow";
-type ConnectionStringAuthType = "scram" | "ldap" | "kerberos" | OIDCConnectionAuthType | "x.509";
+export type ConnectionStringAuthType = "scram" | "ldap" | "kerberos" | OIDCConnectionAuthType | "x.509";
 
 export interface ConnectionState {
     tag: ConnectionTag;
@@ -114,7 +114,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
                 tag: "connected",
                 connectedAtlasCluster: settings.atlas,
                 serviceProvider,
-                connectionStringAuthType: this.inferConnectionTypeFromSettings(settings),
+                connectionStringAuthType: ConnectionManager.inferConnectionTypeFromSettings(settings),
             });
         } catch (error: unknown) {
             const errorReason = error instanceof Error ? error.message : `${error as string}`;
@@ -154,7 +154,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
         return newState;
     }
 
-    private inferConnectionTypeFromSettings(settings: ConnectionSettings): ConnectionStringAuthType {
+    static inferConnectionTypeFromSettings(settings: ConnectionSettings): ConnectionStringAuthType {
         const connString = new ConnectionString(settings.connectionString);
         const searchParams = connString.typedSearchParams<MongoClientOptions>();
 

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -1,0 +1,179 @@
+import { ConnectOptions } from "./config.js";
+import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import EventEmitter from "events";
+import { setAppNameParamIfMissing } from "../helpers/connectionOptions.js";
+import { packageInfo } from "./packageInfo.js";
+import ConnectionString from "mongodb-connection-string-url";
+import { MongoClientOptions } from "mongodb";
+import { ErrorCodes, MongoDBError } from "./errors.js";
+
+export interface AtlasClusterConnectionInfo {
+    username: string;
+    projectId: string;
+    clusterName: string;
+    expiryDate: Date;
+}
+
+export interface ConnectionSettings extends ConnectOptions {
+    connectionString: string;
+    atlas?: AtlasClusterConnectionInfo;
+}
+
+type ConnectionTag = "connected" | "connecting" | "disconnected" | "errored";
+type OIDCConnectionAuthType = "oidc-auth-flow" | "oidc-device-flow";
+type ConnectionStringAuthType = "scram" | "ldap" | "kerberos" | OIDCConnectionAuthType | "x.509";
+
+export interface ConnectionState {
+    tag: ConnectionTag;
+    connectionStringAuthType?: ConnectionStringAuthType;
+}
+
+export interface ConnectionStateConnected extends ConnectionState {
+    tag: "connected";
+    serviceProvider: NodeDriverServiceProvider;
+    connectedAtlasCluster?: AtlasClusterConnectionInfo;
+}
+
+export interface ConnectionStateConnecting extends ConnectionState {
+    tag: "connecting";
+    serviceProvider: NodeDriverServiceProvider;
+    oidcConnectionType: OIDCConnectionAuthType;
+    oidcLoginUrl?: string;
+    oidcUserCode?: string;
+}
+
+export interface ConnectionStateDisconnected extends ConnectionState {
+    tag: "disconnected";
+}
+
+export interface ConnectionStateErrored extends ConnectionState {
+    tag: "errored";
+    errorReason: string;
+}
+
+export type AnyConnectionState =
+    | ConnectionState
+    | ConnectionStateConnected
+    | ConnectionStateConnecting
+    | ConnectionStateDisconnected
+    | ConnectionStateErrored;
+
+export interface ConnectionManagerEvents {
+    "connection-requested": [AnyConnectionState];
+    "connection-succeeded": [ConnectionStateConnected];
+    "connection-timed-out": [ConnectionStateErrored];
+    "connection-closed": [ConnectionStateDisconnected];
+    "connection-errored": [ConnectionStateErrored];
+}
+
+export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
+    private state: AnyConnectionState;
+
+    constructor() {
+        super();
+        this.state = { tag: "disconnected" };
+    }
+
+    async connect(settings: ConnectionSettings): Promise<AnyConnectionState> {
+        if (this.state.tag == "connected" || this.state.tag == "connecting") {
+            await this.disconnect();
+        }
+
+        let serviceProvider: NodeDriverServiceProvider;
+        try {
+            settings = { ...settings };
+            settings.connectionString = setAppNameParamIfMissing({
+                connectionString: settings.connectionString,
+                defaultAppName: `${packageInfo.mcpServerName} ${packageInfo.version}`,
+            });
+
+            serviceProvider = await NodeDriverServiceProvider.connect(settings.connectionString, {
+                productDocsLink: "https://github.com/mongodb-js/mongodb-mcp-server/",
+                productName: "MongoDB MCP",
+                readConcern: {
+                    level: settings.readConcern,
+                },
+                readPreference: settings.readPreference,
+                writeConcern: {
+                    w: settings.writeConcern,
+                },
+                timeoutMS: settings.timeoutMS,
+                proxy: { useEnvironmentVariableProxies: true },
+                applyProxyToOIDC: true,
+            });
+        } catch (error: unknown) {
+            const errorReason = error instanceof Error ? error.message : `${error as string}`;
+            this.changeState("connection-errored", { tag: "errored", errorReason });
+            throw new MongoDBError(ErrorCodes.MisconfiguredConnectionString, errorReason);
+        }
+
+        try {
+            await serviceProvider?.runCommand?.("admin", { hello: 1 });
+
+            return this.changeState("connection-succeeded", {
+                tag: "connected",
+                connectedAtlasCluster: settings.atlas,
+                serviceProvider,
+                connectionStringAuthType: this.inferConnectionTypeFromSettings(settings),
+            });
+        } catch (error: unknown) {
+            const errorReason = error instanceof Error ? error.message : `${error as string}`;
+            this.changeState("connection-errored", { tag: "errored", errorReason });
+            throw new MongoDBError(ErrorCodes.NotConnectedToMongoDB, errorReason);
+        }
+    }
+
+    async disconnect(): Promise<ConnectionStateDisconnected | ConnectionStateErrored> {
+        if (this.state.tag == "disconnected") {
+            return this.state as ConnectionStateDisconnected;
+        }
+
+        if (this.state.tag == "errored") {
+            return this.state as ConnectionStateErrored;
+        }
+
+        if (this.state.tag == "connected" || this.state.tag == "connecting") {
+            const state = this.state as ConnectionStateConnecting | ConnectionStateConnected;
+            try {
+                await state.serviceProvider?.close(true);
+            } finally {
+                this.changeState("connection-closed", { tag: "disconnected" });
+            }
+        }
+
+        return { tag: "disconnected" };
+    }
+
+    get currentConnectionState(): AnyConnectionState {
+        return this.state;
+    }
+
+    changeState<State extends AnyConnectionState>(event: keyof ConnectionManagerEvents, newState: State): State {
+        this.state = newState;
+        this.emit(event, newState);
+        return newState;
+    }
+
+    private inferConnectionTypeFromSettings(settings: ConnectionSettings): ConnectionStringAuthType {
+        const connString = new ConnectionString(settings.connectionString);
+        const searchParams = connString.typedSearchParams<MongoClientOptions>();
+
+        switch (searchParams.get("authMechanism")) {
+            case "MONGODB-OIDC": {
+                return "oidc-auth-flow"; // TODO: depending on if we don't have a --browser later it can be oidc-device-flow
+            }
+            case "MONGODB-X509":
+                return "x.509";
+            case "GSSAPI":
+                return "kerberos";
+            case "PLAIN":
+                if (searchParams.get("authSource") == "$external") {
+                    return "ldap";
+                }
+                break;
+            default:
+                return "scram";
+        }
+        return "scram";
+    }
+}

--- a/src/resources/common/debug.ts
+++ b/src/resources/common/debug.ts
@@ -10,10 +10,10 @@ type ConnectionStateDebuggingInformation = {
 
 export class DebugResource extends ReactiveResource(
     {
-        name: "debug-mongodb-connectivity",
-        uri: "debug://mongodb-connectivity",
+        name: "debug-mongodb",
+        uri: "debug://mongodb",
         config: {
-            description: "Debugging information for connectivity issues.",
+            description: "Debugging information for MongoDB connectivity issues.",
         },
     },
     {

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,12 +38,15 @@ export class Server {
     }
 
     async connect(transport: Transport): Promise<void> {
+        // Resources are now reactive, so we register them ASAP so they can listen to events like
+        // connection events.
+        this.registerResources();
         await this.validateConfig();
 
         this.mcpServer.server.registerCapabilities({ logging: {} });
 
+        // TODO: Eventually we might want to make tools reactive too instead of relying on custom logic.
         this.registerTools();
-        this.registerResources();
 
         // This is a workaround for an issue we've seen with some models, where they'll see that everything in the `arguments`
         // object is optional, and then not pass it at all. However, the MCP server expects the `arguments` object to be if
@@ -194,7 +197,10 @@ export class Server {
 
         if (this.userConfig.connectionString) {
             try {
-                await this.session.connectToMongoDB(this.userConfig.connectionString, this.userConfig.connectOptions);
+                await this.session.connectToMongoDB({
+                    connectionString: this.userConfig.connectionString,
+                    ...this.userConfig.connectOptions,
+                });
             } catch (error) {
                 console.error(
                     "Failed to connect to MongoDB instance using the connection string from the config: ",

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -27,7 +27,7 @@ export class ConnectClusterTool extends AtlasToolBase {
         clusterName: string
     ): Promise<"connected" | "disconnected" | "connecting" | "connected-to-other-cluster" | "unknown"> {
         if (!this.session.connectedAtlasCluster) {
-            if (this.session.serviceProvider) {
+            if (this.session.isConnectedToMongoDB()) {
                 return "connected-to-other-cluster";
             }
             return "disconnected";
@@ -40,7 +40,7 @@ export class ConnectClusterTool extends AtlasToolBase {
             return "connected-to-other-cluster";
         }
 
-        if (!this.session.serviceProvider) {
+        if (!this.session.isConnectedToMongoDB()) {
             return "connecting";
         }
 
@@ -145,7 +145,7 @@ export class ConnectClusterTool extends AtlasToolBase {
             try {
                 lastError = undefined;
 
-                await this.session.connectToMongoDB(connectionString, this.config.connectOptions);
+                await this.session.connectToMongoDB({ connectionString, ...this.config.connectOptions });
                 break;
             } catch (err: unknown) {
                 const error = err instanceof Error ? err : new Error(String(err));

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -5,6 +5,7 @@ import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ErrorCodes, MongoDBError } from "../../common/errors.js";
 import logger, { LogId } from "../../common/logger.js";
 import { Server } from "../../server.js";
+import { AnyConnectionState } from "../../common/connectionManager.js";
 
 export const DbOperationArgs = {
     database: z.string().describe("Database name"),
@@ -16,7 +17,7 @@ export abstract class MongoDBToolBase extends ToolBase {
     public category: ToolCategory = "mongodb";
 
     protected async ensureConnected(): Promise<NodeDriverServiceProvider> {
-        if (!this.session.serviceProvider) {
+        if (!this.session.isConnectedToMongoDB()) {
             if (this.session.connectedAtlasCluster) {
                 throw new MongoDBError(
                     ErrorCodes.NotConnectedToMongoDB,
@@ -38,7 +39,7 @@ export abstract class MongoDBToolBase extends ToolBase {
             }
         }
 
-        if (!this.session.serviceProvider) {
+        if (!this.session.isConnectedToMongoDB()) {
             throw new MongoDBError(ErrorCodes.NotConnectedToMongoDB, "Not connected to MongoDB");
         }
 
@@ -116,8 +117,8 @@ export abstract class MongoDBToolBase extends ToolBase {
         return super.handleError(error, args);
     }
 
-    protected connectToMongoDB(connectionString: string): Promise<void> {
-        return this.session.connectToMongoDB(connectionString, this.config.connectOptions);
+    protected connectToMongoDB(connectionString: string): Promise<AnyConnectionState> {
+        return this.session.connectToMongoDB({ connectionString, ...this.config.connectOptions });
     }
 
     protected resolveTelemetryMetadata(

--- a/tests/integration/common/connectionManager.test.ts
+++ b/tests/integration/common/connectionManager.test.ts
@@ -1,0 +1,151 @@
+import {
+    ConnectionManager,
+    ConnectionManagerEvents,
+    ConnectionStateConnected,
+    ConnectionStringAuthType,
+} from "../../../src/common/connectionManager.js";
+import { describeWithMongoDB } from "../tools/mongodb/mongodbHelpers.js";
+import { describe, beforeEach, expect, it, vi, afterEach } from "vitest";
+import { config } from "../../../src/common/config.js";
+
+describeWithMongoDB("Connection Manager", (integration) => {
+    function connectionManager() {
+        return integration.mcpServer().session.connectionManager;
+    }
+
+    afterEach(async () => {
+        // disconnect on purpose doesn't change the state if it was failed to avoid losing
+        // information in production.
+        await connectionManager().disconnect();
+        // for testing, force disconnecting AND setting the connection to closed to reset the
+        // state of the connection manager
+        connectionManager().changeState("connection-closed", { tag: "disconnected" });
+    });
+
+    describe("when successfully connected", () => {
+        type ConnectionManagerSpies = {
+            "connection-requested": (event: ConnectionManagerEvents["connection-requested"][0]) => void;
+            "connection-succeeded": (event: ConnectionManagerEvents["connection-succeeded"][0]) => void;
+            "connection-timed-out": (event: ConnectionManagerEvents["connection-timed-out"][0]) => void;
+            "connection-closed": (event: ConnectionManagerEvents["connection-closed"][0]) => void;
+            "connection-errored": (event: ConnectionManagerEvents["connection-errored"][0]) => void;
+        };
+
+        let connectionManagerSpies: ConnectionManagerSpies;
+
+        beforeEach(async () => {
+            connectionManagerSpies = {
+                "connection-requested": vi.fn(),
+                "connection-succeeded": vi.fn(),
+                "connection-timed-out": vi.fn(),
+                "connection-closed": vi.fn(),
+                "connection-errored": vi.fn(),
+            };
+
+            for (const [event, spy] of Object.entries(connectionManagerSpies)) {
+                connectionManager().on(event as keyof ConnectionManagerEvents, spy);
+            }
+
+            await connectionManager().connect({
+                connectionString: integration.connectionString(),
+                ...integration.mcpServer().userConfig.connectOptions,
+            });
+        });
+
+        it("should be marked explicitly as connected", () => {
+            expect(connectionManager().currentConnectionState.tag).toEqual("connected");
+        });
+
+        it("can query mongodb successfully", async () => {
+            const connectionState = connectionManager().currentConnectionState as ConnectionStateConnected;
+            const collections = await connectionState.serviceProvider.listCollections("admin");
+            expect(collections).not.toBe([]);
+        });
+
+        it("should notify that the connection was successful", () => {
+            expect(connectionManagerSpies["connection-succeeded"]).toHaveBeenCalledOnce();
+        });
+
+        describe("when disconnects", () => {
+            beforeEach(async () => {
+                await connectionManager().disconnect();
+            });
+
+            it("should notify that it was disconnected before connecting", () => {
+                expect(connectionManagerSpies["connection-closed"]).toHaveBeenCalled();
+            });
+        });
+
+        describe("when reconnects", () => {
+            beforeEach(async () => {
+                await connectionManager().connect({
+                    connectionString: integration.connectionString(),
+                    ...integration.mcpServer().userConfig.connectOptions,
+                });
+            });
+
+            it("should notify that it was disconnected before connecting", () => {
+                expect(connectionManagerSpies["connection-closed"]).toHaveBeenCalled();
+            });
+
+            it("should notify that it was connected again", () => {
+                expect(connectionManagerSpies["connection-succeeded"]).toHaveBeenCalled();
+            });
+        });
+
+        describe("when fails to connect to a new cluster", () => {
+            beforeEach(async () => {
+                try {
+                    await connectionManager().connect({
+                        connectionString: "mongodb://localhost:xxxxx",
+                        ...integration.mcpServer().userConfig.connectOptions,
+                    });
+                } catch (_error: unknown) {
+                    void _error;
+                }
+            });
+
+            it("should notify that it was disconnected before connecting", () => {
+                expect(connectionManagerSpies["connection-closed"]).toHaveBeenCalled();
+            });
+
+            it("should notify that it failed connecting", () => {
+                expect(connectionManagerSpies["connection-errored"]).toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe("when disconnected", () => {
+        it("should be marked explictly as disconnected", () => {
+            expect(connectionManager().currentConnectionState.tag).toEqual("disconnected");
+        });
+    });
+});
+
+describe("Connection Manager connection type inference", () => {
+    const testCases = [
+        { connectionString: "mongodb://localhost:27017", connectionType: "scram" },
+        { connectionString: "mongodb://localhost:27017?authMechanism=MONGODB-X509", connectionType: "x.509" },
+        { connectionString: "mongodb://localhost:27017?authMechanism=GSSAPI", connectionType: "kerberos" },
+        {
+            connectionString: "mongodb://localhost:27017?authMechanism=PLAIN&authSource=$external",
+            connectionType: "ldap",
+        },
+        { connectionString: "mongodb://localhost:27017?authMechanism=PLAIN", connectionType: "scram" },
+        { connectionString: "mongodb://localhost:27017?authMechanism=MONGODB-OIDC", connectionType: "oidc-auth-flow" },
+    ] as {
+        connectionString: string;
+        connectionType: ConnectionStringAuthType;
+    }[];
+
+    for (const { connectionString, connectionType } of testCases) {
+        it(`infers ${connectionType} from ${connectionString}`, () => {
+            const actualConnectionType = ConnectionManager.inferConnectionTypeFromSettings({
+                connectionString,
+                ...config.connectOptions,
+            });
+
+            expect(actualConnectionType).toBe(connectionType);
+        });
+    }
+});

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -8,6 +8,7 @@ import { Session } from "../../src/common/session.js";
 import { Telemetry } from "../../src/telemetry/telemetry.js";
 import { config } from "../../src/common/config.js";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { ConnectionManager } from "../../src/common/connectionManager.js";
 
 interface ParameterInfo {
     name: string;
@@ -53,10 +54,13 @@ export function setupIntegrationTest(getUserConfig: () => UserConfig): Integrati
             }
         );
 
+        const connectionManager = new ConnectionManager();
+
         const session = new Session({
             apiBaseUrl: userConfig.apiBaseUrl,
             apiClientId: userConfig.apiClientId,
             apiClientSecret: userConfig.apiClientSecret,
+            connectionManager,
         });
 
         // Mock hasValidAccessToken for tests

--- a/tests/integration/tools/mongodb/connect/connect.test.ts
+++ b/tests/integration/tools/mongodb/connect/connect.test.ts
@@ -14,6 +14,9 @@ describeWithMongoDB(
     (integration) => {
         beforeEach(() => {
             integration.mcpServer().userConfig.connectionString = integration.connectionString();
+            integration.mcpServer().session.connectionManager.changeState("connection-succeeded", {
+                tag: "connected",
+            });
         });
 
         validateToolMetadata(
@@ -75,7 +78,7 @@ describeWithMongoDB(
 
                 const content = getResponseContent(response.content);
 
-                expect(content).toContain("Error running switch-connection");
+                expect(content).toContain("The configured connection string is not valid.");
             });
         });
     },
@@ -125,7 +128,7 @@ describeWithMongoDB(
                     arguments: { connectionString: "mongodb://localhost:12345" },
                 });
                 const content = getResponseContent(response.content);
-                expect(content).toContain("Error running connect");
+                expect(content).toContain("The configured connection string is not valid.");
 
                 // Should not suggest using the config connection string (because we don't have one)
                 expect(content).not.toContain("Your config lists a different connection string");

--- a/tests/integration/transports/stdio.test.ts
+++ b/tests/integration/transports/stdio.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { describe, expect, beforeEach, it, beforeAll, afterAll } from "vitest";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { describeWithMongoDB } from "../tools/mongodb/mongodbHelpers.js";
 
-describe("StdioRunner", () => {
+describeWithMongoDB("StdioRunner", (integration) => {
+    beforeEach(() => {
+        integration.mcpServer().userConfig.connectionString = integration.connectionString();
+        integration.mcpServer().session.connectionManager.changeState("connection-succeeded", {
+            tag: "connected",
+        });
+    });
+
     describe("client connects successfully", () => {
         let client: Client;
         let transport: StdioClientTransport;
@@ -12,6 +20,7 @@ describe("StdioRunner", () => {
                 args: ["dist/index.js"],
                 env: {
                     MDB_MCP_TRANSPORT: "stdio",
+                    MDB_MCP_CONNECTION_STRING: integration.connectionString(),
                 },
             });
             client = new Client({

--- a/tests/unit/common/session.test.ts
+++ b/tests/unit/common/session.test.ts
@@ -43,7 +43,10 @@ describe("Session", () => {
 
         for (const testCase of testCases) {
             it(`should update connection string for ${testCase.name}`, async () => {
-                await session.connectToMongoDB(testCase.connectionString, config.connectOptions);
+                await session.connectToMongoDB({
+                    connectionString: testCase.connectionString,
+                    ...config.connectOptions,
+                });
                 expect(session.serviceProvider).toBeDefined();
 
                 const connectMock = MockNodeDriverServiceProvider.connect;
@@ -58,7 +61,7 @@ describe("Session", () => {
         }
 
         it("should configure the proxy to use environment variables", async () => {
-            await session.connectToMongoDB("mongodb://localhost", config.connectOptions);
+            await session.connectToMongoDB({ connectionString: "mongodb://localhost", ...config.connectOptions });
             expect(session.serviceProvider).toBeDefined();
 
             const connectMock = MockNodeDriverServiceProvider.connect;


### PR DESCRIPTION
## Proposed changes

This PR basically proposes consolidating all connections into a single class, ConnectionManager. After this PR, both Atlas tools and MongoDB tools use the same code to connect to MongoDB, independently of the connection type.

Also, the ConnectionManager gets an upgrade on how to handle errors and debugging information:

* The ConnectionManager keeps track of the latest state and emits events when the connection status changes.
* There is a new debug resource that contains information about the last connection error.
* The ConnectionManager infers the authentication type, to provide more information to the user when something goes wrong.
* The ConnectionManager implements the non-terminal "connecting" state for OIDC flows.

To avoid changing the whole architecture and _maybe_ support multitenancy in the future, the ConnectionManager is hidden and isolated in the Session.

* Tools still use the session, who acts as a proxy between the ConnectionManager and the tool.
* Tools still work with the service provider through the Session, and the session ensures the connection is active.


This PR is bigger than usual because the refactor touches some root infrastructure, but hopefully the unit and integration tests I've added, along with the manual testing, ensures everything works correctly.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
