### PR TITLE
chore: emit close on ConnectionManager

### DIFF
--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -102,16 +102,7 @@ export class Session extends EventEmitter<SessionEvents> {
     async disconnect(): Promise<void> {
         const atlasCluster = this.connectedAtlasCluster;
 
-        try {
-            await this.connectionManager.disconnect();
-        } catch (err: unknown) {
-            const error = err instanceof Error ? err : new Error(String(err));
-            this.logger.error({
-                id: LogId.mongodbDisconnectFailure,
-                context: "session",
-                message: `Error closing service provider: ${error.message}`,
-            });
-        }
+        await this.connectionManager.close();
 
         if (atlasCluster?.username && atlasCluster?.projectId) {
             void this.apiClient


### PR DESCRIPTION
## Proposed changes
This is part of required changes needed for fixing multiple client connection handling issue on VSCode https://github.com/mongodb-js/vscode/pull/1132.

The idea is for ConnectionManager to emit a `close` event when the session is being closed which is a signal that a previously connected client has disconnected.

The VSCode MCPController will make use of this event to clean up after client disconnects.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
