### PR TITLE
feat: atlas-get-performance-advisor tool: tweak language for slow queries

### DIFF
--- a/src/common/atlas/performanceAdvisorUtils.ts
+++ b/src/common/atlas/performanceAdvisorUtils.ts
@@ -9,6 +9,9 @@ export type SlowQueryLog = components["schemas"]["PerformanceAdvisorSlowQuery"];
 
 export const DEFAULT_SLOW_QUERY_LOGS_LIMIT = 50;
 
+export const SUGGESTED_INDEXES_COPY = `Note: The "Weight" field is measured in bytes, and represents the estimated number of bytes saved in disk reads per executed read query that would be saved by implementing an index suggestion. Please convert this to MB or GB for easier readability.`;
+export const SLOW_QUERY_LOGS_COPY = `Please notify the user that the MCP server tool limits slow query logs to the most recent ${DEFAULT_SLOW_QUERY_LOGS_LIMIT} slow query logs. This is a limitation of the MCP server tool only. More slow query logs and performance suggestions can be seen in the Atlas UI. Please give to the user the following docs about the performance advisor: https://www.mongodb.com/docs/atlas/performance-advisor/.`;
+
 interface SuggestedIndexesResponse {
     content: components["schemas"]["PerformanceAdvisorResponse"];
 }

--- a/src/tools/atlas/read/getPerformanceAdvisor.ts
+++ b/src/tools/atlas/read/getPerformanceAdvisor.ts
@@ -9,6 +9,8 @@ import {
     getSchemaAdvice,
     getSlowQueries,
     DEFAULT_SLOW_QUERY_LOGS_LIMIT,
+    SUGGESTED_INDEXES_COPY,
+    SLOW_QUERY_LOGS_COPY,
 } from "../../../common/atlas/performanceAdvisorUtils.js";
 import { AtlasArgs } from "../../args.js";
 
@@ -98,11 +100,11 @@ export class GetPerformanceAdvisorTool extends AtlasToolBase {
             const performanceAdvisorData = [
                 `## Suggested Indexes\n${
                     hasSuggestedIndexes
-                        ? `Note: The "Weight" field is measured in bytes, and represents the estimated number of bytes saved in disk reads per executed read query that would be saved by implementing an index suggestion. Please convert this to MB or GB for easier readability.\n${JSON.stringify(suggestedIndexesResult.value?.suggestedIndexes)}`
+                        ? `${SUGGESTED_INDEXES_COPY}\n${JSON.stringify(suggestedIndexesResult.value?.suggestedIndexes)}`
                         : "No suggested indexes found."
                 }`,
                 `## Drop Index Suggestions\n${hasDropIndexSuggestions ? JSON.stringify(dropIndexSuggestionsResult.value) : "No drop index suggestions found."}`,
-                `## Slow Query Logs\n${hasSlowQueryLogs ? `Please notify the user that the slow query logs are limited to the most recent ${DEFAULT_SLOW_QUERY_LOGS_LIMIT} slow query logs. This is a limitation of the MCP server tool only.\n${JSON.stringify(slowQueryLogsResult.value?.slowQueryLogs)}` : "No slow query logs found."}`,
+                `## Slow Query Logs\n${hasSlowQueryLogs ? `${SLOW_QUERY_LOGS_COPY}\n${JSON.stringify(slowQueryLogsResult.value?.slowQueryLogs)}` : "No slow query logs found."}`,
                 `## Schema Suggestions\n${hasSchemaSuggestions ? JSON.stringify(schemaSuggestionsResult.value?.recommendations) : "No schema suggestions found."}`,
             ];
 


### PR DESCRIPTION
## Proposed changes
From a product request: Adjusts the language when getting the slow queries for the performance advisor tool. Conveys the language to the LLM that the max limit for number of slow queries is due to the MCP server tool only (and not across Atlas).

## Checklist
- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)

<img width="468" height="76" alt="Screenshot 2025-10-13 at 6 15 31 PM" src="https://github.com/user-attachments/assets/696787aa-34ca-4008-858c-6971721fc4bc" />
