### PR TITLE
fix: fix expectations for export accuracy tests

### DIFF
--- a/tests/accuracy/export.test.ts
+++ b/tests/accuracy/export.test.ts
@@ -8,6 +8,7 @@ describeAccuracyTests([
             {
                 toolName: "export",
                 parameters: {
+                    exportTitle: Matcher.string(),
                     database: "mflix",
                     collection: "movies",
                     filter: Matcher.emptyObjectOrUndefined,
@@ -22,6 +23,7 @@ describeAccuracyTests([
             {
                 toolName: "export",
                 parameters: {
+                    exportTitle: Matcher.string(),
                     database: "mflix",
                     collection: "movies",
                     filter: {
@@ -37,6 +39,7 @@ describeAccuracyTests([
             {
                 toolName: "export",
                 parameters: {
+                    exportTitle: Matcher.string(),
                     database: "mflix",
                     collection: "movies",
                     projection: {
@@ -57,6 +60,7 @@ describeAccuracyTests([
             {
                 toolName: "export",
                 parameters: {
+                    exportTitle: Matcher.string(),
                     database: "mflix",
                     collection: "movies",
                     filter: { genres: "Horror" },


### PR DESCRIPTION
## Proposed changes

Looks like we had some tests failing because the model was providing the export title but we weren't expecting it.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
