### PR TITLE
fix: atlas connectCluster defaults to readOnly DB roles - MCP-125

### DIFF
--- a/src/common/atlas/roles.ts
+++ b/src/common/atlas/roles.ts
@@ -13,12 +13,11 @@ export function getDefaultRoleFromConfig(config: UserConfig): DatabaseUserRole {
         };
     }
 
-    // If all write tools are enabled, use readWriteAnyDatabase
+    // If any of the write tools are enabled, use readWriteAnyDatabase
     if (
-        !config.disabledTools?.includes("create") &&
-        !config.disabledTools?.includes("update") &&
-        !config.disabledTools?.includes("delete") &&
-        !config.disabledTools?.includes("metadata")
+        !config.disabledTools?.includes("create") ||
+        !config.disabledTools?.includes("update") ||
+        !config.disabledTools?.includes("delete")
     ) {
         return {
             roleName: "readWriteAnyDatabase",

--- a/src/common/atlas/roles.ts
+++ b/src/common/atlas/roles.ts
@@ -1,32 +1,33 @@
 import type { UserConfig } from "../config.js";
 import type { DatabaseUserRole } from "./openapi.js";
 
+const readWriteRole: DatabaseUserRole = {
+    roleName: "readWriteAnyDatabase",
+    databaseName: "admin",
+};
+
+const readOnlyRole: DatabaseUserRole = {
+    roleName: "readAnyDatabase",
+    databaseName: "admin",
+};
+
 /**
  * Get the default role name for the database user based on the Atlas Admin API
  * https://www.mongodb.com/docs/atlas/mongodb-users-roles-and-privileges/
  */
 export function getDefaultRoleFromConfig(config: UserConfig): DatabaseUserRole {
     if (config.readOnly) {
-        return {
-            roleName: "readAnyDatabase",
-            databaseName: "admin",
-        };
+        return readOnlyRole;
     }
 
     // If any of the write tools are enabled, use readWriteAnyDatabase
     if (
-        !config.disabledTools?.includes("create") ||
-        !config.disabledTools?.includes("update") ||
-        !config.disabledTools?.includes("delete")
+        !config.disabledTools.includes("create") ||
+        !config.disabledTools.includes("update") ||
+        !config.disabledTools.includes("delete")
     ) {
-        return {
-            roleName: "readWriteAnyDatabase",
-            databaseName: "admin",
-        };
+        return readWriteRole;
     }
 
-    return {
-        roleName: "readAnyDatabase",
-        databaseName: "admin",
-    };
+    return readOnlyRole;
 }

--- a/src/common/atlas/roles.ts
+++ b/src/common/atlas/roles.ts
@@ -1,0 +1,33 @@
+import { UserConfig } from "../config.js";
+import { DatabaseUserRole } from "./openapi.js";
+
+/**
+ * Get the default role name for the database user based on the Atlas Admin API
+ * https://www.mongodb.com/docs/atlas/mongodb-users-roles-and-privileges/
+ */
+export function getDefaultRoleFromConfig(config: UserConfig): DatabaseUserRole {
+    if (config.readOnly) {
+        return {
+            roleName: "readAnyDatabase",
+            databaseName: "admin",
+        };
+    }
+
+    // If all write tools are enabled, use readWriteAnyDatabase
+    if (
+        !config.disabledTools?.includes("create") &&
+        !config.disabledTools?.includes("update") &&
+        !config.disabledTools?.includes("delete") &&
+        !config.disabledTools?.includes("metadata")
+    ) {
+        return {
+            roleName: "readWriteAnyDatabase",
+            databaseName: "admin",
+        };
+    }
+
+    return {
+        roleName: "readAnyDatabase",
+        databaseName: "admin",
+    };
+}

--- a/src/common/atlas/roles.ts
+++ b/src/common/atlas/roles.ts
@@ -1,5 +1,5 @@
-import { UserConfig } from "../config.js";
-import { DatabaseUserRole } from "./openapi.js";
+import type { UserConfig } from "../config.js";
+import type { DatabaseUserRole } from "./openapi.js";
 
 /**
  * Get the default role name for the database user based on the Atlas Admin API

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -93,6 +93,8 @@ export class ConnectClusterTool extends AtlasToolBase {
                 oidcAuthType: "NONE",
                 x509Type: "NONE",
                 deleteAfterDate: expiryDate.toISOString(),
+                description:
+                    "This role is created by MongoDB MCP to connect to the cluster via the atlas-connect-cluster tool",
             },
         });
 

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -7,6 +7,7 @@ import { LogId } from "../../../common/logger.js";
 import { inspectCluster } from "../../../common/atlas/cluster.js";
 import { ensureCurrentIpInAccessList } from "../../../common/atlas/accessListUtils.js";
 import { AtlasClusterConnectionInfo } from "../../../common/connectionManager.js";
+import { DatabaseUserRole } from "../../../common/atlas/openapi.js";
 
 const EXPIRY_MS = 1000 * 60 * 60 * 12; // 12 hours
 
@@ -72,16 +73,7 @@ export class ConnectClusterTool extends AtlasToolBase {
         const password = await generateSecurePassword();
 
         const expiryDate = new Date(Date.now() + EXPIRY_MS);
-
-        const readOnly =
-            this.config.readOnly ||
-            (this.config.disabledTools?.includes("create") &&
-                this.config.disabledTools?.includes("update") &&
-                this.config.disabledTools?.includes("delete") &&
-                !this.config.disabledTools?.includes("read") &&
-                !this.config.disabledTools?.includes("metadata"));
-
-        const roleName = readOnly ? "readAnyDatabase" : "readWriteAnyDatabase";
+        const role = this.getRoleFromConfig();
 
         await this.session.apiClient.createDatabaseUser({
             params: {
@@ -92,12 +84,7 @@ export class ConnectClusterTool extends AtlasToolBase {
             body: {
                 databaseName: "admin",
                 groupId: projectId,
-                roles: [
-                    {
-                        roleName,
-                        databaseName: "admin",
-                    },
-                ],
+                roles: [role],
                 scopes: [{ type: "CLUSTER", name: clusterName }],
                 username,
                 password,
@@ -256,6 +243,37 @@ export class ConnectClusterTool extends AtlasToolBase {
                     text: `Warning: Make sure your IP address was enabled in the allow list setting of the Atlas cluster.`,
                 },
             ],
+        };
+    }
+
+    /**
+     * @description Get the role name for the database user based on the Atlas Admin API https://www.mongodb.com/docs/atlas/mongodb-users-roles-and-privileges/
+     * @returns The role name for the database user
+     */
+    private getRoleFromConfig(): DatabaseUserRole {
+        if (this.config.readOnly) {
+            return {
+                roleName: "readAnyDatabase",
+                databaseName: "admin",
+            };
+        }
+
+        // If all write tools are enabled, use readWriteAnyDatabase
+        if (
+            !this.config.disabledTools?.includes("create") &&
+            !this.config.disabledTools?.includes("update") &&
+            !this.config.disabledTools?.includes("delete") &&
+            !this.config.disabledTools?.includes("metadata")
+        ) {
+            return {
+                roleName: "readWriteAnyDatabase",
+                databaseName: "admin",
+            };
+        }
+
+        return {
+            roleName: "readAnyDatabase",
+            databaseName: "admin",
         };
     }
 }

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -93,8 +93,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                 oidcAuthType: "NONE",
                 x509Type: "NONE",
                 deleteAfterDate: expiryDate.toISOString(),
-                description:
-                    "This role is created by MongoDB MCP to connect to the cluster via the atlas-connect-cluster tool",
+                description: "This temporary user is created by the MongoDB MCP Server to connect to the cluster.",
             },
         });
 

--- a/tests/unit/common/roles.test.ts
+++ b/tests/unit/common/roles.test.ts
@@ -42,10 +42,9 @@ describe("getDefaultRoleFromConfig", () => {
         });
     });
 
-    // loop with each disabled tool
     for (const tool of ["create", "update", "delete", "metadata"]) {
-        it(`should return the correct role for a read-write config with ${tool} disabled`, () => {
-            const config = { ...readWriteConfig, disabledTools: [tool] };
+        it(`should return the correct role for a config with ${tool} disabled`, () => {
+            const config = { ...defaultConfig, disabledTools: [tool] };
             const role = getDefaultRoleFromConfig(config);
             expect(role).toEqual({
                 roleName: "readAnyDatabase",

--- a/tests/unit/common/roles.test.ts
+++ b/tests/unit/common/roles.test.ts
@@ -18,6 +18,30 @@ describe("getDefaultRoleFromConfig", () => {
         disabledTools: [],
     };
 
+    const readWriteConfigWithDeleteDisabled: UserConfig = {
+        ...defaultConfig,
+        readOnly: false,
+        disabledTools: ["delete"],
+    };
+
+    const readWriteConfigWithCreateDisabled: UserConfig = {
+        ...defaultConfig,
+        readOnly: false,
+        disabledTools: ["create"],
+    };
+
+    const readWriteConfigWithUpdateDisabled: UserConfig = {
+        ...defaultConfig,
+        readOnly: false,
+        disabledTools: ["update"],
+    };
+
+    const readWriteConfigWithAllToolsDisabled: UserConfig = {
+        ...defaultConfig,
+        readOnly: false,
+        disabledTools: ["create", "update", "delete"],
+    };
+
     it("should return the correct role for a read-only config", () => {
         const role = getDefaultRoleFromConfig(readOnlyConfig);
         expect(role).toEqual({
@@ -42,14 +66,35 @@ describe("getDefaultRoleFromConfig", () => {
         });
     });
 
-    for (const tool of ["create", "update", "delete", "metadata"]) {
-        it(`should return the correct role for a config with ${tool} disabled`, () => {
-            const config = { ...defaultConfig, disabledTools: [tool] };
-            const role = getDefaultRoleFromConfig(config);
-            expect(role).toEqual({
-                roleName: "readAnyDatabase",
-                databaseName: "admin",
-            });
+    it("should return the correct role for a read-write config with delete disabled", () => {
+        const role = getDefaultRoleFromConfig(readWriteConfigWithDeleteDisabled);
+        expect(role).toEqual({
+            roleName: "readWriteAnyDatabase",
+            databaseName: "admin",
         });
-    }
+    });
+
+    it("should return the correct role for a read-write config with create disabled", () => {
+        const role = getDefaultRoleFromConfig(readWriteConfigWithCreateDisabled);
+        expect(role).toEqual({
+            roleName: "readWriteAnyDatabase",
+            databaseName: "admin",
+        });
+    });
+
+    it("should return the correct role for a read-write config with update disabled", () => {
+        const role = getDefaultRoleFromConfig(readWriteConfigWithUpdateDisabled);
+        expect(role).toEqual({
+            roleName: "readAnyDatabase",
+            databaseName: "admin",
+        });
+    });
+
+    it("should return the correct role for a read-write config with all tools disabled", () => {
+        const role = getDefaultRoleFromConfig(readWriteConfigWithAllToolsDisabled);
+        expect(role).toEqual({
+            roleName: "readAnyDatabase",
+            databaseName: "admin",
+        });
+    });
 });

--- a/tests/unit/common/roles.test.ts
+++ b/tests/unit/common/roles.test.ts
@@ -85,7 +85,7 @@ describe("getDefaultRoleFromConfig", () => {
     it("should return the correct role for a read-write config with update disabled", () => {
         const role = getDefaultRoleFromConfig(readWriteConfigWithUpdateDisabled);
         expect(role).toEqual({
-            roleName: "readAnyDatabase",
+            roleName: "readWriteAnyDatabase",
             databaseName: "admin",
         });
     });

--- a/tests/unit/common/roles.test.ts
+++ b/tests/unit/common/roles.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { getDefaultRoleFromConfig } from "../../../src/common/atlas/roles.js";
+import { defaultUserConfig, UserConfig } from "../../../src/common/config.js";
+
+describe("getDefaultRoleFromConfig", () => {
+    const defaultConfig: UserConfig = {
+        ...defaultUserConfig,
+    };
+
+    const readOnlyConfig: UserConfig = {
+        ...defaultConfig,
+        readOnly: true,
+    };
+
+    const readWriteConfig: UserConfig = {
+        ...defaultConfig,
+        readOnly: false,
+        disabledTools: [],
+    };
+
+    it("should return the correct role for a read-only config", () => {
+        const role = getDefaultRoleFromConfig(readOnlyConfig);
+        expect(role).toEqual({
+            roleName: "readAnyDatabase",
+            databaseName: "admin",
+        });
+    });
+
+    it("should return the correct role for a read-write config", () => {
+        const role = getDefaultRoleFromConfig(readWriteConfig);
+        expect(role).toEqual({
+            roleName: "readWriteAnyDatabase",
+            databaseName: "admin",
+        });
+    });
+
+    it("should return the correct role for a read-write config with all tools enabled", () => {
+        const role = getDefaultRoleFromConfig(readWriteConfig);
+        expect(role).toEqual({
+            roleName: "readWriteAnyDatabase",
+            databaseName: "admin",
+        });
+    });
+
+    // loop with each disabled tool
+    for (const tool of ["create", "update", "delete", "metadata"]) {
+        it(`should return the correct role for a read-write config with ${tool} disabled`, () => {
+            const config = { ...readWriteConfig, disabledTools: [tool] };
+            const role = getDefaultRoleFromConfig(config);
+            expect(role).toEqual({
+                roleName: "readAnyDatabase",
+                databaseName: "admin",
+            });
+        });
+    }
+});

--- a/tests/unit/common/roles.test.ts
+++ b/tests/unit/common/roles.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getDefaultRoleFromConfig } from "../../../src/common/atlas/roles.js";
-import { defaultUserConfig, UserConfig } from "../../../src/common/config.js";
+import { defaultUserConfig, type UserConfig } from "../../../src/common/config.js";
 
 describe("getDefaultRoleFromConfig", () => {
     const defaultConfig: UserConfig = {


### PR DESCRIPTION
## Proposed changes

- Defaults to readOnly DB user role unless all tools are enabled

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
