### PR TITLE
chore: add arg-parser and put the config under test MCP-86

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,4 +55,4 @@ jobs:
           rm -rf node_modules
           npm pkg set scripts.prepare="exit 0"
           npm install --omit=dev
-      - run: npx -y @modelcontextprotocol/inspector --cli --method tools/list -- node dist/esm/index.js
+      - run: npx -y @modelcontextprotocol/inspector@0.16.2 --cli --method tools/list -- node dist/esm/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mongodb-js/device-id": "^0.3.1",
         "@mongodb-js/devtools-connect": "^3.9.2",
         "@mongodb-js/devtools-proxy-support": "^0.5.1",
+        "@mongosh/arg-parser": "^3.14.0",
         "@mongosh/service-provider-node-driver": "^3.10.2",
         "@vitest/eslint-plugin": "^1.3.4",
         "bson": "^6.10.4",
@@ -2274,10 +2275,54 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@mongosh/arg-parser": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@mongosh/arg-parser/-/arg-parser-3.14.0.tgz",
+      "integrity": "sha512-ue7FtuO9rgmjrh2lFZdgtrVMrGXeqBG8mWDDTb/CZ2GZNtULhAdk9d+gdnjupQNH66fGWoKdLhuur466HuJrtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/errors": "2.4.2",
+        "@mongosh/i18n": "^2.15.2",
+        "mongodb-connection-string-url": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/arg-parser/node_modules/@mongosh/errors": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-2.4.2.tgz",
+      "integrity": "sha512-p+LOHVj/VIt6cpJY1AvDmG/QLP7WZQ7q+32paU6qxjXaoC0kMqmemaqK5cUj8JWod1VEv9/Ol4T6OfWTwPG20A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
     "node_modules/@mongosh/errors": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-2.4.0.tgz",
       "integrity": "sha512-2YwY4TYlrAy3VC9Y5Xa1OWlbdb57O0ZTDfntROFcfotrMXkZc9CU+jafrKRNcPJz8UAhoUcSTDJuaLpC3AutHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/i18n": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-2.15.2.tgz",
+      "integrity": "sha512-E286cGq9/Cgg1TjkOvuKG5ymmIZI/gUpXatK83Ulp9EbQ+tqSwDsv+A3Z+unFyRHYvFuTLVlBCXFyHRDBn8Nww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongosh/errors": "2.4.2"
+      },
+      "engines": {
+        "node": ">=14.15.1"
+      }
+    },
+    "node_modules/@mongosh/i18n/node_modules/@mongosh/errors": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-2.4.2.tgz",
+      "integrity": "sha512-p+LOHVj/VIt6cpJY1AvDmG/QLP7WZQ7q+32paU6qxjXaoC0kMqmemaqK5cUj8JWod1VEv9/Ol4T6OfWTwPG20A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.15.1"

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@mongodb-js/device-id": "^0.3.1",
     "@mongodb-js/devtools-connect": "^3.9.2",
     "@mongodb-js/devtools-proxy-support": "^0.5.1",
+    "@mongosh/arg-parser": "^3.14.0",
     "@mongosh/service-provider-node-driver": "^3.10.2",
     "@vitest/eslint-plugin": "^1.3.4",
     "bson": "^6.10.4",

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -275,14 +275,10 @@ function commaSeparatedToArray<T extends string[]>(str: string | string[] | unde
     }
 
     if (str.length === 1) {
-        if (str[0]?.indexOf(",") === -1) {
-            return str.filter((e) => e.trim().length > 0) as T;
-        } else {
-            return str[0]
-                ?.split(",")
-                .map((e) => e.trim())
-                .filter((e) => e.length > 0) as T;
-        }
+        return str[0]
+            ?.split(",")
+            .map((e) => e.trim())
+            .filter((e) => e.length > 0) as T;
     }
 
     return str as T;

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -273,9 +273,12 @@ function commaSeparatedToArray<T extends string[]>(str: string | string[] | unde
 
     if (str.length === 1) {
         if (str[0]?.indexOf(",") === -1) {
-            return str as T;
+            return str.filter((e) => e.trim().length > 0) as T;
         } else {
-            return str[0]?.split(",").map((e) => e.trim()) as T;
+            return str[0]
+                ?.split(",")
+                .map((e) => e.trim())
+                .filter((e) => e.length > 0) as T;
         }
     }
 
@@ -315,7 +318,8 @@ export function setupUserConfig({
         throw new Error(`Invalid telemetry: ${telemetry}`);
     }
 
-    if (userConfig.httpPort < 1 || userConfig.httpPort > 65535) {
+    const httpPort = +userConfig.httpPort;
+    if (httpPort < 1 || httpPort > 65535 || isNaN(httpPort)) {
         throw new Error(`Invalid httpPort: ${userConfig.httpPort}`);
     }
 

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -66,7 +66,6 @@ const OPTIONS = {
         "tlsAllowInvalidCertificates",
         "tlsAllowInvalidHostnames",
         "tlsFIPSMode",
-        "tlsUseSystemCA",
         "version",
     ],
     array: ["disabledTools", "loggers"],

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -250,6 +250,9 @@ function parseCliConfig(args: string[]): CliOptions {
         };
 
     const positionalArguments = parsed._ ?? [];
+    // if we have a positional argument that matches a connection string
+    // store it as the connection specifier and remove it from the argument
+    // list, so it doesn't get misunderstood by the mongosh args-parser
     if (!parsed.nodb && isConnectionSpecifier(positionalArguments[0])) {
         parsed.connectionSpecifier = positionalArguments.shift();
     }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -164,6 +164,11 @@ export const defaultDriverOptions: ConnectionInfo["driverOptions"] = {
     applyProxyToOIDC: true,
 };
 
+export const driverOptions = setupDriverConfig({
+    config,
+    defaults: defaultDriverOptions,
+});
+
 function getLogPath(): string {
     const logPath = path.join(getLocalDataPath(), "mongodb-mcp", ".app-logs");
     return logPath;
@@ -301,4 +306,18 @@ export function setupUserConfig({
     }
 
     return userConfig;
+}
+
+export function setupDriverConfig({
+    config,
+    defaults,
+}: {
+    config: UserConfig;
+    defaults: ConnectionInfo["driverOptions"];
+}): ConnectionInfo["driverOptions"] {
+    const { driverOptions } = generateConnectionInfoFromCliArgs(config);
+    return {
+        ...defaults,
+        ...driverOptions,
+    };
 }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,8 +1,103 @@
 import path from "path";
 import os from "os";
 import argv from "yargs-parser";
-
+import type { CliOptions } from "@mongosh/arg-parser";
 import { ReadConcernLevel, ReadPreferenceMode, W } from "mongodb";
+
+// From: https://github.com/mongodb-js/mongosh/blob/main/packages/cli-repl/src/arg-parser.ts
+const OPTIONS = {
+    string: [
+        "apiBaseUrl",
+        "apiClientId",
+        "apiClientSecret",
+        "connectionString",
+        "httpHost",
+        "httpPort",
+        "idleTimeoutMs",
+        "logPath",
+        "notificationTimeoutMs",
+        "telemetry",
+        "transport",
+        "apiVersion",
+        "authenticationDatabase",
+        "authenticationMechanism",
+        "browser",
+        "db",
+        "gssapiHostName",
+        "gssapiServiceName",
+        "host",
+        "oidcFlows",
+        "oidcRedirectUri",
+        "password",
+        "port",
+        "sslCAFile",
+        "sslCRLFile",
+        "sslCertificateSelector",
+        "sslDisabledProtocols",
+        "sslPEMKeyFile",
+        "sslPEMKeyPassword",
+        "sspiHostnameCanonicalization",
+        "sspiRealmOverride",
+        "tlsCAFile",
+        "tlsCRLFile",
+        "tlsCertificateKeyFile",
+        "tlsCertificateKeyFilePassword",
+        "tlsCertificateSelector",
+        "tlsDisabledProtocols",
+        "username",
+    ],
+    boolean: [
+        "apiDeprecationErrors",
+        "apiStrict",
+        "help",
+        "indexCheck",
+        "ipv6",
+        "nodb",
+        "oidcIdTokenAsAccessToken",
+        "oidcNoNonce",
+        "oidcTrustedEndpoint",
+        "readOnly",
+        "retryWrites",
+        "ssl",
+        "sslAllowInvalidCertificates",
+        "sslAllowInvalidHostnames",
+        "sslFIPSMode",
+        "tls",
+        "tlsAllowInvalidCertificates",
+        "tlsAllowInvalidHostnames",
+        "tlsFIPSMode",
+        "tlsUseSystemCA",
+        "version",
+    ],
+    array: ["disabledTools", "loggers"],
+    alias: {
+        h: "help",
+        p: "password",
+        u: "username",
+        "build-info": "buildInfo",
+        browser: "browser",
+        oidcDumpTokens: "oidcDumpTokens",
+        oidcRedirectUrl: "oidcRedirectUri",
+        oidcIDTokenAsAccessToken: "oidcIdTokenAsAccessToken",
+    },
+    configuration: {
+        "camel-case-expansion": false,
+        "unknown-options-as-args": true,
+        "parse-positional-numbers": false,
+        "parse-numbers": false,
+        "greedy-arrays": true,
+        "short-option-groups": false,
+    },
+};
+
+function isConnectionSpecifier(arg: string | undefined): boolean {
+    return (
+        arg !== undefined &&
+        (arg.startsWith("mongodb://") ||
+            arg.startsWith("mongodb+srv://") ||
+            !(arg.endsWith(".js") || arg.endsWith(".mongodb")))
+    );
+}
 
 export interface ConnectOptions {
     readConcern: ReadConcernLevel;
@@ -13,7 +108,7 @@ export interface ConnectOptions {
 
 // If we decide to support non-string config options, we'll need to extend the mechanism for parsing
 // env variables.
-export interface UserConfig {
+export interface UserConfig extends CliOptions {
     apiBaseUrl: string;
     apiClientId?: string;
     apiClientSecret?: string;
@@ -59,11 +154,11 @@ const defaults: UserConfig = {
     notificationTimeoutMs: 540000, // 9 minutes
 };
 
-export const config = {
-    ...defaults,
-    ...getEnvConfig(),
-    ...getCliConfig(),
-};
+export const config = setupUserConfig({
+    defaults,
+    cli: process.argv,
+    env: process.env,
+});
 
 function getLocalDataPath(): string {
     return process.platform === "win32"
@@ -83,7 +178,7 @@ function getExportsPath(): string {
 // Gets the config supplied by the user as environment variables. The variable names
 // are prefixed with `MDB_MCP_` and the keys match the UserConfig keys, but are converted
 // to SNAKE_UPPER_CASE.
-function getEnvConfig(): Partial<UserConfig> {
+function parseEnvConfig(env: Record<string, unknown>): Partial<UserConfig> {
     function setValue(obj: Record<string, unknown>, path: string[], value: string): void {
         const currentField = path.shift();
         if (!currentField) {
@@ -120,7 +215,7 @@ function getEnvConfig(): Partial<UserConfig> {
     }
 
     const result: Record<string, unknown> = {};
-    const mcpVariables = Object.entries(process.env).filter(
+    const mcpVariables = Object.entries(env).filter(
         ([key, value]) => value !== undefined && key.startsWith("MDB_MCP_")
     ) as [string, string][];
     for (const [key, value] of mcpVariables) {
@@ -139,9 +234,72 @@ function SNAKE_CASE_toCamelCase(str: string): string {
     return str.toLowerCase().replace(/([-_][a-z])/g, (group) => group.toUpperCase().replace("_", ""));
 }
 
-// Reads the cli args and parses them into a UserConfig object.
-function getCliConfig(): Partial<UserConfig> {
-    return argv(process.argv.slice(2), {
-        array: ["disabledTools", "loggers"],
-    }) as unknown as Partial<UserConfig>;
+// Right now we have arguments that are not compatible with the format used in mongosh.
+// An example is using --connectionString and positional arguments.
+// We will consolidate them in a way where the mongosh format takes precedence.
+// We will warn users that previous configuration is deprecated in favour of
+// whatever is in mongosh.
+function parseCliConfig(args: string[]): CliOptions {
+    const programArgs = args.slice(2);
+    const parsed = argv(programArgs, OPTIONS) as unknown as CliOptions &
+        UserConfig & {
+            _?: string[];
+        };
+
+    const positionalArguments = parsed._ ?? [];
+    if (!parsed.nodb && isConnectionSpecifier(positionalArguments[0])) {
+        parsed.connectionSpecifier = positionalArguments.shift();
+    }
+
+    delete parsed._;
+    return parsed;
+}
+
+function commaSeparatedToArray<T extends string[]>(str: string | string[] | undefined): T {
+    if (str === undefined) {
+        return [] as unknown as T;
+    }
+
+    if (!Array.isArray(str)) {
+        return [str] as T;
+    }
+
+    if (str.length === 0) {
+        return str as T;
+    }
+
+    if (str.length === 1) {
+        if (str[0]?.indexOf(",") === -1) {
+            return str as T;
+        } else {
+            return str[0]?.split(",").map((e) => e.trim()) as T;
+        }
+    }
+
+    return str as T;
+}
+
+export function setupUserConfig({
+    cli,
+    env,
+    defaults,
+}: {
+    cli: string[];
+    env: Record<string, unknown>;
+    defaults: Partial<UserConfig>;
+}): UserConfig {
+    const userConfig: UserConfig = {
+        ...defaults,
+        ...parseEnvConfig(env),
+        ...parseCliConfig(cli),
+    } as UserConfig;
+
+    userConfig.disabledTools = commaSeparatedToArray(userConfig.disabledTools);
+    userConfig.loggers = commaSeparatedToArray(userConfig.loggers);
+
+    if (userConfig.connectionString && userConfig.connectionSpecifier) {
+        delete userConfig.connectionString;
+    }
+
+    return userConfig;
 }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,8 +1,8 @@
 import path from "path";
 import os from "os";
 import argv from "yargs-parser";
-import type { CliOptions } from "@mongosh/arg-parser";
-import type { ConnectionInfo } from "@mongosh/arg-parser";
+import type { CliOptions, ConnectionInfo } from "@mongosh/arg-parser";
+import { generateConnectionInfoFromCliArgs } from "@mongosh/arg-parser";
 
 // From: https://github.com/mongodb-js/mongosh/blob/main/packages/cli-repl/src/arg-parser.ts
 const OPTIONS = {
@@ -296,21 +296,9 @@ export function setupUserConfig({
     userConfig.loggers = commaSeparatedToArray(userConfig.loggers);
 
     if (userConfig.connectionString && userConfig.connectionSpecifier) {
-        delete userConfig.connectionString;
+        const connectionInfo = generateConnectionInfoFromCliArgs(userConfig);
+        userConfig.connectionString = connectionInfo.connectionString;
     }
 
     return userConfig;
 }
-
-/**
-                   readConcern: {
-                    level: settings.readConcern,
-                },
-                readPreference: settings.readPreference,
-                writeConcern: {
-                    w: settings.writeConcern,
-                },
-                timeoutMS: settings.timeoutMS,
-                proxy: { useEnvironmentVariableProxies: true },
-                applyProxyToOIDC: true,
-**/

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -1,4 +1,4 @@
-import { defaultDriverOptions } from "./config.js";
+import { driverOptions } from "./config.js";
 import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import EventEmitter from "events";
 import { setAppNameParamIfMissing } from "../helpers/connectionOptions.js";
@@ -92,7 +92,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
             serviceProvider = await NodeDriverServiceProvider.connect(settings.connectionString, {
                 productDocsLink: "https://github.com/mongodb-js/mongodb-mcp-server/",
                 productName: "MongoDB MCP",
-                ...defaultDriverOptions,
+                ...driverOptions,
             });
         } catch (error: unknown) {
             const errorReason = error instanceof Error ? error.message : `${error as string}`;

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -1,4 +1,4 @@
-import { ConnectOptions } from "./config.js";
+import { defaultDriverOptions } from "./config.js";
 import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import EventEmitter from "events";
 import { setAppNameParamIfMissing } from "../helpers/connectionOptions.js";
@@ -14,7 +14,7 @@ export interface AtlasClusterConnectionInfo {
     expiryDate: Date;
 }
 
-export interface ConnectionSettings extends ConnectOptions {
+export interface ConnectionSettings {
     connectionString: string;
     atlas?: AtlasClusterConnectionInfo;
 }
@@ -70,6 +70,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
 
     constructor() {
         super();
+
         this.state = { tag: "disconnected" };
     }
 
@@ -91,16 +92,7 @@ export class ConnectionManager extends EventEmitter<ConnectionManagerEvents> {
             serviceProvider = await NodeDriverServiceProvider.connect(settings.connectionString, {
                 productDocsLink: "https://github.com/mongodb-js/mongodb-mcp-server/",
                 productName: "MongoDB MCP",
-                readConcern: {
-                    level: settings.readConcern,
-                },
-                readPreference: settings.readPreference,
-                writeConcern: {
-                    w: settings.writeConcern,
-                },
-                timeoutMS: settings.timeoutMS,
-                proxy: { useEnvironmentVariableProxies: true },
-                applyProxyToOIDC: true,
+                ...defaultDriverOptions,
             });
         } catch (error: unknown) {
             const errorReason = error instanceof Error ? error.message : `${error as string}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ function assertFIPSMode() {
 }
 
 function assertHelpMode() {
-    if (!!config.help) {
+    if (config.help) {
         console.log("For usage information refer to the README.md:");
         console.log("https://github.com/mongodb-js/mongodb-mcp-server?tab=readme-ov-file#quick-start");
         process.exit(0);
@@ -119,7 +119,7 @@ function assertHelpMode() {
 }
 
 function assertVersionMode() {
-    if (!!config.version) {
+    if (config.version) {
         console.log(packageInfo.version);
         process.exit(0);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,19 @@
 
 import { ConsoleLogger, LogId } from "./common/logger.js";
 import { config } from "./common/config.js";
+import crypto from "crypto";
+import { packageInfo } from "./common/packageInfo.js";
 import { StdioRunner } from "./transports/stdio.js";
 import { StreamableHttpRunner } from "./transports/streamableHttp.js";
+import { systemCA } from "@mongodb-js/devtools-proxy-support";
 
 async function main(): Promise<void> {
+    systemCA().catch(() => undefined); // load system CA asynchronously as in mongosh
+
+    assertFIPSMode();
+    assertHelpMode();
+    assertVersionMode();
+
     const transportRunner = config.transport === "stdio" ? new StdioRunner(config) : new StreamableHttpRunner(config);
 
     const shutdown = (): void => {
@@ -78,3 +87,40 @@ main().catch((error: unknown) => {
     });
     process.exit(1);
 });
+
+function assertFIPSMode() {
+    let fipsError: Error | undefined = undefined;
+    if (config.tlsFIPSMode) {
+        if (!fipsError && !crypto.getFips()) {
+            fipsError = new Error("FIPS mode not enabled despite requested.");
+        }
+    }
+
+    if (fipsError) {
+        if (process.config.variables.node_shared_openssl) {
+            console.error(
+                "Could not enable FIPS mode. Please ensure that your system OpenSSL installation supports FIPS."
+            );
+        } else {
+            console.error("Could not enable FIPS mode. This installation does not appear to support FIPS.");
+        }
+        console.error("Error details:");
+        console.error(fipsError);
+        process.exit(1);
+    }
+}
+
+function assertHelpMode() {
+    if (!!config.help) {
+        console.log("For usage information refer to the README.md:");
+        console.log("https://github.com/mongodb-js/mongodb-mcp-server?tab=readme-ov-file#quick-start");
+        process.exit(0);
+    }
+}
+
+function assertVersionMode() {
+    if (!!config.version) {
+        console.log(packageInfo.version);
+        process.exit(0);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ main().catch((error: unknown) => {
     process.exit(1);
 });
 
-function assertFIPSMode() {
+function assertFIPSMode(): void | never {
     let fipsError: Error | undefined = undefined;
     if (config.tlsFIPSMode) {
         if (!fipsError && !crypto.getFips()) {
@@ -110,7 +110,7 @@ function assertFIPSMode() {
     }
 }
 
-function assertHelpMode() {
+function assertHelpMode(): void | never {
     if (config.help) {
         console.log("For usage information refer to the README.md:");
         console.log("https://github.com/mongodb-js/mongodb-mcp-server?tab=readme-ov-file#quick-start");
@@ -118,7 +118,7 @@ function assertHelpMode() {
     }
 }
 
-function assertVersionMode() {
+function assertVersionMode(): void | never {
     if (config.version) {
         console.log(packageInfo.version);
         process.exit(0);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,4 +1,4 @@
 export { Server, type ServerOptions } from "./server.js";
 export { Telemetry } from "./telemetry/telemetry.js";
 export { Session, type SessionOptions } from "./common/session.js";
-export type { UserConfig, ConnectOptions } from "./common/config.js";
+export type { UserConfig } from "./common/config.js";

--- a/src/resources/common/config.ts
+++ b/src/resources/common/config.ts
@@ -1,4 +1,5 @@
 import { ReactiveResource } from "../resource.js";
+import { defaultDriverOptions } from "../../common/config.js";
 import type { UserConfig } from "../../common/config.js";
 import type { Telemetry } from "../../telemetry/telemetry.js";
 import type { Session } from "../../lib.js";
@@ -37,7 +38,7 @@ export class ConfigResource extends ReactiveResource<UserConfig, readonly []> {
             connectionString: this.current.connectionString
                 ? "set; access to MongoDB tools are currently available to use"
                 : "not set; before using any MongoDB tool, you need to configure a connection string, alternatively you can setup MongoDB Atlas access, more info at 'https://github.com/mongodb-js/mongodb-mcp-server'.",
-            connectOptions: this.current.connectOptions,
+            connectOptions: defaultDriverOptions,
             atlas:
                 this.current.apiClientId && this.current.apiClientSecret
                     ? "set; MongoDB Atlas tools are currently available to use"

--- a/src/server.ts
+++ b/src/server.ts
@@ -221,7 +221,6 @@ export class Server {
             try {
                 await this.session.connectToMongoDB({
                     connectionString: this.userConfig.connectionString,
-                    ...this.userConfig.connectOptions,
                 });
             } catch (error) {
                 console.error(

--- a/src/server.ts
+++ b/src/server.ts
@@ -188,35 +188,6 @@ export class Server {
     }
 
     private async validateConfig(): Promise<void> {
-        const transport = this.userConfig.transport as string;
-        if (transport !== "http" && transport !== "stdio") {
-            throw new Error(`Invalid transport: ${transport}`);
-        }
-
-        const telemetry = this.userConfig.telemetry as string;
-        if (telemetry !== "enabled" && telemetry !== "disabled") {
-            throw new Error(`Invalid telemetry: ${telemetry}`);
-        }
-
-        if (this.userConfig.httpPort < 1 || this.userConfig.httpPort > 65535) {
-            throw new Error(`Invalid httpPort: ${this.userConfig.httpPort}`);
-        }
-
-        if (this.userConfig.loggers.length === 0) {
-            throw new Error("No loggers found in config");
-        }
-
-        const loggerTypes = new Set(this.userConfig.loggers);
-        if (loggerTypes.size !== this.userConfig.loggers.length) {
-            throw new Error("Duplicate loggers found in config");
-        }
-
-        for (const loggerType of this.userConfig.loggers as string[]) {
-            if (loggerType !== "mcp" && loggerType !== "disk" && loggerType !== "stderr") {
-                throw new Error(`Invalid logger: ${loggerType}`);
-            }
-        }
-
         if (this.userConfig.connectionString) {
             try {
                 await this.session.connectToMongoDB({

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -139,7 +139,7 @@ export class ConnectClusterTool extends AtlasToolBase {
             try {
                 lastError = undefined;
 
-                await this.session.connectToMongoDB({ connectionString, ...this.config.connectOptions, atlas });
+                await this.session.connectToMongoDB({ connectionString, atlas });
                 break;
             } catch (err: unknown) {
                 const error = err instanceof Error ? err : new Error(String(err));

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -118,7 +118,7 @@ export abstract class MongoDBToolBase extends ToolBase {
     }
 
     protected connectToMongoDB(connectionString: string): Promise<void> {
-        return this.session.connectToMongoDB({ connectionString, ...this.config.connectOptions });
+        return this.session.connectToMongoDB({ connectionString });
     }
 
     protected resolveTelemetryMetadata(

--- a/tests/integration/common/connectionManager.test.ts
+++ b/tests/integration/common/connectionManager.test.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../src/common/connectionManager.js";
 import { describeWithMongoDB } from "../tools/mongodb/mongodbHelpers.js";
 import { describe, beforeEach, expect, it, vi, afterEach } from "vitest";
-import { config } from "../../../src/common/config.js";
 
 describeWithMongoDB("Connection Manager", (integration) => {
     function connectionManager(): ConnectionManager {
@@ -48,7 +47,6 @@ describeWithMongoDB("Connection Manager", (integration) => {
 
             await connectionManager().connect({
                 connectionString: integration.connectionString(),
-                ...integration.mcpServer().userConfig.connectOptions,
             });
         });
 
@@ -88,7 +86,6 @@ describeWithMongoDB("Connection Manager", (integration) => {
             beforeEach(async () => {
                 await connectionManager().connect({
                     connectionString: integration.connectionString(),
-                    ...integration.mcpServer().userConfig.connectOptions,
                 });
             });
 
@@ -110,7 +107,6 @@ describeWithMongoDB("Connection Manager", (integration) => {
                 try {
                     await connectionManager().connect({
                         connectionString: "mongodb://localhost:xxxxx",
-                        ...integration.mcpServer().userConfig.connectOptions,
                     });
                 } catch (_error: unknown) {
                     void _error;
@@ -158,7 +154,6 @@ describe("Connection Manager connection type inference", () => {
         it(`infers ${connectionType} from ${connectionString}`, () => {
             const actualConnectionType = ConnectionManager.inferConnectionTypeFromSettings({
                 connectionString,
-                ...config.connectOptions,
             });
 
             expect(actualConnectionType).toBe(connectionType);

--- a/tests/integration/tools/mongodb/connect/connect.test.ts
+++ b/tests/integration/tools/mongodb/connect/connect.test.ts
@@ -15,7 +15,6 @@ describeWithMongoDB(
         beforeEach(async () => {
             await integration.mcpServer().session.connectToMongoDB({
                 connectionString: integration.connectionString(),
-                ...config.connectOptions,
             });
         });
 

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -404,7 +404,10 @@ describe("config", () => {
                 defaults: {},
             });
 
-            expect(actual.connectionString).toBe(undefined);
+            // the shell specifies directConnection=true and serverSelectionTimeoutMS=2000 by default
+            expect(actual.connectionString).toBe(
+                "mongodb://localhost/?directConnection=true&serverSelectionTimeoutMS=2000"
+            );
             expect(actual.connectionSpecifier).toBe("mongodb://localhost");
         });
     });

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -360,7 +360,7 @@ describe("config", () => {
         });
     });
 
-    describe("precende rules", () => {
+    describe("precedence rules", () => {
         it("cli arguments take precedence over env vars", () => {
             const actual = setupUserConfig({
                 cli: ["myself", "--", "--connectionString", "mongodb://localhost"],

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -1,0 +1,415 @@
+import { describe, it, expect } from "vitest";
+import { setupUserConfig, UserConfig } from "../../../src/common/config.js";
+
+describe.only("config", () => {
+    describe("env var parsing", () => {
+        describe("string cases", () => {
+            const testCases = {
+                MDB_MCP_API_BASE_URL: "apiBaseUrl",
+                MDB_MCP_API_CLIENT_ID: "apiClientId",
+                MDB_MCP_API_CLIENT_SECRET: "apiClientSecret",
+                MDB_MCP_TELEMETRY: "telemetry",
+                MDB_MCP_LOG_PATH: "logPath",
+                MDB_MCP_CONNECTION_STRING: "connectionString",
+                MDB_MCP_READ_ONLY: "readOnly",
+                MDB_MCP_INDEX_CHECK: "indexCheck",
+                MDB_MCP_TRANSPORT: "transport",
+                MDB_MCP_HTTP_PORT: "httpPort",
+                MDB_MCP_HTTP_HOST: "httpHost",
+                MDB_MCP_IDLE_TIMEOUT_MS: "idleTimeoutMs",
+                MDB_MCP_NOTIFICATION_TIMEOUT_MS: "notificationTimeoutMs",
+            } as const;
+
+            for (const [envVar, config] of Object.entries(testCases)) {
+                it(`should map ${envVar} to ${config}`, () => {
+                    const randomValue = "value=" + Math.random();
+
+                    const actual = setupUserConfig({
+                        cli: [],
+                        env: {
+                            [envVar]: randomValue,
+                        },
+                        defaults: {},
+                    });
+
+                    expect(actual[config]).toBe(randomValue);
+                });
+            }
+        });
+
+        describe("array cases", () => {
+            const testCases = {
+                MDB_MCP_DISABLED_TOOLS: "disabledTools",
+                MDB_MCP_LOGGERS: "loggers",
+            } as const;
+
+            for (const [envVar, config] of Object.entries(testCases)) {
+                it(`should map ${envVar} to ${config}`, () => {
+                    const randomValue = "value=" + Math.random();
+
+                    const actual = setupUserConfig({
+                        cli: [],
+                        env: {
+                            [envVar]: randomValue,
+                        },
+                        defaults: {},
+                    });
+
+                    expect(actual[config]).toEqual([randomValue]);
+                });
+            }
+        });
+    });
+
+    describe("cli parsing", () => {
+        describe("string use cases", () => {
+            const testCases = [
+                {
+                    cli: ["--apiBaseUrl", "http://some-url.com"],
+                    expected: { apiBaseUrl: "http://some-url.com" },
+                },
+                {
+                    cli: ["--apiClientId", "OmgSoIdYeah"],
+                    expected: { apiClientId: "OmgSoIdYeah" },
+                },
+                {
+                    cli: ["--apiClientSecret", "OmgSoSecretYeah"],
+                    expected: { apiClientSecret: "OmgSoSecretYeah" },
+                },
+                {
+                    cli: ["--connectionString", "mongodb://localhost"],
+                    expected: { connectionString: "mongodb://localhost" },
+                },
+                {
+                    cli: ["--httpHost", "mongodb://localhost"],
+                    expected: { httpHost: "mongodb://localhost" },
+                },
+                {
+                    cli: ["--httpPort", "8080"],
+                    expected: { httpPort: "8080" },
+                },
+                {
+                    cli: ["--idleTimeoutMs", "42"],
+                    expected: { idleTimeoutMs: "42" },
+                },
+                {
+                    cli: ["--logPath", "/var/"],
+                    expected: { logPath: "/var/" },
+                },
+                {
+                    cli: ["--notificationTimeoutMs", "42"],
+                    expected: { notificationTimeoutMs: "42" },
+                },
+                {
+                    cli: ["--telemetry", "obviously"],
+                    expected: { telemetry: "obviously" },
+                },
+                {
+                    cli: ["--transport", "stdio"],
+                    expected: { transport: "stdio" },
+                },
+                {
+                    cli: ["--apiVersion", "1"],
+                    expected: { apiVersion: "1" },
+                },
+                {
+                    cli: ["--authenticationDatabase", "admin"],
+                    expected: { authenticationDatabase: "admin" },
+                },
+                {
+                    cli: ["--authenticationMechanism", "PLAIN"],
+                    expected: { authenticationMechanism: "PLAIN" },
+                },
+                {
+                    cli: ["--browser", "firefox"],
+                    expected: { browser: "firefox" },
+                },
+                {
+                    cli: ["--db", "test"],
+                    expected: { db: "test" },
+                },
+                {
+                    cli: ["--gssapiHostName", "localhost"],
+                    expected: { gssapiHostName: "localhost" },
+                },
+                {
+                    cli: ["--gssapiServiceName", "SERVICE"],
+                    expected: { gssapiServiceName: "SERVICE" },
+                },
+                {
+                    cli: ["--host", "localhost"],
+                    expected: { host: "localhost" },
+                },
+                {
+                    cli: ["--oidcFlows", "device"],
+                    expected: { oidcFlows: "device" },
+                },
+                {
+                    cli: ["--oidcRedirectUri", "https://oidc"],
+                    expected: { oidcRedirectUri: "https://oidc" },
+                },
+                {
+                    cli: ["--password", "123456"],
+                    expected: { password: "123456" },
+                },
+                {
+                    cli: ["--port", "27017"],
+                    expected: { port: "27017" },
+                },
+                {
+                    cli: ["--sslCAFile", "/var/file"],
+                    expected: { sslCAFile: "/var/file" },
+                },
+                {
+                    cli: ["--sslCRLFile", "/var/file"],
+                    expected: { sslCRLFile: "/var/file" },
+                },
+                {
+                    cli: ["--sslCertificateSelector", "pem=pom"],
+                    expected: { sslCertificateSelector: "pem=pom" },
+                },
+                {
+                    cli: ["--sslDisabledProtocols", "tls1"],
+                    expected: { sslDisabledProtocols: "tls1" },
+                },
+                {
+                    cli: ["--sslPEMKeyFile", "/var/pem"],
+                    expected: { sslPEMKeyFile: "/var/pem" },
+                },
+                {
+                    cli: ["--sslPEMKeyPassword", "654321"],
+                    expected: { sslPEMKeyPassword: "654321" },
+                },
+                {
+                    cli: ["--sspiHostnameCanonicalization", "true"],
+                    expected: { sspiHostnameCanonicalization: "true" },
+                },
+                {
+                    cli: ["--sspiRealmOverride", "OVER9000!"],
+                    expected: { sspiRealmOverride: "OVER9000!" },
+                },
+                {
+                    cli: ["--tlsCAFile", "/var/file"],
+                    expected: { tlsCAFile: "/var/file" },
+                },
+                {
+                    cli: ["--tlsCRLFile", "/var/file"],
+                    expected: { tlsCRLFile: "/var/file" },
+                },
+                {
+                    cli: ["--tlsCertificateKeyFile", "/var/file"],
+                    expected: { tlsCertificateKeyFile: "/var/file" },
+                },
+                {
+                    cli: ["--tlsCertificateKeyFilePassword", "4242"],
+                    expected: { tlsCertificateKeyFilePassword: "4242" },
+                },
+                {
+                    cli: ["--tlsCertificateSelector", "pom=pum"],
+                    expected: { tlsCertificateSelector: "pom=pum" },
+                },
+                {
+                    cli: ["--tlsDisabledProtocols", "tls1"],
+                    expected: { tlsDisabledProtocols: "tls1" },
+                },
+                {
+                    cli: ["--username", "admin"],
+                    expected: { username: "admin" },
+                },
+            ] as { cli: string[]; expected: Partial<UserConfig> }[];
+
+            for (const { cli, expected } of testCases) {
+                it(`should parse '${cli.join(" ")}' to ${JSON.stringify(expected)}`, () => {
+                    const actual = setupUserConfig({
+                        cli: ["myself", "--", ...cli],
+                        env: {},
+                        defaults: {},
+                    });
+
+                    for (const [key, value] of Object.entries(expected)) {
+                        expect(actual[key as keyof UserConfig]).toBe(value as unknown);
+                    }
+                });
+            }
+        });
+
+        describe("boolean use cases", () => {
+            const testCases = [
+                {
+                    cli: ["--apiDeprecationErrors"],
+                    expected: { apiDeprecationErrors: true },
+                },
+                {
+                    cli: ["--apiStrict"],
+                    expected: { apiStrict: true },
+                },
+                {
+                    cli: ["--help"],
+                    expected: { help: true },
+                },
+                {
+                    cli: ["--indexCheck"],
+                    expected: { indexCheck: true },
+                },
+                {
+                    cli: ["--ipv6"],
+                    expected: { ipv6: true },
+                },
+                {
+                    cli: ["--nodb"],
+                    expected: { nodb: true },
+                },
+                {
+                    cli: ["--oidcIdTokenAsAccessToken"],
+                    expected: { oidcIdTokenAsAccessToken: true },
+                },
+                {
+                    cli: ["--oidcNoNonce"],
+                    expected: { oidcNoNonce: true },
+                },
+                {
+                    cli: ["--oidcTrustedEndpoint"],
+                    expected: { oidcTrustedEndpoint: true },
+                },
+                {
+                    cli: ["--readOnly"],
+                    expected: { readOnly: true },
+                },
+                {
+                    cli: ["--retryWrites"],
+                    expected: { retryWrites: true },
+                },
+                {
+                    cli: ["--ssl"],
+                    expected: { ssl: true },
+                },
+                {
+                    cli: ["--sslAllowInvalidCertificates"],
+                    expected: { sslAllowInvalidCertificates: true },
+                },
+                {
+                    cli: ["--sslAllowInvalidHostnames"],
+                    expected: { sslAllowInvalidHostnames: true },
+                },
+                {
+                    cli: ["--sslFIPSMode"],
+                    expected: { sslFIPSMode: true },
+                },
+                {
+                    cli: ["--tls"],
+                    expected: { tls: true },
+                },
+                {
+                    cli: ["--tlsAllowInvalidCertificates"],
+                    expected: { tlsAllowInvalidCertificates: true },
+                },
+                {
+                    cli: ["--tlsAllowInvalidHostnames"],
+                    expected: { tlsAllowInvalidHostnames: true },
+                },
+                {
+                    cli: ["--tlsFIPSMode"],
+                    expected: { tlsFIPSMode: true },
+                },
+                {
+                    cli: ["--tlsUseSystemCA"],
+                    expected: { tlsUseSystemCA: true },
+                },
+                {
+                    cli: ["--version"],
+                    expected: { version: true },
+                },
+            ] as { cli: string[]; expected: Partial<UserConfig> }[];
+
+            for (const { cli, expected } of testCases) {
+                it(`should parse '${cli.join(" ")}' to ${JSON.stringify(expected)}`, () => {
+                    const actual = setupUserConfig({
+                        cli: ["myself", "--", ...cli],
+                        env: {},
+                        defaults: {},
+                    });
+
+                    for (const [key, value] of Object.entries(expected)) {
+                        expect(actual[key as keyof UserConfig]).toBe(value as unknown);
+                    }
+                });
+            }
+        });
+
+        describe("array use cases", () => {
+            const testCases = [
+                {
+                    cli: ["--disabledTools", "some,tool"],
+                    expected: { disabledTools: ["some", "tool"] },
+                },
+                {
+                    cli: ["--loggers", "canada,file"],
+                    expected: { loggers: ["canada", "file"] },
+                },
+            ] as { cli: string[]; expected: Partial<UserConfig> }[];
+
+            for (const { cli, expected } of testCases) {
+                it(`should parse '${cli.join(" ")}' to ${JSON.stringify(expected)}`, () => {
+                    const actual = setupUserConfig({
+                        cli: ["myself", "--", ...cli],
+                        env: {},
+                        defaults: {},
+                    });
+
+                    for (const [key, value] of Object.entries(expected)) {
+                        expect(actual[key as keyof UserConfig]).toEqual(value as unknown);
+                    }
+                });
+            }
+        });
+    });
+
+    describe("precende rules", () => {
+        it("cli arguments take precedence over env vars", () => {
+            const actual = setupUserConfig({
+                cli: ["myself", "--", "--connectionString", "mongodb://localhost"],
+                env: { MDB_MCP_CONNECTION_STRING: "mongodb://crazyhost" },
+                defaults: {},
+            });
+
+            expect(actual.connectionString).toBe("mongodb://localhost");
+        });
+
+        it("any cli argument takes precedence over defaults", () => {
+            const actual = setupUserConfig({
+                cli: ["myself", "--", "--connectionString", "mongodb://localhost"],
+                env: {},
+                defaults: {
+                    connectionString: "mongodb://crazyhost",
+                },
+            });
+
+            expect(actual.connectionString).toBe("mongodb://localhost");
+        });
+
+        it("any env var takes precedence over defaults", () => {
+            const actual = setupUserConfig({
+                cli: [],
+                env: { MDB_MCP_CONNECTION_STRING: "mongodb://localhost" },
+                defaults: {
+                    connectionString: "mongodb://crazyhost",
+                },
+            });
+
+            expect(actual.connectionString).toBe("mongodb://localhost");
+        });
+    });
+
+    describe("consolidation", () => {
+        it("positional argument for url has precedence over --connectionString", () => {
+            const actual = setupUserConfig({
+                cli: ["myself", "--", "mongodb://localhost", "--connectionString", "toRemove"],
+                env: {},
+                defaults: {},
+            });
+
+            expect(actual.connectionString).toBe(undefined);
+            expect(actual.connectionSpecifier).toBe("mongodb://localhost");
+        });
+    });
+});

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { setupUserConfig, UserConfig, defaultUserConfig } from "../../../src/common/config.js";
-import assert from "assert";
 
 describe("config", () => {
     describe("env var parsing", () => {

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { setupUserConfig, UserConfig } from "../../../src/common/config.js";
 
-describe.only("config", () => {
+describe("config", () => {
     describe("env var parsing", () => {
         describe("string cases", () => {
             const testCases = {
@@ -227,7 +227,7 @@ describe.only("config", () => {
                     });
 
                     for (const [key, value] of Object.entries(expected)) {
-                        expect(actual[key as keyof UserConfig]).toBe(value as unknown);
+                        expect(actual[key as keyof UserConfig]).toBe(value);
                     }
                 });
             }
@@ -312,10 +312,6 @@ describe.only("config", () => {
                     expected: { tlsFIPSMode: true },
                 },
                 {
-                    cli: ["--tlsUseSystemCA"],
-                    expected: { tlsUseSystemCA: true },
-                },
-                {
                     cli: ["--version"],
                     expected: { version: true },
                 },
@@ -330,7 +326,7 @@ describe.only("config", () => {
                     });
 
                     for (const [key, value] of Object.entries(expected)) {
-                        expect(actual[key as keyof UserConfig]).toBe(value as unknown);
+                        expect(actual[key as keyof UserConfig]).toBe(value);
                     }
                 });
             }
@@ -357,7 +353,7 @@ describe.only("config", () => {
                     });
 
                     for (const [key, value] of Object.entries(expected)) {
-                        expect(actual[key as keyof UserConfig]).toEqual(value as unknown);
+                        expect(actual[key as keyof UserConfig]).toEqual(value);
                     }
                 });
             }

--- a/tests/unit/common/session.test.ts
+++ b/tests/unit/common/session.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import { Session } from "../../../src/common/session.js";
+import { config } from "../../../src/common/config.js";
 import { CompositeLogger } from "../../../src/common/logger.js";
 import { ConnectionManager } from "../../../src/common/connectionManager.js";
 import { ExportsManager } from "../../../src/common/exportsManager.js";

--- a/tests/unit/common/session.test.ts
+++ b/tests/unit/common/session.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import { Session } from "../../../src/common/session.js";
-import { config } from "../../../src/common/config.js";
 import { CompositeLogger } from "../../../src/common/logger.js";
 import { ConnectionManager } from "../../../src/common/connectionManager.js";
 import { ExportsManager } from "../../../src/common/exportsManager.js";
@@ -52,7 +51,6 @@ describe("Session", () => {
             it(`should update connection string for ${testCase.name}`, async () => {
                 await session.connectToMongoDB({
                     connectionString: testCase.connectionString,
-                    ...config.connectOptions,
                 });
                 expect(session.serviceProvider).toBeDefined();
 
@@ -68,7 +66,7 @@ describe("Session", () => {
         }
 
         it("should configure the proxy to use environment variables", async () => {
-            await session.connectToMongoDB({ connectionString: "mongodb://localhost", ...config.connectOptions });
+            await session.connectToMongoDB({ connectionString: "mongodb://localhost" });
             expect(session.serviceProvider).toBeDefined();
 
             const connectMock = MockNodeDriverServiceProvider.connect;


### PR DESCRIPTION
## Proposed changes

Use mongosh argument parser to generate the connection string that is going to be used to connect to MongoDB, aligning with how mongosh does it and making sure we support additional authentication mechanisms. It removes a bunch of flags and types not necessary now with the consolidation.

There will be integration tests for each of the supported connection types when playing each of their tasks. Specific support is out of the scope of this PR.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
