### PR TITLE
fix: start mcp even if connection fails - [MCP-140]

### DIFF
--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -41,6 +41,7 @@ export const LogId = {
 
     mongodbConnectFailure: mongoLogId(1_004_001),
     mongodbDisconnectFailure: mongoLogId(1_004_002),
+    mongodbConnectTry: mongoLogId(1_004_003),
 
     toolUpdateFailure: mongoLogId(1_005_001),
     resourceUpdateFailure: mongoLogId(1_005_002),

--- a/src/server.ts
+++ b/src/server.ts
@@ -245,7 +245,7 @@ export class Server {
         if (this.userConfig.connectionString) {
             try {
                 this.session.logger.info({
-                    id: LogId.serverInitialized,
+                    id: LogId.mongodbConnectTry,
                     context: "server",
                     message: `Detected a MongoDB connection string in the configuration, trying to connect...`,
                 });
@@ -257,7 +257,7 @@ export class Server {
                 this.session.logger.error({
                     id: LogId.mongodbConnectFailure,
                     context: "server",
-                    message: `Failed to connect to MongoDB instance using the connection string from the config: ${error as string}`,
+                    message: `Failed to connect to MongoDB instance using the connection string from the config: ${error instanceof Error ? error.message : String(error)}`,
                 });
             }
         }


### PR DESCRIPTION
## Proposed changes

MCP-140

## Tests

Logs for a successfull flow
```shell
{"t":{"$date":"2025-09-02T11:25:09.980Z"},"s":"I","c":"MONGODB-MCP","id":1000002,"ctx":"server","msg":"Detected a MongoDB connection string in the configuration, trying to connect..."}
{"t":{"$date":"2025-09-02T11:25:09.980Z"},"s":"I","c":"MONGODB-MCP","id":1000002,"ctx":"server","msg":"Server with version 0.3.0 started with transport StdioServerTransport and agent runner {\"name\":\"cursor-vscode\",\"version\":\"1.0.0\",\"title\":\"unknown\"}"}
{"t":{"$date":"2025-09-02T11:25:09.980Z"},"s":"I","c":"MONGODB-MCP","id":1002002,"ctx":"telemetry","msg":"Telemetry is disabled."}
{"t":{"$date":"2025-09-02T11:25:58.619Z"},"s":"D1","c":"MONGODB-MCP","id":1003001,"ctx":"tool","msg":"Executing tool list-databases"}
```

Logs for a failed flow
```shell
{"t":{"$date":"2025-09-02T11:26:26.942Z"},"s":"I","c":"MONGODB-MCP","id":1000002,"ctx":"server","msg":"Detected a MongoDB connection string in the configuration, trying to connect..."}
{"t":{"$date":"2025-09-02T11:26:26.943Z"},"s":"I","c":"MONGODB-MCP","id":1000002,"ctx":"server","msg":"Server with version 0.3.0 started with transport StdioServerTransport and agent runner {\"name\":\"cursor-vscode\",\"version\":\"1.0.0\",\"title\":\"unknown\"}"}
{"t":{"$date":"2025-09-02T11:26:26.943Z"},"s":"I","c":"MONGODB-MCP","id":1002002,"ctx":"telemetry","msg":"Telemetry is disabled."}
{"t":{"$date":"2025-09-02T11:26:28.497Z"},"s":"E","c":"MONGODB-MCP","id":1004001,"ctx":"server","msg":"Failed to connect to MongoDB instance using the connection string from the config: Error: bad auth : authentication failed"}
```

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
