### PR TITLE
chore: downgrade yargs-parser to v21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "oauth4webapi": "^3.8.0",
         "openapi-fetch": "^0.14.0",
         "ts-levenshtein": "^1.0.7",
-        "yargs-parser": "^22.0.0",
+        "yargs-parser": "21.1.1",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -11279,16 +11279,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/openapi-typescript/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/openid-client": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.7.1.tgz",
@@ -15401,12 +15391,12 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
+        "node": ">=12"
       }
     },
     "node_modules/yargs/node_modules/ansi-regex": {
@@ -15452,16 +15442,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/yargs-parser": "^21.0.3",
     "@typescript-eslint/parser": "^8.44.0",
     "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/eslint-plugin": "^1.3.4",
     "ai": "^4.3.17",
     "duplexpair": "^1.0.2",
     "eslint": "^9.34.0",
@@ -93,7 +94,6 @@
     "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.41.0",
-    "@vitest/eslint-plugin": "^1.3.4",
     "uuid": "^13.0.0",
     "vitest": "^3.2.4"
   },
@@ -115,7 +115,7 @@
     "oauth4webapi": "^3.8.0",
     "openapi-fetch": "^0.14.0",
     "ts-levenshtein": "^1.0.7",
-    "yargs-parser": "^22.0.0",
+    "yargs-parser": "21.1.1",
     "zod": "^3.25.76"
   },
   "engines": {


### PR DESCRIPTION
## Proposed changes
We need to keep yargs-parser pinned to v21 because it eventually ends up on the library path of mongodb-mcp-server which gets bundled in VSCode extension and yargs-parser@22 is not compatible with webpack (does not work at all).

So until we find a way to remove yargs-parser from the lib path, which should be doable, we need to keep yargs-parser pinned to v21.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
