### PR TITLE
chore: enable eslint rule for consistent type import/export MCP-130

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,6 +48,13 @@ export default defineConfig([
         rules: {
             "@typescript-eslint/switch-exhaustiveness-check": "error",
             "@typescript-eslint/no-non-null-assertion": "error",
+            "@typescript-eslint/consistent-type-imports": ["error", { prefer: "type-imports" }],
+            "@typescript-eslint/consistent-type-exports": [
+                "error",
+                {
+                    fixMixedExportsWithInlineTypeSpecifier: false,
+                },
+            ],
             eqeqeq: "error",
             "no-self-compare": "error",
             "no-unassigned-vars": "error",

--- a/scripts/accuracy/generateTestSummary.ts
+++ b/scripts/accuracy/generateTestSummary.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { readFile, writeFile, mkdir } from "fs/promises";
 import { getAccuracyResultStorage } from "../../tests/accuracy/sdk/accuracyResultStorage/getAccuracyResultStorage.js";
-import {
+import type {
     AccuracyResult,
     AccuracyRunStatuses,
     ExpectedToolCall,

--- a/scripts/apply.ts
+++ b/scripts/apply.ts
@@ -1,5 +1,5 @@
 import fs from "fs/promises";
-import { OpenAPIV3_1 } from "openapi-types";
+import type { OpenAPIV3_1 } from "openapi-types";
 import argv from "yargs-parser";
 
 function findObjectFromRef<T>(obj: T | OpenAPIV3_1.ReferenceObject, openapi: OpenAPIV3_1.Document): T {

--- a/scripts/filter.ts
+++ b/scripts/filter.ts
@@ -1,4 +1,4 @@
-import { OpenAPIV3_1 } from "openapi-types";
+import type { OpenAPIV3_1 } from "openapi-types";
 
 async function readStdin(): Promise<string> {
     return new Promise<string>((resolve, reject) => {

--- a/src/common/atlas/accessListUtils.ts
+++ b/src/common/atlas/accessListUtils.ts
@@ -1,4 +1,4 @@
-import { ApiClient } from "./apiClient.js";
+import type { ApiClient } from "./apiClient.js";
 import { LogId } from "../logger.js";
 import { ApiClientError } from "./apiClientError.js";
 

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -1,10 +1,11 @@
-import createClient, { Client, Middleware } from "openapi-fetch";
-import type { ClientOptions, FetchOptions } from "openapi-fetch";
+import createClient from "openapi-fetch";
+import type { ClientOptions, FetchOptions, Client, Middleware } from "openapi-fetch";
 import { ApiClientError } from "./apiClientError.js";
-import { paths, operations } from "./openapi.js";
-import { CommonProperties, TelemetryEvent } from "../../telemetry/types.js";
+import type { paths, operations } from "./openapi.js";
+import type { CommonProperties, TelemetryEvent } from "../../telemetry/types.js";
 import { packageInfo } from "../packageInfo.js";
-import { LoggerBase, LogId } from "../logger.js";
+import type { LoggerBase } from "../logger.js";
+import { LogId } from "../logger.js";
 import { createFetch } from "@mongodb-js/devtools-proxy-support";
 import * as oauth from "oauth4webapi";
 import { Request as NodeFetchRequest } from "node-fetch";

--- a/src/common/atlas/apiClientError.ts
+++ b/src/common/atlas/apiClientError.ts
@@ -1,4 +1,4 @@
-import { ApiError } from "./openapi.js";
+import type { ApiError } from "./openapi.js";
 
 export class ApiClientError extends Error {
     private constructor(

--- a/src/common/atlas/cluster.ts
+++ b/src/common/atlas/cluster.ts
@@ -1,5 +1,5 @@
-import { ClusterDescription20240805, FlexClusterDescription20241113 } from "./openapi.js";
-import { ApiClient } from "./apiClient.js";
+import type { ClusterDescription20240805, FlexClusterDescription20241113 } from "./openapi.js";
+import type { ApiClient } from "./apiClient.js";
 import { LogId } from "../logger.js";
 
 export interface Cluster {

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -1,15 +1,17 @@
-import { UserConfig, DriverOptions } from "./config.js";
+import type { UserConfig, DriverOptions } from "./config.js";
 import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import EventEmitter from "events";
 import { setAppNameParamIfMissing } from "../helpers/connectionOptions.js";
 import { packageInfo } from "./packageInfo.js";
 import ConnectionString from "mongodb-connection-string-url";
-import { MongoClientOptions } from "mongodb";
+import type { MongoClientOptions } from "mongodb";
 import { ErrorCodes, MongoDBError } from "./errors.js";
-import { DeviceId } from "../helpers/deviceId.js";
-import { AppNameComponents } from "../helpers/connectionOptions.js";
-import { CompositeLogger, LogId } from "./logger.js";
-import { ConnectionInfo, generateConnectionInfoFromCliArgs } from "@mongosh/arg-parser";
+import type { DeviceId } from "../helpers/deviceId.js";
+import type { AppNameComponents } from "../helpers/connectionOptions.js";
+import type { CompositeLogger } from "./logger.js";
+import { LogId } from "./logger.js";
+import type { ConnectionInfo } from "@mongosh/arg-parser";
+import { generateConnectionInfoFromCliArgs } from "@mongosh/arg-parser";
 
 export interface AtlasClusterConnectionInfo {
     username: string;

--- a/src/common/exportsManager.ts
+++ b/src/common/exportsManager.ts
@@ -3,14 +3,16 @@ import path from "path";
 import fs from "fs/promises";
 import EventEmitter from "events";
 import { createWriteStream } from "fs";
-import { AggregationCursor, FindCursor } from "mongodb";
-import { EJSON, EJSONOptions, ObjectId } from "bson";
+import type { AggregationCursor, FindCursor } from "mongodb";
+import type { EJSONOptions } from "bson";
+import { EJSON, ObjectId } from "bson";
 import { Transform } from "stream";
 import { pipeline } from "stream/promises";
-import { MongoLogId } from "mongodb-log-writer";
+import type { MongoLogId } from "mongodb-log-writer";
 
-import { UserConfig } from "./config.js";
-import { LoggerBase, LogId } from "./logger.js";
+import type { UserConfig } from "./config.js";
+import type { LoggerBase } from "./logger.js";
+import { LogId } from "./logger.js";
 
 export const jsonExportFormat = z.enum(["relaxed", "canonical"]);
 export type JSONExportFormat = z.infer<typeof jsonExportFormat>;

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,8 +1,9 @@
 import fs from "fs/promises";
-import { mongoLogId, MongoLogId, MongoLogManager, MongoLogWriter } from "mongodb-log-writer";
+import type { MongoLogId, MongoLogWriter } from "mongodb-log-writer";
+import { mongoLogId, MongoLogManager } from "mongodb-log-writer";
 import redact from "mongodb-redact";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { LoggingMessageNotification } from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { LoggingMessageNotification } from "@modelcontextprotocol/sdk/types.js";
 import { EventEmitter } from "events";
 
 export type LogLevel = LoggingMessageNotification["params"]["level"];

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -1,17 +1,19 @@
 import { ObjectId } from "bson";
-import { ApiClient, ApiClientCredentials } from "./atlas/apiClient.js";
-import { Implementation } from "@modelcontextprotocol/sdk/types.js";
-import { CompositeLogger, LogId } from "./logger.js";
+import type { ApiClientCredentials } from "./atlas/apiClient.js";
+import { ApiClient } from "./atlas/apiClient.js";
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
+import type { CompositeLogger } from "./logger.js";
+import { LogId } from "./logger.js";
 import EventEmitter from "events";
-import {
+import type {
     AtlasClusterConnectionInfo,
     ConnectionManager,
     ConnectionSettings,
     ConnectionStateConnected,
 } from "./connectionManager.js";
-import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import { ErrorCodes, MongoDBError } from "./errors.js";
-import { ExportsManager } from "./exportsManager.js";
+import type { ExportsManager } from "./exportsManager.js";
 
 export interface SessionOptions {
     apiBaseUrl: string;

--- a/src/common/sessionStore.ts
+++ b/src/common/sessionStore.ts
@@ -1,6 +1,8 @@
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { LogId, LoggerBase } from "./logger.js";
-import { ManagedTimeout, setManagedTimeout } from "./managedTimeout.js";
+import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { LoggerBase } from "./logger.js";
+import { LogId } from "./logger.js";
+import type { ManagedTimeout } from "./managedTimeout.js";
+import { setManagedTimeout } from "./managedTimeout.js";
 
 export class SessionStore {
     private sessions: {

--- a/src/helpers/connectionOptions.ts
+++ b/src/helpers/connectionOptions.ts
@@ -1,4 +1,4 @@
-import { MongoClientOptions } from "mongodb";
+import type { MongoClientOptions } from "mongodb";
 import ConnectionString from "mongodb-connection-string-url";
 
 export interface AppNameComponents {

--- a/src/helpers/deviceId.ts
+++ b/src/helpers/deviceId.ts
@@ -1,6 +1,7 @@
 import { getDeviceId } from "@mongodb-js/device-id";
 import nodeMachineId from "node-machine-id";
-import { LogId, LoggerBase } from "../common/logger.js";
+import type { LoggerBase } from "../common/logger.js";
+import { LogId } from "../common/logger.js";
 
 export const DEVICE_ID_TIMEOUT = 3000;
 

--- a/src/helpers/indexCheck.ts
+++ b/src/helpers/indexCheck.ts
@@ -1,5 +1,5 @@
-import { Document } from "mongodb";
-import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import type { Document } from "mongodb";
+import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import { ErrorCodes, MongoDBError } from "../common/errors.js";
 
 /**

--- a/src/resources/common/debug.ts
+++ b/src/resources/common/debug.ts
@@ -1,6 +1,6 @@
 import { ReactiveResource } from "../resource.js";
 import type { Telemetry } from "../../telemetry/telemetry.js";
-import { Session, UserConfig } from "../../lib.js";
+import type { Session, UserConfig } from "../../lib.js";
 
 type ConnectionStateDebuggingInformation = {
     readonly tag: "connected" | "connecting" | "disconnected" | "errored";

--- a/src/resources/common/exportedData.ts
+++ b/src/resources/common/exportedData.ts
@@ -1,12 +1,12 @@
-import {
+import type {
     CompleteResourceTemplateCallback,
     ListResourcesCallback,
     ReadResourceTemplateCallback,
-    ResourceTemplate,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { Server } from "../../server.js";
+import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Server } from "../../server.js";
 import { LogId } from "../../common/logger.js";
-import { Session } from "../../common/session.js";
+import type { Session } from "../../common/session.js";
 
 export class ExportedData {
     private readonly name = "exported-data";

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -1,9 +1,9 @@
-import { Server } from "../server.js";
-import { Session } from "../common/session.js";
-import { UserConfig } from "../common/config.js";
-import { Telemetry } from "../telemetry/telemetry.js";
+import type { Server } from "../server.js";
+import type { Session } from "../common/session.js";
+import type { UserConfig } from "../common/config.js";
+import type { Telemetry } from "../telemetry/telemetry.js";
 import type { SessionEvents } from "../common/session.js";
-import { ReadResourceCallback, ResourceMetadata } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ReadResourceCallback, ResourceMetadata } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { LogId } from "../common/logger.js";
 
 type PayloadOf<K extends keyof SessionEvents> = SessionEvents[K][0];

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,22 +1,22 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { Session } from "./common/session.js";
-import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Session } from "./common/session.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { AtlasTools } from "./tools/atlas/tools.js";
 import { MongoDbTools } from "./tools/mongodb/tools.js";
 import { Resources } from "./resources/resources.js";
 import { LogId } from "./common/logger.js";
-import { Telemetry } from "./telemetry/telemetry.js";
-import { UserConfig } from "./common/config.js";
+import type { Telemetry } from "./telemetry/telemetry.js";
+import type { UserConfig } from "./common/config.js";
 import { type ServerEvent } from "./telemetry/types.js";
 import { type ServerCommand } from "./telemetry/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
     CallToolRequestSchema,
-    CallToolResult,
     SubscribeRequestSchema,
     UnsubscribeRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
-import { ToolBase } from "./tools/tool.js";
+import type { ToolBase } from "./tools/tool.js";
 import { validateConnectionString } from "./helpers/connectionOptions.js";
 
 export interface ServerOptions {

--- a/src/telemetry/eventCache.ts
+++ b/src/telemetry/eventCache.ts
@@ -1,5 +1,5 @@
 import { LRUCache } from "lru-cache";
-import { BaseEvent } from "./types.js";
+import type { BaseEvent } from "./types.js";
 
 /**
  * Singleton class for in-memory telemetry event caching

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,12 +1,12 @@
-import { Session } from "../common/session.js";
-import { BaseEvent, CommonProperties } from "./types.js";
-import { UserConfig } from "../common/config.js";
+import type { Session } from "../common/session.js";
+import type { BaseEvent, CommonProperties } from "./types.js";
+import type { UserConfig } from "../common/config.js";
 import { LogId } from "../common/logger.js";
-import { ApiClient } from "../common/atlas/apiClient.js";
+import type { ApiClient } from "../common/atlas/apiClient.js";
 import { MACHINE_METADATA } from "./constants.js";
 import { EventCache } from "./eventCache.js";
 import { detectContainerEnv } from "../helpers/container.js";
-import { DeviceId } from "../helpers/deviceId.js";
+import type { DeviceId } from "../helpers/deviceId.js";
 
 type EventResult = {
     success: boolean;

--- a/src/tools/atlas/atlasTool.ts
+++ b/src/tools/atlas/atlasTool.ts
@@ -1,6 +1,7 @@
-import { ToolBase, ToolCategory, TelemetryToolMetadata, ToolArgs } from "../tool.js";
-import { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ToolCategory, TelemetryToolMetadata, ToolArgs } from "../tool.js";
+import { ToolBase } from "../tool.js";
+import type { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { LogId } from "../../common/logger.js";
 import { z } from "zod";
 import { ApiClientError } from "../../common/atlas/apiClientError.js";

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import { generateSecurePassword } from "../../../helpers/generatePassword.js";
 import { LogId } from "../../../common/logger.js";
 import { inspectCluster } from "../../../common/atlas/cluster.js";
 import { ensureCurrentIpInAccessList } from "../../../common/atlas/accessListUtils.js";
-import { AtlasClusterConnectionInfo } from "../../../common/connectionManager.js";
+import type { AtlasClusterConnectionInfo } from "../../../common/connectionManager.js";
 
 const EXPIRY_MS = 1000 * 60 * 60 * 12; // 12 hours
 

--- a/src/tools/atlas/create/createAccessList.ts
+++ b/src/tools/atlas/create/createAccessList.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import { makeCurrentIpAccessListEntry, DEFAULT_ACCESS_LIST_COMMENT } from "../../../common/atlas/accessListUtils.js";
 
 export class CreateAccessListTool extends AtlasToolBase {

--- a/src/tools/atlas/create/createDBUser.ts
+++ b/src/tools/atlas/create/createDBUser.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
-import { CloudDatabaseUser, DatabaseUserRole } from "../../../common/atlas/openapi.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
+import type { CloudDatabaseUser, DatabaseUserRole } from "../../../common/atlas/openapi.js";
 import { generateSecurePassword } from "../../../helpers/generatePassword.js";
 import { ensureCurrentIpInAccessList } from "../../../common/atlas/accessListUtils.js";
 

--- a/src/tools/atlas/create/createFreeCluster.ts
+++ b/src/tools/atlas/create/createFreeCluster.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
-import { ClusterDescription20240805 } from "../../../common/atlas/openapi.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
+import type { ClusterDescription20240805 } from "../../../common/atlas/openapi.js";
 import { ensureCurrentIpInAccessList } from "../../../common/atlas/accessListUtils.js";
 
 export class CreateFreeClusterTool extends AtlasToolBase {

--- a/src/tools/atlas/create/createProject.ts
+++ b/src/tools/atlas/create/createProject.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
-import { Group } from "../../../common/atlas/openapi.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
+import type { Group } from "../../../common/atlas/openapi.js";
 
 export class CreateProjectTool extends AtlasToolBase {
     public name = "atlas-create-project";

--- a/src/tools/atlas/read/inspectAccessList.ts
+++ b/src/tools/atlas/read/inspectAccessList.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 
 export class InspectAccessListTool extends AtlasToolBase {
     public name = "atlas-inspect-access-list";

--- a/src/tools/atlas/read/inspectCluster.ts
+++ b/src/tools/atlas/read/inspectCluster.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
-import { Cluster, inspectCluster } from "../../../common/atlas/cluster.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
+import type { Cluster } from "../../../common/atlas/cluster.js";
+import { inspectCluster } from "../../../common/atlas/cluster.js";
 
 export class InspectClusterTool extends AtlasToolBase {
     public name = "atlas-inspect-cluster";

--- a/src/tools/atlas/read/listAlerts.ts
+++ b/src/tools/atlas/read/listAlerts.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 
 export class ListAlertsTool extends AtlasToolBase {
     public name = "atlas-list-alerts";

--- a/src/tools/atlas/read/listClusters.ts
+++ b/src/tools/atlas/read/listClusters.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
-import {
+import type { ToolArgs, OperationType } from "../../tool.js";
+import type {
     PaginatedClusterDescription20240805,
     PaginatedOrgGroupView,
     Group,

--- a/src/tools/atlas/read/listDBUsers.ts
+++ b/src/tools/atlas/read/listDBUsers.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
-import { DatabaseUserRole, UserScope } from "../../../common/atlas/openapi.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
+import type { DatabaseUserRole, UserScope } from "../../../common/atlas/openapi.js";
 
 export class ListDBUsersTool extends AtlasToolBase {
     public name = "atlas-list-db-users";

--- a/src/tools/atlas/read/listOrgs.ts
+++ b/src/tools/atlas/read/listOrgs.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { OperationType } from "../../tool.js";
+import type { OperationType } from "../../tool.js";
 
 export class ListOrganizationsTool extends AtlasToolBase {
     public name = "atlas-list-orgs";

--- a/src/tools/atlas/read/listProjects.ts
+++ b/src/tools/atlas/read/listProjects.ts
@@ -1,8 +1,8 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
-import { OperationType } from "../../tool.js";
+import type { OperationType } from "../../tool.js";
 import { z } from "zod";
-import { ToolArgs } from "../../tool.js";
+import type { ToolArgs } from "../../tool.js";
 
 export class ListProjectsTool extends AtlasToolBase {
     public name = "atlas-list-projects";

--- a/src/tools/mongodb/connect/connect.ts
+++ b/src/tools/mongodb/connect/connect.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import assert from "assert";
-import { UserConfig } from "../../../common/config.js";
-import { Telemetry } from "../../../telemetry/telemetry.js";
-import { Session } from "../../../common/session.js";
-import { Server } from "../../../server.js";
+import type { UserConfig } from "../../../common/config.js";
+import type { Telemetry } from "../../../telemetry/telemetry.js";
+import type { Session } from "../../../common/session.js";
+import type { Server } from "../../../server.js";
 
 const disconnectedSchema = z
     .object({

--- a/src/tools/mongodb/create/createCollection.ts
+++ b/src/tools/mongodb/create/createCollection.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { OperationType, ToolArgs } from "../../tool.js";
+import type { OperationType, ToolArgs } from "../../tool.js";
 
 export class CreateCollectionTool extends MongoDBToolBase {
     public name = "create-collection";

--- a/src/tools/mongodb/create/createIndex.ts
+++ b/src/tools/mongodb/create/createIndex.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
-import { IndexDirection } from "mongodb";
+import type { ToolArgs, OperationType } from "../../tool.js";
+import type { IndexDirection } from "mongodb";
 
 export class CreateIndexTool extends MongoDBToolBase {
     public name = "create-index";

--- a/src/tools/mongodb/create/insertMany.ts
+++ b/src/tools/mongodb/create/insertMany.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 
 export class InsertManyTool extends MongoDBToolBase {
     public name = "insert-many";

--- a/src/tools/mongodb/delete/deleteMany.ts
+++ b/src/tools/mongodb/delete/deleteMany.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import { checkIndexUsage } from "../../../helpers/indexCheck.js";
 
 export class DeleteManyTool extends MongoDBToolBase {

--- a/src/tools/mongodb/delete/dropCollection.ts
+++ b/src/tools/mongodb/delete/dropCollection.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 
 export class DropCollectionTool extends MongoDBToolBase {
     public name = "drop-collection";

--- a/src/tools/mongodb/delete/dropDatabase.ts
+++ b/src/tools/mongodb/delete/dropDatabase.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 
 export class DropDatabaseTool extends MongoDBToolBase {
     public name = "drop-database";

--- a/src/tools/mongodb/metadata/collectionSchema.ts
+++ b/src/tools/mongodb/metadata/collectionSchema.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import { getSimplifiedSchema } from "mongodb-schema";
 
 export class CollectionSchemaTool extends MongoDBToolBase {

--- a/src/tools/mongodb/metadata/collectionStorageSize.ts
+++ b/src/tools/mongodb/metadata/collectionStorageSize.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 
 export class CollectionStorageSizeTool extends MongoDBToolBase {
     public name = "collection-storage-size";

--- a/src/tools/mongodb/metadata/dbStats.ts
+++ b/src/tools/mongodb/metadata/dbStats.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import { EJSON } from "bson";
 
 export class DbStatsTool extends MongoDBToolBase {

--- a/src/tools/mongodb/metadata/explain.ts
+++ b/src/tools/mongodb/metadata/explain.ts
@@ -1,8 +1,9 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import { z } from "zod";
-import { ExplainVerbosity, Document } from "mongodb";
+import type { Document } from "mongodb";
+import { ExplainVerbosity } from "mongodb";
 import { AggregateArgs } from "../read/aggregate.js";
 import { FindArgs } from "../read/find.js";
 import { CountArgs } from "../read/count.js";

--- a/src/tools/mongodb/metadata/listCollections.ts
+++ b/src/tools/mongodb/metadata/listCollections.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 
 export class ListCollectionsTool extends MongoDBToolBase {
     public name = "list-collections";

--- a/src/tools/mongodb/metadata/listDatabases.ts
+++ b/src/tools/mongodb/metadata/listDatabases.ts
@@ -1,7 +1,7 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { MongoDBToolBase } from "../mongodbTool.js";
-import * as bson from "bson";
-import { OperationType } from "../../tool.js";
+import type * as bson from "bson";
+import type { OperationType } from "../../tool.js";
 
 export class ListDatabasesTool extends MongoDBToolBase {
     public name = "list-databases";

--- a/src/tools/mongodb/metadata/logs.ts
+++ b/src/tools/mongodb/metadata/logs.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import { z } from "zod";
 
 export class LogsTool extends MongoDBToolBase {

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
-import { ToolArgs, ToolBase, ToolCategory, TelemetryToolMetadata } from "../tool.js";
-import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ToolArgs, ToolCategory, TelemetryToolMetadata } from "../tool.js";
+import { ToolBase } from "../tool.js";
+import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ErrorCodes, MongoDBError } from "../../common/errors.js";
 import { LogId } from "../../common/logger.js";
-import { Server } from "../../server.js";
+import type { Server } from "../../server.js";
 import { EJSON } from "bson";
 
 export const DbOperationArgs = {

--- a/src/tools/mongodb/read/aggregate.ts
+++ b/src/tools/mongodb/read/aggregate.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, formatUntrustedData, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import { checkIndexUsage } from "../../../helpers/indexCheck.js";
 
 export const AggregateArgs = {

--- a/src/tools/mongodb/read/collectionIndexes.ts
+++ b/src/tools/mongodb/read/collectionIndexes.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 
 export class CollectionIndexesTool extends MongoDBToolBase {
     public name = "collection-indexes";

--- a/src/tools/mongodb/read/count.ts
+++ b/src/tools/mongodb/read/count.ts
@@ -1,6 +1,6 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import { z } from "zod";
 import { checkIndexUsage } from "../../../helpers/indexCheck.js";
 

--- a/src/tools/mongodb/read/export.ts
+++ b/src/tools/mongodb/read/export.ts
@@ -1,8 +1,8 @@
 import z from "zod";
 import { ObjectId } from "bson";
-import { AggregationCursor, FindCursor } from "mongodb";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { OperationType, ToolArgs } from "../../tool.js";
+import type { AggregationCursor, FindCursor } from "mongodb";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { OperationType, ToolArgs } from "../../tool.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import { FindArgs } from "./find.js";
 import { jsonExportFormat } from "../../../common/exportsManager.js";

--- a/src/tools/mongodb/read/find.ts
+++ b/src/tools/mongodb/read/find.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, formatUntrustedData, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
-import { SortDirection } from "mongodb";
+import type { ToolArgs, OperationType } from "../../tool.js";
+import type { SortDirection } from "mongodb";
 import { checkIndexUsage } from "../../../helpers/indexCheck.js";
 
 export const FindArgs = {

--- a/src/tools/mongodb/update/renameCollection.ts
+++ b/src/tools/mongodb/update/renameCollection.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 
 export class RenameCollectionTool extends MongoDBToolBase {
     public name = "rename-collection";

--- a/src/tools/mongodb/update/updateMany.ts
+++ b/src/tools/mongodb/update/updateMany.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
-import { ToolArgs, OperationType } from "../../tool.js";
+import type { ToolArgs, OperationType } from "../../tool.js";
 import { checkIndexUsage } from "../../../helpers/indexCheck.js";
 
 export class UpdateManyTool extends MongoDBToolBase {

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,12 +1,13 @@
-import { z, type ZodRawShape, type ZodNever, AnyZodObject } from "zod";
+import type { z, AnyZodObject } from "zod";
+import { type ZodRawShape, type ZodNever } from "zod";
 import type { RegisteredTool, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult, ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
-import { Session } from "../common/session.js";
+import type { Session } from "../common/session.js";
 import { LogId } from "../common/logger.js";
-import { Telemetry } from "../telemetry/telemetry.js";
+import type { Telemetry } from "../telemetry/telemetry.js";
 import { type ToolEvent } from "../telemetry/types.js";
-import { UserConfig } from "../common/config.js";
-import { Server } from "../server.js";
+import type { UserConfig } from "../common/config.js";
+import type { Server } from "../server.js";
 
 export type ToolArgs<Args extends ZodRawShape> = z.objectOutputType<Args, ZodNever>;
 

--- a/src/transports/base.ts
+++ b/src/transports/base.ts
@@ -1,10 +1,12 @@
-import { driverOptions, UserConfig } from "../common/config.js";
+import type { UserConfig } from "../common/config.js";
+import { driverOptions } from "../common/config.js";
 import { packageInfo } from "../common/packageInfo.js";
 import { Server } from "../server.js";
 import { Session } from "../common/session.js";
 import { Telemetry } from "../telemetry/telemetry.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { CompositeLogger, ConsoleLogger, DiskLogger, LoggerBase, McpLogger } from "../common/logger.js";
+import type { LoggerBase } from "../common/logger.js";
+import { CompositeLogger, ConsoleLogger, DiskLogger, McpLogger } from "../common/logger.js";
 import { ExportsManager } from "../common/exportsManager.js";
 import { ConnectionManager } from "../common/connectionManager.js";
 import { DeviceId } from "../helpers/deviceId.js";

--- a/src/transports/stdio.ts
+++ b/src/transports/stdio.ts
@@ -1,10 +1,11 @@
 import { LogId } from "../common/logger.js";
-import { Server } from "../server.js";
+import type { Server } from "../server.js";
 import { TransportRunnerBase } from "./base.js";
-import { JSONRPCMessage, JSONRPCMessageSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { JSONRPCMessageSchema } from "@modelcontextprotocol/sdk/types.js";
 import { EJSON } from "bson";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { UserConfig } from "../common/config.js";
+import type { UserConfig } from "../common/config.js";
 
 // This is almost a copy of ReadBuffer from @modelcontextprotocol/sdk
 // but it uses EJSON.parse instead of JSON.parse to handle BSON types

--- a/src/transports/streamableHttp.ts
+++ b/src/transports/streamableHttp.ts
@@ -1,9 +1,9 @@
 import express from "express";
-import http from "http";
+import type http from "http";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { TransportRunnerBase } from "./base.js";
-import { UserConfig } from "../common/config.js";
+import type { UserConfig } from "../common/config.js";
 import { LogId } from "../common/logger.js";
 import { randomUUID } from "crypto";
 import { SessionStore } from "../common/sessionStore.js";

--- a/tests/accuracy/sdk/accuracyResultStorage/diskStorage.ts
+++ b/tests/accuracy/sdk/accuracyResultStorage/diskStorage.ts
@@ -2,14 +2,14 @@ import path from "path";
 import fs from "fs/promises";
 import { lock } from "proper-lockfile";
 import { ACCURACY_RESULTS_DIR, LATEST_ACCURACY_RUN_NAME } from "../constants.js";
-import {
+import type {
     AccuracyResult,
     AccuracyResultStorage,
-    AccuracyRunStatus,
     AccuracyRunStatuses,
     ExpectedToolCall,
     ModelResponse,
 } from "./resultStorage.js";
+import { AccuracyRunStatus } from "./resultStorage.js";
 
 export class DiskBasedResultStorage implements AccuracyResultStorage {
     async getAccuracyResult(commitSHA: string, runId?: string): Promise<AccuracyResult | null> {

--- a/tests/accuracy/sdk/accuracyResultStorage/getAccuracyResultStorage.ts
+++ b/tests/accuracy/sdk/accuracyResultStorage/getAccuracyResultStorage.ts
@@ -1,6 +1,6 @@
 import { DiskBasedResultStorage } from "./diskStorage.js";
 import { MongoDBBasedResultStorage } from "./mongodbStorage.js";
-import { AccuracyResultStorage } from "./resultStorage.js";
+import type { AccuracyResultStorage } from "./resultStorage.js";
 
 export function getAccuracyResultStorage(): AccuracyResultStorage {
     const { MDB_ACCURACY_MDB_URL, MDB_ACCURACY_MDB_DB, MDB_ACCURACY_MDB_COLLECTION } = process.env;

--- a/tests/accuracy/sdk/accuracyResultStorage/mongodbStorage.ts
+++ b/tests/accuracy/sdk/accuracyResultStorage/mongodbStorage.ts
@@ -1,12 +1,13 @@
-import { Collection, MongoClient } from "mongodb";
-import {
+import type { Collection } from "mongodb";
+import { MongoClient } from "mongodb";
+import type {
     AccuracyResult,
     AccuracyResultStorage,
-    AccuracyRunStatus,
     AccuracyRunStatuses,
     ExpectedToolCall,
     ModelResponse,
 } from "./resultStorage.js";
+import { AccuracyRunStatus } from "./resultStorage.js";
 
 // We could decide to omit some fields from the model response to reduce the size of the stored results. Since
 // so far, the responses are not too big, we do not omit any fields, but if we decide to do so in the future,

--- a/tests/accuracy/sdk/accuracyScorer.ts
+++ b/tests/accuracy/sdk/accuracyScorer.ts
@@ -1,4 +1,4 @@
-import { ExpectedToolCall, LLMToolCall } from "./accuracyResultStorage/resultStorage.js";
+import type { ExpectedToolCall, LLMToolCall } from "./accuracyResultStorage/resultStorage.js";
 import { Matcher } from "./matcher.js";
 
 /**

--- a/tests/accuracy/sdk/accuracyTestingClient.ts
+++ b/tests/accuracy/sdk/accuracyTestingClient.ts
@@ -1,11 +1,11 @@
 import { v4 as uuid } from "uuid";
 import { experimental_createMCPClient as createMCPClient, tool as createVercelTool } from "ai";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 import { MCP_SERVER_CLI_SCRIPT } from "./constants.js";
-import { LLMToolCall } from "./accuracyResultStorage/resultStorage.js";
-import { VercelMCPClient, VercelMCPClientTools } from "./agent.js";
+import type { LLMToolCall } from "./accuracyResultStorage/resultStorage.js";
+import type { VercelMCPClient, VercelMCPClientTools } from "./agent.js";
 
 type ToolResultGeneratorFn = (...parameters: unknown[]) => CallToolResult | Promise<CallToolResult>;
 export type MockedTools = Record<string, ToolResultGeneratorFn>;

--- a/tests/accuracy/sdk/agent.ts
+++ b/tests/accuracy/sdk/agent.ts
@@ -1,5 +1,6 @@
-import { generateText, LanguageModelV1, experimental_createMCPClient } from "ai";
-import { Model } from "./models.js";
+import type { LanguageModelV1, experimental_createMCPClient } from "ai";
+import { generateText } from "ai";
+import type { Model } from "./models.js";
 
 const systemPrompt = [
     'The keywords "MUST", "MUST NOT", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119',

--- a/tests/accuracy/sdk/describeAccuracyTests.ts
+++ b/tests/accuracy/sdk/describeAccuracyTests.ts
@@ -1,13 +1,15 @@
 import { describe, it, beforeAll, beforeEach, afterAll } from "vitest";
 import { getAvailableModels } from "./models.js";
 import { calculateToolCallingAccuracy } from "./accuracyScorer.js";
-import { getVercelToolCallingAgent, PromptDefinition, VercelAgent } from "./agent.js";
+import type { PromptDefinition, VercelAgent } from "./agent.js";
+import { getVercelToolCallingAgent } from "./agent.js";
 import { prepareTestData, setupMongoDBIntegrationTest } from "../../integration/tools/mongodb/mongodbHelpers.js";
-import { AccuracyTestingClient, MockedTools } from "./accuracyTestingClient.js";
-import { AccuracyResultStorage, ExpectedToolCall, LLMToolCall } from "./accuracyResultStorage/resultStorage.js";
+import type { MockedTools } from "./accuracyTestingClient.js";
+import { AccuracyTestingClient } from "./accuracyTestingClient.js";
+import type { AccuracyResultStorage, ExpectedToolCall, LLMToolCall } from "./accuracyResultStorage/resultStorage.js";
 import { getAccuracyResultStorage } from "./accuracyResultStorage/getAccuracyResultStorage.js";
 import { getCommitSHA } from "./gitInfo.js";
-import { MongoClient } from "mongodb";
+import type { MongoClient } from "mongodb";
 
 export interface AccuracyTestConfig {
     /** The prompt to be provided to LLM for evaluation. */

--- a/tests/accuracy/sdk/models.ts
+++ b/tests/accuracy/sdk/models.ts
@@ -1,4 +1,4 @@
-import { LanguageModelV1 } from "ai";
+import type { LanguageModelV1 } from "ai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createAzure } from "@ai-sdk/azure";
 import { createOpenAI } from "@ai-sdk/openai";

--- a/tests/accuracy/untrustedData.test.ts
+++ b/tests/accuracy/untrustedData.test.ts
@@ -1,5 +1,6 @@
 import path from "path";
-import { AccuracyTestConfig, describeAccuracyTests } from "./sdk/describeAccuracyTests.js";
+import type { AccuracyTestConfig } from "./sdk/describeAccuracyTests.js";
+import { describeAccuracyTests } from "./sdk/describeAccuracyTests.js";
 import { Matcher } from "./sdk/matcher.js";
 import * as fs from "fs";
 

--- a/tests/integration/common/connectionManager.oidc.test.ts
+++ b/tests/integration/common/connectionManager.oidc.test.ts
@@ -1,15 +1,13 @@
-import { describe, beforeEach, afterAll, it, expect, TestContext } from "vitest";
+import type { TestContext } from "vitest";
+import { describe, beforeEach, afterAll, it, expect } from "vitest";
 import semver from "semver";
 import process from "process";
-import {
-    describeWithMongoDB,
-    isCommunityServer,
-    getServerVersion,
-    MongoDBIntegrationTestCase,
-} from "../tools/mongodb/mongodbHelpers.js";
+import type { MongoDBIntegrationTestCase } from "../tools/mongodb/mongodbHelpers.js";
+import { describeWithMongoDB, isCommunityServer, getServerVersion } from "../tools/mongodb/mongodbHelpers.js";
 import { defaultTestConfig, responseAsText, timeout, waitUntil } from "../helpers.js";
-import { ConnectionStateConnected, ConnectionStateConnecting } from "../../../src/common/connectionManager.js";
-import { setupDriverConfig, UserConfig } from "../../../src/common/config.js";
+import type { ConnectionStateConnected, ConnectionStateConnecting } from "../../../src/common/connectionManager.js";
+import type { UserConfig } from "../../../src/common/config.js";
+import { setupDriverConfig } from "../../../src/common/config.js";
 import path from "path";
 import type { OIDCMockProviderConfig } from "@mongodb-js/oidc-mock-provider";
 import { OIDCMockProvider } from "@mongodb-js/oidc-mock-provider";

--- a/tests/integration/common/connectionManager.test.ts
+++ b/tests/integration/common/connectionManager.test.ts
@@ -1,9 +1,9 @@
-import {
-    ConnectionManager,
+import type {
     ConnectionManagerEvents,
     ConnectionStateConnected,
     ConnectionStringAuthType,
 } from "../../../src/common/connectionManager.js";
+import { ConnectionManager } from "../../../src/common/connectionManager.js";
 import type { UserConfig } from "../../../src/common/config.js";
 import { describeWithMongoDB } from "../tools/mongodb/mongodbHelpers.js";
 import { describe, beforeEach, expect, it, vi, afterEach } from "vitest";

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -6,11 +6,12 @@ import { Telemetry } from "../../src/telemetry/telemetry.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "./inMemoryTransport.js";
-import { UserConfig, DriverOptions } from "../../src/common/config.js";
+import type { UserConfig, DriverOptions } from "../../src/common/config.js";
 import { McpError, ResourceUpdatedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
 import { config, driverOptions } from "../../src/common/config.js";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { ConnectionManager, ConnectionState } from "../../src/common/connectionManager.js";
+import type { ConnectionState } from "../../src/common/connectionManager.js";
+import { ConnectionManager } from "../../src/common/connectionManager.js";
 import { DeviceId } from "../../src/helpers/deviceId.js";
 
 interface ParameterInfo {

--- a/tests/integration/inMemoryTransport.ts
+++ b/tests/integration/inMemoryTransport.ts
@@ -1,5 +1,5 @@
-import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
 export class InMemoryTransport implements Transport {
     private outputController: ReadableStreamDefaultController<JSONRPCMessage> | undefined;

--- a/tests/integration/resources/exportedData.test.ts
+++ b/tests/integration/resources/exportedData.test.ts
@@ -2,11 +2,11 @@ import path from "path";
 import fs from "fs/promises";
 import { Long } from "bson";
 import { describe, expect, it, beforeEach, afterAll } from "vitest";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { defaultTestConfig, resourceChangedNotification, timeout } from "../helpers.js";
 import { describeWithMongoDB } from "../tools/mongodb/mongodbHelpers.js";
 import { contentWithResourceURILink } from "../tools/mongodb/read/export.test.js";
-import { UserConfig } from "../../../src/lib.js";
+import type { UserConfig } from "../../../src/lib.js";
 
 const userConfig: UserConfig = {
     ...defaultTestConfig,

--- a/tests/integration/tools/atlas/accessLists.test.ts
+++ b/tests/integration/tools/atlas/accessLists.test.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { describeWithAtlas, withProject } from "./atlasHelpers.js";
 import { expectDefined } from "../../helpers.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";

--- a/tests/integration/tools/atlas/alerts.test.ts
+++ b/tests/integration/tools/atlas/alerts.test.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "../../helpers.js";
 import { parseTable, describeWithAtlas, withProject } from "./atlasHelpers.js";
 import { describe, expect, it } from "vitest";

--- a/tests/integration/tools/atlas/atlasHelpers.ts
+++ b/tests/integration/tools/atlas/atlasHelpers.ts
@@ -1,8 +1,10 @@
 import { ObjectId } from "mongodb";
-import { Group } from "../../../../src/common/atlas/openapi.js";
-import { ApiClient } from "../../../../src/common/atlas/apiClient.js";
-import { setupIntegrationTest, IntegrationTest, defaultTestConfig, defaultDriverOptions } from "../../helpers.js";
-import { afterAll, beforeAll, describe, SuiteCollector } from "vitest";
+import type { Group } from "../../../../src/common/atlas/openapi.js";
+import type { ApiClient } from "../../../../src/common/atlas/apiClient.js";
+import type { IntegrationTest } from "../../helpers.js";
+import { setupIntegrationTest, defaultTestConfig, defaultDriverOptions } from "../../helpers.js";
+import type { SuiteCollector } from "vitest";
+import { afterAll, beforeAll, describe } from "vitest";
 
 export type IntegrationTestFunction = (integration: IntegrationTest) => void;
 

--- a/tests/integration/tools/atlas/clusters.test.ts
+++ b/tests/integration/tools/atlas/clusters.test.ts
@@ -1,8 +1,8 @@
-import { Session } from "../../../../src/common/session.js";
+import type { Session } from "../../../../src/common/session.js";
 import { expectDefined, getResponseElements } from "../../helpers.js";
 import { describeWithAtlas, withProject, randomId } from "./atlasHelpers.js";
-import { ClusterDescription20240805 } from "../../../../src/common/atlas/openapi.js";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ClusterDescription20240805 } from "../../../../src/common/atlas/openapi.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 function sleep(ms: number): Promise<void> {

--- a/tests/integration/tools/atlas/dbUsers.test.ts
+++ b/tests/integration/tools/atlas/dbUsers.test.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { describeWithAtlas, withProject, randomId } from "./atlasHelpers.js";
 import { expectDefined, getResponseElements } from "../../helpers.js";
 import { ApiClientError } from "../../../../src/common/atlas/apiClientError.js";

--- a/tests/integration/tools/atlas/orgs.test.ts
+++ b/tests/integration/tools/atlas/orgs.test.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "../../helpers.js";
 import { parseTable, describeWithAtlas } from "./atlasHelpers.js";
 import { describe, expect, it } from "vitest";

--- a/tests/integration/tools/atlas/projects.test.ts
+++ b/tests/integration/tools/atlas/projects.test.ts
@@ -1,4 +1,4 @@
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ObjectId } from "mongodb";
 import { parseTable, describeWithAtlas } from "./atlasHelpers.js";
 import { expectDefined } from "../../helpers.js";

--- a/tests/integration/tools/mongodb/create/createIndex.test.ts
+++ b/tests/integration/tools/mongodb/create/createIndex.test.ts
@@ -7,7 +7,7 @@ import {
     validateThrowsForInvalidArguments,
     expectDefined,
 } from "../../../helpers.js";
-import { IndexDirection } from "mongodb";
+import type { IndexDirection } from "mongodb";
 import { expect, it } from "vitest";
 
 describeWithMongoDB("createIndex tool", (integration) => {

--- a/tests/integration/tools/mongodb/metadata/collectionSchema.test.ts
+++ b/tests/integration/tools/mongodb/metadata/collectionSchema.test.ts
@@ -8,9 +8,9 @@ import {
     validateThrowsForInvalidArguments,
     databaseCollectionInvalidArgs,
 } from "../../../helpers.js";
-import { Document } from "bson";
-import { OptionalId } from "mongodb";
-import { SimplifiedSchema } from "mongodb-schema";
+import type { Document } from "bson";
+import type { OptionalId } from "mongodb";
+import type { SimplifiedSchema } from "mongodb-schema";
 import { describe, expect, it } from "vitest";
 
 describeWithMongoDB("collectionSchema tool", (integration) => {

--- a/tests/integration/tools/mongodb/mongodbHelpers.ts
+++ b/tests/integration/tools/mongodb/mongodbHelpers.ts
@@ -1,16 +1,13 @@
-import { MongoCluster, MongoClusterOptions } from "mongodb-runner";
+import type { MongoClusterOptions } from "mongodb-runner";
+import { MongoCluster } from "mongodb-runner";
 import path from "path";
 import { fileURLToPath } from "url";
 import fs from "fs/promises";
-import { Document, MongoClient, ObjectId } from "mongodb";
-import {
-    getResponseContent,
-    IntegrationTest,
-    setupIntegrationTest,
-    defaultTestConfig,
-    defaultDriverOptions,
-} from "../../helpers.js";
-import { UserConfig, DriverOptions } from "../../../../src/common/config.js";
+import type { Document } from "mongodb";
+import { MongoClient, ObjectId } from "mongodb";
+import type { IntegrationTest } from "../../helpers.js";
+import { getResponseContent, setupIntegrationTest, defaultTestConfig, defaultDriverOptions } from "../../helpers.js";
+import type { UserConfig, DriverOptions } from "../../../../src/common/config.js";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/tests/integration/tools/mongodb/read/collectionIndexes.test.ts
+++ b/tests/integration/tools/mongodb/read/collectionIndexes.test.ts
@@ -1,4 +1,4 @@
-import { IndexDirection } from "mongodb";
+import type { IndexDirection } from "mongodb";
 import {
     databaseCollectionParameters,
     validateToolMetadata,

--- a/tests/integration/tools/mongodb/read/export.test.ts
+++ b/tests/integration/tools/mongodb/read/export.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { Long } from "bson";
 import fs from "fs/promises";
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import {
     databaseCollectionParameters,
     defaultTestConfig,
@@ -11,7 +11,7 @@ import {
     validateToolMetadata,
 } from "../../../helpers.js";
 import { describeWithMongoDB } from "../mongodbHelpers.js";
-import { UserConfig } from "../../../../../src/lib.js";
+import type { UserConfig } from "../../../../../src/lib.js";
 
 const userConfig: UserConfig = {
     ...defaultTestConfig,

--- a/tests/unit/accessListUtils.test.ts
+++ b/tests/unit/accessListUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { ApiClient } from "../../src/common/atlas/apiClient.js";
+import type { ApiClient } from "../../src/common/atlas/apiClient.js";
 import { ensureCurrentIpInAccessList, DEFAULT_ACCESS_LIST_COMMENT } from "../../src/common/atlas/accessListUtils.js";
 import { ApiClientError } from "../../src/common/atlas/apiClientError.js";
 import { NullLogger } from "../../src/common/logger.js";

--- a/tests/unit/accuracyScorer.test.ts
+++ b/tests/unit/accuracyScorer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { calculateToolCallingAccuracy } from "../accuracy/sdk/accuracyScorer.js";
-import { ExpectedToolCall, LLMToolCall } from "../accuracy/sdk/accuracyResultStorage/resultStorage.js";
+import type { ExpectedToolCall, LLMToolCall } from "../accuracy/sdk/accuracyResultStorage/resultStorage.js";
 import { Matcher } from "../accuracy/sdk/matcher.js";
 
 describe("calculateToolCallingAccuracy", () => {

--- a/tests/unit/common/apiClient.test.ts
+++ b/tests/unit/common/apiClient.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiClient } from "../../../src/common/atlas/apiClient.js";
-import { CommonProperties, TelemetryEvent, TelemetryResult } from "../../../src/telemetry/types.js";
+import type { CommonProperties, TelemetryEvent, TelemetryResult } from "../../../src/telemetry/types.js";
 import { NullLogger } from "../../../src/common/logger.js";
 
 describe("ApiClient", () => {

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { setupUserConfig, UserConfig, defaultUserConfig } from "../../../src/common/config.js";
+import type { UserConfig } from "../../../src/common/config.js";
+import { setupUserConfig, defaultUserConfig } from "../../../src/common/config.js";
 
 describe("config", () => {
     describe("env var parsing", () => {

--- a/tests/unit/common/exportsManager.test.ts
+++ b/tests/unit/common/exportsManager.test.ts
@@ -1,20 +1,22 @@
 import path from "path";
 import fs from "fs/promises";
 import { Readable, Transform } from "stream";
-import { FindCursor, Long } from "mongodb";
+import type { FindCursor } from "mongodb";
+import { Long } from "mongodb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExportsManagerConfig } from "../../../src/common/exportsManager.js";
 import {
     ensureExtension,
     isExportExpired,
     ExportsManager,
-    ExportsManagerConfig,
     validateExportName,
 } from "../../../src/common/exportsManager.js";
 
 import { config } from "../../../src/common/config.js";
 import { ROOT_DIR } from "../../accuracy/sdk/constants.js";
 import { timeout } from "../../integration/helpers.js";
-import { EJSON, EJSONOptions, ObjectId } from "bson";
+import type { EJSONOptions } from "bson";
+import { EJSON, ObjectId } from "bson";
 import { CompositeLogger } from "../../../src/common/logger.js";
 
 const logger = new CompositeLogger();

--- a/tests/unit/common/session.test.ts
+++ b/tests/unit/common/session.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, Mocked, vi } from "vitest";
+import type { Mocked } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import { Session } from "../../../src/common/session.js";
 import { config, driverOptions } from "../../../src/common/config.js";

--- a/tests/unit/helpers/indexCheck.test.ts
+++ b/tests/unit/helpers/indexCheck.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { usesIndex, getIndexCheckErrorMessage } from "../../../src/helpers/indexCheck.js";
-import { Document } from "mongodb";
+import type { Document } from "mongodb";
 
 describe("indexCheck", () => {
     describe("usesIndex", () => {

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -1,6 +1,8 @@
-import { describe, beforeEach, afterEach, vi, MockInstance, it, expect } from "vitest";
-import { CompositeLogger, ConsoleLogger, DiskLogger, LoggerType, LogId, McpLogger } from "../../src/common/logger.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { MockInstance } from "vitest";
+import { describe, beforeEach, afterEach, vi, it, expect } from "vitest";
+import type { LoggerType } from "../../src/common/logger.js";
+import { CompositeLogger, ConsoleLogger, DiskLogger, LogId, McpLogger } from "../../src/common/logger.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import os from "os";
 import * as path from "path";
 import * as fs from "fs/promises";

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -1,13 +1,13 @@
 import { ApiClient } from "../../src/common/atlas/apiClient.js";
-import { Session } from "../../src/common/session.js";
+import type { Session } from "../../src/common/session.js";
 import { Telemetry } from "../../src/telemetry/telemetry.js";
-import { BaseEvent, TelemetryResult } from "../../src/telemetry/types.js";
+import type { BaseEvent, TelemetryResult } from "../../src/telemetry/types.js";
 import { EventCache } from "../../src/telemetry/eventCache.js";
 import { config } from "../../src/common/config.js";
 import { afterEach, beforeEach, describe, it, vi, expect } from "vitest";
 import { NullLogger } from "../../src/common/logger.js";
 import type { MockedFunction } from "vitest";
-import { DeviceId } from "../../src/helpers/deviceId.js";
+import type { DeviceId } from "../../src/helpers/deviceId.js";
 
 // Mock the ApiClient to avoid real API calls
 vi.mock("../../src/common/atlas/apiClient.js");

--- a/tests/unit/transports/stdio.test.ts
+++ b/tests/unit/transports/stdio.test.ts
@@ -1,9 +1,9 @@
 import { Decimal128, MaxKey, MinKey, ObjectId, Timestamp, UUID } from "bson";
 import { createStdioTransport, EJsonReadBuffer } from "../../../src/transports/stdio.js";
-import { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
-import { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { Readable } from "stream";
+import type { Readable } from "stream";
 import { ReadBuffer } from "@modelcontextprotocol/sdk/shared/stdio.js";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 describe("stdioTransport", () => {


### PR DESCRIPTION
## Proposed changes

This is part of the effort for introducing an eslint rule to only use injected config in source code. This PR enables consistent type import/export rule on which the next rule will build upon.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
