### PR TITLE
chore: adapt ServiceProvider.close call not to pass any parameter anymore

### DIFF
--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -242,7 +242,7 @@ export class MCPConnectionManager extends ConnectionManager {
 
         if (this.currentConnectionState.tag === "connected" || this.currentConnectionState.tag === "connecting") {
             try {
-                await this.currentConnectionState.serviceProvider?.close(true);
+                await this.currentConnectionState.serviceProvider?.close();
             } finally {
                 this.changeState("connection-close", {
                     tag: "disconnected",


### PR DESCRIPTION
## Proposed changes
In the [following PR](https://github.com/mongodb-js/mongodb-mcp-server/pull/507) we merged a bump to `@mongosh/service-provider-node-driver` but the bump came with an interface update to `NodeDriverServiceProvider.close()` (`close` does not support parameters anymore) so the usages in our code needed to be modified as well. 

This PR does the same fixing the build problem on main.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
