### PR TITLE
ci: add ipAccessList after creating project

### DIFF
--- a/.github/workflows/code_health.yaml
+++ b/.github/workflows/code_health.yaml
@@ -54,7 +54,7 @@ jobs:
           MDB_MCP_API_CLIENT_ID: ${{ secrets.TEST_ATLAS_CLIENT_ID }}
           MDB_MCP_API_CLIENT_SECRET: ${{ secrets.TEST_ATLAS_CLIENT_SECRET }}
           MDB_MCP_API_BASE_URL: ${{ vars.TEST_ATLAS_BASE_URL }}
-        run: npm test -- --exclude "tests/unit/**" --exclude "tests/integration/tools/mongodb/**" --exclude "tests/integration/*.ts"
+        run: npm test -- tests/integration/tools/atlas
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -84,7 +84,7 @@ export function setupIntegrationTest(
         });
 
         // Mock hasValidAccessToken for tests
-        if (userConfig.apiClientId && userConfig.apiClientSecret) {
+        if (!userConfig.apiClientId && !userConfig.apiClientSecret) {
             const mockFn = vi.fn().mockResolvedValue(true);
             session.apiClient.validateAccessToken = mockFn;
         }

--- a/tests/integration/tools/atlas/atlasHelpers.ts
+++ b/tests/integration/tools/atlas/atlasHelpers.ts
@@ -19,6 +19,7 @@ export function describeWithAtlas(name: string, fn: IntegrationTestFunction): vo
                 ...defaultTestConfig,
                 apiClientId: process.env.MDB_MCP_API_CLIENT_ID,
                 apiClientSecret: process.env.MDB_MCP_API_CLIENT_SECRET,
+                apiBaseUrl: process.env.MDB_MCP_API_BASE_URL ?? "https://cloud-dev.mongodb.com",
             }),
             () => defaultDriverOptions
         );
@@ -39,6 +40,13 @@ export function withProject(integration: IntegrationTest, fn: ProjectTestFunctio
         beforeAll(async () => {
             const apiClient = integration.mcpServer().session.apiClient;
 
+            // check that it has credentials
+            if (!apiClient.hasCredentials()) {
+                throw new Error("No credentials available");
+            }
+
+            // validate access token
+            await apiClient.validateAccessToken();
             try {
                 const group = await createProject(apiClient);
                 projectId = group.id;

--- a/tests/integration/tools/atlas/atlasHelpers.ts
+++ b/tests/integration/tools/atlas/atlasHelpers.ts
@@ -42,6 +42,23 @@ export function withProject(integration: IntegrationTest, fn: ProjectTestFunctio
             try {
                 const group = await createProject(apiClient);
                 projectId = group.id;
+
+                // add current IP to project access list
+                const { currentIpv4Address } = await apiClient.getIpInfo();
+                await apiClient.createProjectIpAccessList({
+                    params: {
+                        path: {
+                            groupId: projectId,
+                        },
+                    },
+                    body: [
+                        {
+                            ipAddress: currentIpv4Address,
+                            groupId: projectId,
+                            comment: "Added by MongoDB MCP Server to enable tool access",
+                        },
+                    ],
+                });
             } catch (error) {
                 console.error("Failed to create project:", error);
                 throw error;

--- a/tests/integration/tools/atlas/atlasHelpers.ts
+++ b/tests/integration/tools/atlas/atlasHelpers.ts
@@ -42,23 +42,6 @@ export function withProject(integration: IntegrationTest, fn: ProjectTestFunctio
             try {
                 const group = await createProject(apiClient);
                 projectId = group.id;
-
-                // add current IP to project access list
-                const { currentIpv4Address } = await apiClient.getIpInfo();
-                await apiClient.createProjectIpAccessList({
-                    params: {
-                        path: {
-                            groupId: projectId,
-                        },
-                    },
-                    body: [
-                        {
-                            ipAddress: currentIpv4Address,
-                            groupId: projectId,
-                            comment: "Added by MongoDB MCP Server to enable tool access",
-                        },
-                    ],
-                });
             } catch (error) {
                 console.error("Failed to create project:", error);
                 throw error;
@@ -127,6 +110,23 @@ async function createProject(apiClient: ApiClient): Promise<Group & Required<Pic
     if (!group?.id) {
         throw new Error("Failed to create project");
     }
+
+    // add current IP to project access list
+    const { currentIpv4Address } = await apiClient.getIpInfo();
+    await apiClient.createProjectIpAccessList({
+        params: {
+            path: {
+                groupId: group.id,
+            },
+        },
+        body: [
+            {
+                ipAddress: currentIpv4Address,
+                groupId: group.id,
+                comment: "Added by MongoDB MCP Server to enable tool access",
+            },
+        ],
+    });
 
     return group as Group & Required<Pick<Group, "id">>;
 }


### PR DESCRIPTION
## Proposed changes

- fixes the Atlas test command
- Adds IP to access list of any created project test
- Checks that apiClient has credentials and updates a mock for validation

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
