### PR TITLE
fix: allow connect tool on readOnly mode

### DIFF
--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -149,7 +149,7 @@ export abstract class ToolBase {
         let errorClarification: string | undefined;
 
         // Check read-only mode first
-        if (this.config.readOnly && !["read", "metadata"].includes(this.operationType)) {
+        if (this.config.readOnly && !["read", "metadata", "connect"].includes(this.operationType)) {
             errorClarification = `read-only mode is enabled, its operation type, \`${this.operationType}\`,`;
         } else if (this.config.disabledTools.includes(this.category)) {
             errorClarification = `its category, \`${this.category}\`,`;

--- a/tests/integration/common/connectionManager.oidc.test.ts
+++ b/tests/integration/common/connectionManager.oidc.test.ts
@@ -98,7 +98,7 @@ describe.skipIf(process.platform !== "linux")("ConnectionManager OIDC Tests", as
             ...defaultTestConfig,
             oidcRedirectURi: "http://localhost:0/",
             authenticationMechanism: "MONGODB-OIDC",
-            maxIdleTimeMS: "1",
+            maxIdleTimeMS: "10000",
             minPoolSize: "0",
             username: "testuser",
             browser: fetchBrowserFixture,


### PR DESCRIPTION
## Proposed changes

- Connect used to be under `metadata` category, after we updated it, it got removed from the `readOnly` tools. This is needed to be able to use read operations. 

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
