### PR TITLE
fix: don't wait for telemetry events

### DIFF
--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -82,7 +82,7 @@ export type TestConnectionManager = ConnectionManager & {
 
 export abstract class ConnectionManager {
     protected clientName: string;
-    protected readonly _events;
+    protected readonly _events: EventEmitter<ConnectionManagerEvents>;
     readonly events: Pick<EventEmitter<ConnectionManagerEvents>, "on" | "off" | "once">;
     private state: AnyConnectionState;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -193,7 +193,7 @@ export class Server {
             }
         }
 
-        this.telemetry.emitEvents([event]).catch(() => {});
+        this.telemetry.emitEvents([event]);
     }
 
     private registerTools(): void {

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -7,16 +7,29 @@ import { MACHINE_METADATA } from "./constants.js";
 import { EventCache } from "./eventCache.js";
 import { detectContainerEnv } from "../helpers/container.js";
 import type { DeviceId } from "../helpers/deviceId.js";
+import { EventEmitter } from "stream";
 
 type EventResult = {
     success: boolean;
     error?: Error;
 };
 
+async function timeout(promise: Promise<unknown>, ms: number): Promise<void> {
+    await Promise.race([new Promise((resolve) => setTimeout(resolve, ms)), promise]);
+}
+
+export interface TelemetryEvents {
+    "events-emitted": [];
+    "events-send-failed": [];
+    "events-skipped": [];
+}
+
 export class Telemetry {
     private isBufferingEvents: boolean = true;
     /** Resolves when the setup is complete or a timeout occurs */
     public setupPromise: Promise<[string, boolean]> | undefined;
+    public readonly events: EventEmitter<TelemetryEvents> = new EventEmitter();
+
     private eventCache: EventCache;
     private deviceId: DeviceId;
 
@@ -57,6 +70,12 @@ export class Telemetry {
 
     private async setup(): Promise<void> {
         if (!this.isTelemetryEnabled()) {
+            this.session.logger.info({
+                id: LogId.telemetryEmitFailure,
+                context: "telemetry",
+                message: "Telemetry is disabled.",
+                noRedaction: true,
+            });
             return;
         }
 
@@ -71,34 +90,22 @@ export class Telemetry {
 
     public async close(): Promise<void> {
         this.isBufferingEvents = false;
-        await this.emitEvents(this.eventCache.getEvents());
+        await timeout(this.emit([]), 5_000);
     }
 
     /**
      * Emits events through the telemetry pipeline
      * @param events - The events to emit
      */
-    public async emitEvents(events: BaseEvent[]): Promise<void> {
-        try {
-            if (!this.isTelemetryEnabled()) {
-                this.session.logger.info({
-                    id: LogId.telemetryEmitFailure,
-                    context: "telemetry",
-                    message: "Telemetry is disabled.",
-                    noRedaction: true,
-                });
-                return;
-            }
-
-            await this.emit(events);
-        } catch {
-            this.session.logger.debug({
-                id: LogId.telemetryEmitFailure,
-                context: "telemetry",
-                message: "Error emitting telemetry events.",
-                noRedaction: true,
-            });
+    public emitEvents(events: BaseEvent[]): void {
+        if (!this.isTelemetryEnabled()) {
+            this.events.emit("events-skipped");
+            return;
         }
+
+        // Don't wait for events to be sent - we should not block regular server
+        // operations on telemetry
+        void this.emit(events);
     }
 
     /**
@@ -144,32 +151,44 @@ export class Telemetry {
             return;
         }
 
-        const cachedEvents = this.eventCache.getEvents();
-        const allEvents = [...cachedEvents, ...events];
+        try {
+            const cachedEvents = this.eventCache.getEvents();
+            const allEvents = [...cachedEvents, ...events];
 
-        this.session.logger.debug({
-            id: LogId.telemetryEmitStart,
-            context: "telemetry",
-            message: `Attempting to send ${allEvents.length} events (${cachedEvents.length} cached)`,
-        });
-
-        const result = await this.sendEvents(this.session.apiClient, allEvents);
-        if (result.success) {
-            this.eventCache.clearEvents();
             this.session.logger.debug({
-                id: LogId.telemetryEmitSuccess,
+                id: LogId.telemetryEmitStart,
                 context: "telemetry",
-                message: `Sent ${allEvents.length} events successfully: ${JSON.stringify(allEvents, null, 2)}`,
+                message: `Attempting to send ${allEvents.length} events (${cachedEvents.length} cached)`,
             });
-            return;
-        }
 
-        this.session.logger.debug({
-            id: LogId.telemetryEmitFailure,
-            context: "telemetry",
-            message: `Error sending event to client: ${result.error instanceof Error ? result.error.message : String(result.error)}`,
-        });
-        this.eventCache.appendEvents(events);
+            const result = await this.sendEvents(this.session.apiClient, allEvents);
+            if (result.success) {
+                this.eventCache.clearEvents();
+                this.session.logger.debug({
+                    id: LogId.telemetryEmitSuccess,
+                    context: "telemetry",
+                    message: `Sent ${allEvents.length} events successfully: ${JSON.stringify(allEvents, null, 2)}`,
+                });
+                this.events.emit("events-emitted");
+                return;
+            }
+
+            this.session.logger.debug({
+                id: LogId.telemetryEmitFailure,
+                context: "telemetry",
+                message: `Error sending event to client: ${result.error instanceof Error ? result.error.message : String(result.error)}`,
+            });
+            this.eventCache.appendEvents(events);
+            this.events.emit("events-send-failed");
+        } catch (error) {
+            this.session.logger.debug({
+                id: LogId.telemetryEmitFailure,
+                context: "telemetry",
+                message: `Error emitting telemetry events: ${error instanceof Error ? error.message : String(error)}`,
+                noRedaction: true,
+            });
+            this.events.emit("events-send-failed");
+        }
     }
 
     /**

--- a/src/transports/streamableHttp.ts
+++ b/src/transports/streamableHttp.ts
@@ -124,7 +124,7 @@ export class StreamableHttpRunner extends TransportRunnerBase {
                         // eslint-disable-next-line @typescript-eslint/no-misused-promises
                         keepAliveLoop = setInterval(async () => {
                             try {
-                                this.logger.debug({
+                                server.session.logger.debug({
                                     id: LogId.streamableHttpTransportKeepAlive,
                                     context: "streamableHttpTransport",
                                     message: "Sending ping",
@@ -138,7 +138,7 @@ export class StreamableHttpRunner extends TransportRunnerBase {
                             } catch (err) {
                                 try {
                                     failedPings++;
-                                    this.logger.warning({
+                                    server.session.logger.warning({
                                         id: LogId.streamableHttpTransportKeepAliveFailure,
                                         context: "streamableHttpTransport",
                                         message: `Error sending ping (attempt #${failedPings}): ${err instanceof Error ? err.message : String(err)}`,
@@ -162,7 +162,7 @@ export class StreamableHttpRunner extends TransportRunnerBase {
                             this.logger.error({
                                 id: LogId.streamableHttpTransportSessionCloseFailure,
                                 context: "streamableHttpTransport",
-                                message: `Error closing session: ${error instanceof Error ? error.message : String(error)}`,
+                                message: `Error closing session ${sessionId}: ${error instanceof Error ? error.message : String(error)}`,
                             });
                         }
                     },

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -61,6 +61,16 @@ describe("Telemetry", () => {
         };
     }
 
+    function emitEventsForTest(events: BaseEvent[]): Promise<void> {
+        return new Promise((resolve) => {
+            telemetry.events.once("events-emitted", resolve);
+            telemetry.events.once("events-send-failed", resolve);
+            telemetry.events.once("events-skipped", resolve);
+
+            telemetry.emitEvents(events);
+        });
+    }
+
     // Helper function to verify mock calls to reduce duplication
     function verifyMockCalls({
         sendEventsCalls = 0,
@@ -145,7 +155,7 @@ describe("Telemetry", () => {
 
             await telemetry.setupPromise;
 
-            await telemetry.emitEvents([testEvent]);
+            await emitEventsForTest([testEvent]);
 
             verifyMockCalls({
                 sendEventsCalls: 1,
@@ -161,7 +171,7 @@ describe("Telemetry", () => {
 
             await telemetry.setupPromise;
 
-            await telemetry.emitEvents([testEvent]);
+            await emitEventsForTest([testEvent]);
 
             verifyMockCalls({
                 sendEventsCalls: 1,
@@ -186,7 +196,7 @@ describe("Telemetry", () => {
 
             await telemetry.setupPromise;
 
-            await telemetry.emitEvents([newEvent]);
+            await emitEventsForTest([newEvent]);
 
             verifyMockCalls({
                 sendEventsCalls: 1,
@@ -223,7 +233,7 @@ describe("Telemetry", () => {
             const commonProps = telemetry.getCommonProperties();
             expect(commonProps.hosting_mode).toBe("vscode-extension");
 
-            await telemetry.emitEvents([createTestEvent()]);
+            await emitEventsForTest([createTestEvent()]);
 
             const calls = mockApiClient.sendEvents.mock.calls;
             expect(calls).toHaveLength(1);
@@ -305,7 +315,7 @@ describe("Telemetry", () => {
         it("should not send events", async () => {
             const testEvent = createTestEvent();
 
-            await telemetry.emitEvents([testEvent]);
+            await emitEventsForTest([testEvent]);
 
             verifyMockCalls();
         });
@@ -330,7 +340,7 @@ describe("Telemetry", () => {
         it("should not send events", async () => {
             const testEvent = createTestEvent();
 
-            await telemetry.emitEvents([testEvent]);
+            await emitEventsForTest([testEvent]);
 
             verifyMockCalls();
         });


### PR DESCRIPTION
## Proposed changes
While looking at some customer logs, I noticed we're likely being super inefficient by waiting for telemetry events to be sent before we can continue with normal server tasks.

Additionally, added a log for after tool execution.