### PR TITLE
chore: extend lib to provide configurable properties for VSCode

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -101,7 +101,7 @@ interface Options {
     configuration: Record<string, boolean>;
 }
 
-const ALL_CONFIG_KEYS = new Set(
+export const ALL_CONFIG_KEYS = new Set(
     (OPTIONS.string as readonly string[])
         .concat(OPTIONS.array)
         .concat(OPTIONS.boolean)

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,6 +1,6 @@
 export { Server, type ServerOptions } from "./server.js";
 export { Session, type SessionOptions } from "./common/session.js";
-export { defaultUserConfig, type UserConfig } from "./common/config.js";
+export { defaultUserConfig, type UserConfig, ALL_CONFIG_KEYS as configurableProperties } from "./common/config.js";
 export { LoggerBase, type LogPayload, type LoggerType, type LogLevel } from "./common/logger.js";
 export { StreamableHttpRunner } from "./transports/streamableHttp.js";
 export {


### PR DESCRIPTION
## Proposed changes
VSCode exposes a few MCP properties as configurable properties through extension settings. This PR extends the lib with all the configurable properties that the MCP server can accept so that VSCode can filter out the irrelevant ones and provide only the relevant config.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
