### PR TITLE
fix: pin yargs-parser to 21 for VSCode compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "oauth4webapi": "^3.8.0",
         "openapi-fetch": "^0.14.0",
         "ts-levenshtein": "^1.0.7",
-        "yargs-parser": "^22.0.0",
+        "yargs-parser": "^21.1.1",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -11366,16 +11366,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/openapi-typescript/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/openid-client": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.7.1.tgz",
@@ -15450,12 +15440,12 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": ">=12"
       }
     },
     "node_modules/yargs/node_modules/ansi-regex": {
@@ -15501,16 +15491,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "oauth4webapi": "^3.8.0",
     "openapi-fetch": "^0.14.0",
     "ts-levenshtein": "^1.0.7",
-    "yargs-parser": "^22.0.0",
+    "yargs-parser": "^21.1.1",
     "zod": "^3.25.76"
   },
   "engines": {


### PR DESCRIPTION
## Proposed changes
VSCode project works(not directly) with yargs-parser@21 and our project pulls in version 22. The dependency resolution in VSCode resolves yargs-parser to version 21 and thus the usage of this dependency in the imported mcp-server-code breaks.

Ideally, we wouldn't have to do this because the imported code in VSCode, theoretically, in no way relies on yargs-parser. But because of our code setup, the yargs-parser does come in the imported path eventually:
1. exporting types and vaues from config.js in lib entry point which imports yargs-parser. Ideally we should re-organise this to different files, one with schema and one with config helpers.
2. imports from config.js in our trasport/base.js which sets up default connectionManager imported from connectionManager.js which further imports config.js which imports yargs-parser.
3. imports from config.js in our config resource which imports defaultDriverOptions.

To fix this long term there are two options:
1. Re-organise files and imports such that un-necessary code does not end up in lib entry point. This will compromise a bit on DX but is more preferable, we do the same in Compass, btw. Additionally we will have to setup VSCode integration tests.
2. Use bundler to bundle the lib entry point with all the dependencies it might accidentally end up importing. Less preferred because the lib entry point might just grow without us noticing but this will work flawlessly.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
