### PR TITLE
chore: add some extra log level validations

### DIFF
--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -250,7 +250,7 @@ export class DiskLogger extends LoggerBase<{ initialized: [] }> {
 }
 
 export class McpLogger extends LoggerBase {
-    private static readonly LOG_LEVELS: LogLevel[] = [
+    public static readonly LOG_LEVELS: LogLevel[] = [
         "debug",
         "info",
         "notice",
@@ -259,7 +259,7 @@ export class McpLogger extends LoggerBase {
         "critical",
         "alert",
         "emergency",
-    ];
+    ] as const;
 
     public constructor(private readonly server: Server) {
         super();

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { AtlasTools } from "./tools/atlas/tools.js";
 import { MongoDbTools } from "./tools/mongodb/tools.js";
 import { Resources } from "./resources/resources.js";
 import type { LogLevel } from "./common/logger.js";
-import { LogId } from "./common/logger.js";
+import { LogId, McpLogger } from "./common/logger.js";
 import type { Telemetry } from "./telemetry/telemetry.js";
 import type { UserConfig } from "./common/config.js";
 import { type ServerEvent } from "./telemetry/types.js";
@@ -107,6 +107,10 @@ export class Server {
         });
 
         this.mcpServer.server.setRequestHandler(SetLevelRequestSchema, ({ params }) => {
+            if (!McpLogger.LOG_LEVELS.includes(params.level)) {
+                throw new Error(`Invalid log level: ${params.level}`);
+            }
+
             this._mcpLogLevel = params.level;
             return {};
         });

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -7,6 +7,7 @@ import * as path from "path";
 import * as fs from "fs/promises";
 import { once } from "events";
 import type { Server } from "../../src/server.js";
+import { LoggingMessageNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
 
 describe("Logger", () => {
     let consoleErrorSpy: MockInstance<typeof console.error>;
@@ -331,6 +332,10 @@ describe("Logger", () => {
 
             expect(mcpLoggerSpy).toHaveBeenCalledTimes(2);
             expect(getLastMcpLogMessage()).toContain("Alert message");
+        });
+
+        it("MCPLogger.LOG_LEVELS contains all possible levels", () => {
+            expect(McpLogger.LOG_LEVELS).toEqual(LoggingMessageNotificationSchema.shape.params.shape.level.options);
         });
     });
 });


### PR DESCRIPTION
## Proposed changes

This is a follow-up on https://github.com/mongodb-js/mongodb-mcp-server/pull/486 - it adds an extra test to ensure our log levels array is exhaustive and a parameter validation for the http endpoint.
