### PR TITLE
fix(connection): support for multiple hosts urls #327

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -191,6 +191,12 @@ function parseEnvConfig(env: Record<string, unknown>): Partial<UserConfig> {
             return;
         }
         if (path.length === 0) {
+            // MongoDB URLs must not be preprocessed
+            if (value.startsWith("mongodb://") || value.startsWith("mongodb+srv://")) {
+                obj[currentField] = value;
+                return;
+            }
+
             const numberValue = Number(value);
             if (!isNaN(numberValue)) {
                 obj[currentField] = numberValue;

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -5,6 +5,20 @@ import type { CliOptions } from "@mongosh/arg-parser";
 
 describe("config", () => {
     describe("env var parsing", () => {
+        describe("mongodb urls", () => {
+            it("should not try to parse a multiple-host urls", () => {
+                const actual = setupUserConfig({
+                    env: {
+                        MDB_MCP_CONNECTION_STRING: "mongodb://user:password@host1,host2,host3/",
+                    },
+                    cli: [],
+                    defaults: defaultUserConfig,
+                });
+
+                expect(actual.connectionString).toEqual("mongodb://user:password@host1,host2,host3/");
+            });
+        });
+
         describe("string cases", () => {
             const testCases = [
                 { envVar: "MDB_MCP_API_BASE_URL", property: "apiBaseUrl", value: "http://test.com" },


### PR DESCRIPTION
## Proposed changes

Bug: MongoDB URLs passed as environment variables that contain multiple hosts are treated as arrays instead of actual URLS.
Fix: When the environment variable contents start with a mongodb connection protocol (mongodb://, mongodb+srv://) it skips preprocessing the contents and stores it in the config as is.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
