### PR TITLE
chore: use describeWithMongoDB to setup test suites instead of custom wiring

### DIFF
--- a/tests/integration/common/connectionManager.oidc.test.ts
+++ b/tests/integration/common/connectionManager.oidc.test.ts
@@ -3,12 +3,7 @@ import { describe, beforeEach, afterAll, it, expect, vi } from "vitest";
 import semver from "semver";
 import process from "process";
 import type { MongoDBIntegrationTestCase } from "../tools/mongodb/mongodbHelpers.js";
-import {
-    describeWithMongoDB,
-    isCommunityServer,
-    getServerVersion,
-    defaultTestSuiteConfig,
-} from "../tools/mongodb/mongodbHelpers.js";
+import { describeWithMongoDB, isCommunityServer, getServerVersion } from "../tools/mongodb/mongodbHelpers.js";
 import { defaultTestConfig, responseAsText, timeout, waitUntil } from "../helpers.js";
 import type { ConnectionStateConnected, ConnectionStateConnecting } from "../../../src/common/connectionManager.js";
 import type { UserConfig } from "../../../src/common/config.js";
@@ -143,7 +138,6 @@ describe.skipIf(process.platform !== "linux")("ConnectionManager OIDC Tests", as
                 addCb?.(oidcIt);
             },
             {
-                ...defaultTestSuiteConfig,
                 getUserConfig: () => oidcConfig,
                 getDriverOptions: () =>
                     setupDriverConfig({

--- a/tests/integration/elicitation.test.ts
+++ b/tests/integration/elicitation.test.ts
@@ -4,7 +4,7 @@ import { type UserConfig } from "../../src/common/config.js";
 import { defaultTestConfig } from "./helpers.js";
 import { Elicitation } from "../../src/elicitation.js";
 import { createMockElicitInput } from "../utils/elicitationMocks.js";
-import { defaultTestSuiteConfig, describeWithMongoDB } from "./tools/mongodb/mongodbHelpers.js";
+import { describeWithMongoDB } from "./tools/mongodb/mongodbHelpers.js";
 
 function createTestConfig(config: Partial<UserConfig> = {}): UserConfig {
     return {
@@ -173,7 +173,6 @@ describe("Elicitation Integration Tests", () => {
             });
         },
         {
-            ...defaultTestSuiteConfig,
             getUserConfig: () => createTestConfig(),
             getMockElicitationInput: () => mockElicitInput,
         }
@@ -202,7 +201,6 @@ describe("Elicitation Integration Tests", () => {
             });
         },
         {
-            ...defaultTestSuiteConfig,
             getUserConfig: () => createTestConfig(),
             getClientCapabilities: () => ({}),
         }
@@ -240,7 +238,6 @@ describe("Elicitation Integration Tests", () => {
             });
         },
         {
-            ...defaultTestSuiteConfig,
             getUserConfig: () => createTestConfig({ confirmationRequiredTools: ["list-databases"] }),
             getMockElicitationInput: () => mockElicitInput,
         }
@@ -291,7 +288,6 @@ describe("Elicitation Integration Tests", () => {
             });
         },
         {
-            ...defaultTestSuiteConfig,
             getUserConfig: () => createTestConfig(),
             getMockElicitationInput: () => mockElicitInput,
         }
@@ -321,7 +317,6 @@ describe("Elicitation Integration Tests", () => {
             });
         },
         {
-            ...defaultTestSuiteConfig,
             getUserConfig: () => createTestConfig(),
             getMockElicitationInput: () => mockElicitInput,
         }

--- a/tests/integration/indexCheck.test.ts
+++ b/tests/integration/indexCheck.test.ts
@@ -1,5 +1,5 @@
 import { defaultTestConfig, getResponseContent } from "./helpers.js";
-import { defaultTestSuiteConfig, describeWithMongoDB } from "./tools/mongodb/mongodbHelpers.js";
+import { describeWithMongoDB } from "./tools/mongodb/mongodbHelpers.js";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("IndexCheck integration tests", () => {
@@ -314,7 +314,6 @@ describe("IndexCheck integration tests", () => {
                 });
             },
             {
-                ...defaultTestSuiteConfig,
                 getUserConfig: () => ({
                     ...defaultTestConfig,
                     indexCheck: true, // Enable indexCheck
@@ -428,7 +427,6 @@ describe("IndexCheck integration tests", () => {
                 });
             },
             {
-                ...defaultTestSuiteConfig,
                 getUserConfig: () => ({
                     ...defaultTestConfig,
                     indexCheck: false, // Disable indexCheck
@@ -463,7 +461,6 @@ describe("IndexCheck integration tests", () => {
                 });
             },
             {
-                ...defaultTestSuiteConfig,
                 getUserConfig: () => ({
                     ...defaultTestConfig,
                     // indexCheck not specified, should default to false

--- a/tests/integration/resources/exportedData.test.ts
+++ b/tests/integration/resources/exportedData.test.ts
@@ -4,7 +4,7 @@ import { EJSON, Long, ObjectId } from "bson";
 import { describe, expect, it, beforeEach, afterAll } from "vitest";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { defaultTestConfig, getDataFromUntrustedContent, resourceChangedNotification, timeout } from "../helpers.js";
-import { defaultTestSuiteConfig, describeWithMongoDB } from "../tools/mongodb/mongodbHelpers.js";
+import { describeWithMongoDB } from "../tools/mongodb/mongodbHelpers.js";
 import { contentWithResourceURILink } from "../tools/mongodb/read/export.test.js";
 import type { UserConfig } from "../../../src/lib.js";
 
@@ -174,7 +174,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getUserConfig: () => userConfig,
     }
 );

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -1,5 +1,5 @@
 import { defaultTestConfig, expectDefined } from "./helpers.js";
-import { defaultTestSuiteConfig, describeWithMongoDB } from "./tools/mongodb/mongodbHelpers.js";
+import { describeWithMongoDB } from "./tools/mongodb/mongodbHelpers.js";
 import { describe, expect, it } from "vitest";
 
 describe("Server integration test", () => {
@@ -16,7 +16,6 @@ describe("Server integration test", () => {
             });
         },
         {
-            ...defaultTestSuiteConfig,
             getUserConfig: () => ({
                 ...defaultTestConfig,
                 apiClientId: undefined,
@@ -57,7 +56,6 @@ describe("Server integration test", () => {
             });
         },
         {
-            ...defaultTestSuiteConfig,
             getUserConfig: () => ({
                 ...defaultTestConfig,
                 apiClientId: "test",
@@ -89,7 +87,6 @@ describe("Server integration test", () => {
             });
         },
         {
-            ...defaultTestSuiteConfig,
             getUserConfig: () => ({
                 ...defaultTestConfig,
                 readOnly: true,

--- a/tests/integration/tools/mongodb/connect/connect.test.ts
+++ b/tests/integration/tools/mongodb/connect/connect.test.ts
@@ -1,4 +1,4 @@
-import { defaultTestSuiteConfig, describeWithMongoDB } from "../mongodbHelpers.js";
+import { describeWithMongoDB } from "../mongodbHelpers.js";
 import {
     getResponseContent,
     getResponseElements,
@@ -81,7 +81,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getUserConfig: (mdbIntegration) => ({
             ...defaultTestConfig,
             connectionString: mdbIntegration.connectionString(),
@@ -160,7 +159,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getUserConfig: () => ({
             ...defaultTestConfig,
             disabledTools: ["connect"],

--- a/tests/integration/tools/mongodb/delete/dropIndex.test.ts
+++ b/tests/integration/tools/mongodb/delete/dropIndex.test.ts
@@ -8,7 +8,7 @@ import {
     validateThrowsForInvalidArguments,
     validateToolMetadata,
 } from "../../../helpers.js";
-import { defaultTestSuiteConfig, describeWithMongoDB } from "../mongodbHelpers.js";
+import { describeWithMongoDB } from "../mongodbHelpers.js";
 import { createMockElicitInput } from "../../../../utils/elicitationMocks.js";
 import { Elicitation } from "../../../../../src/elicitation.js";
 
@@ -174,7 +174,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getMockElicitationInput: () => mockElicitInput,
     }
 );

--- a/tests/integration/tools/mongodb/mongodbHelpers.ts
+++ b/tests/integration/tools/mongodb/mongodbHelpers.ts
@@ -75,7 +75,7 @@ export type TestSuiteConfig = {
     getClientCapabilities?: () => MockClientCapabilities;
 };
 
-export const defaultTestSuiteConfig: TestSuiteConfig = {
+const defaultTestSuiteConfig: TestSuiteConfig = {
     getUserConfig: () => defaultTestConfig,
     getDriverOptions: () => defaultDriverOptions,
     downloadOptions: DEFAULT_MONGODB_PROCESS_OPTIONS,
@@ -84,14 +84,12 @@ export const defaultTestSuiteConfig: TestSuiteConfig = {
 export function describeWithMongoDB(
     name: string,
     fn: (integration: MongoDBIntegrationTestCase) => void,
-    {
-        getUserConfig,
-        getDriverOptions,
-        downloadOptions,
-        getMockElicitationInput,
-        getClientCapabilities,
-    }: TestSuiteConfig = defaultTestSuiteConfig
+    partialTestSuiteConfig?: Partial<TestSuiteConfig>
 ): void {
+    const { getUserConfig, getDriverOptions, downloadOptions, getMockElicitationInput, getClientCapabilities } = {
+        ...defaultTestSuiteConfig,
+        ...partialTestSuiteConfig,
+    };
     describe.skipIf(!MongoDBClusterProcess.isConfigurationSupportedInCurrentEnv(downloadOptions))(name, () => {
         const mdbIntegration = setupMongoDBIntegrationTest(downloadOptions);
         const mockElicitInput = getMockElicitationInput?.();

--- a/tests/integration/tools/mongodb/read/aggregate.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregate.test.ts
@@ -6,12 +6,7 @@ import {
     defaultTestConfig,
 } from "../../../helpers.js";
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
-import {
-    defaultTestSuiteConfig,
-    describeWithMongoDB,
-    getDocsFromUntrustedContent,
-    validateAutoConnectBehavior,
-} from "../mongodbHelpers.js";
+import { describeWithMongoDB, getDocsFromUntrustedContent, validateAutoConnectBehavior } from "../mongodbHelpers.js";
 import * as constants from "../../../../../src/helpers/constants.js";
 import { freshInsertDocuments } from "./find.test.js";
 
@@ -288,7 +283,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getUserConfig: () => ({ ...defaultTestConfig, maxDocumentsPerQuery: 20 }),
     }
 );
@@ -348,7 +342,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getUserConfig: () => ({ ...defaultTestConfig, maxBytesPerQuery: 200 }),
     }
 );
@@ -381,7 +374,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getUserConfig: () => ({ ...defaultTestConfig, maxDocumentsPerQuery: -1, maxBytesPerQuery: -1 }),
     }
 );

--- a/tests/integration/tools/mongodb/read/export.test.ts
+++ b/tests/integration/tools/mongodb/read/export.test.ts
@@ -10,7 +10,7 @@ import {
     validateThrowsForInvalidArguments,
     validateToolMetadata,
 } from "../../../helpers.js";
-import { defaultTestSuiteConfig, describeWithMongoDB } from "../mongodbHelpers.js";
+import { describeWithMongoDB } from "../mongodbHelpers.js";
 import type { UserConfig } from "../../../../../src/lib.js";
 
 const userConfig: UserConfig = {
@@ -459,7 +459,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getUserConfig: () => userConfig,
     }
 );

--- a/tests/integration/tools/mongodb/read/find.test.ts
+++ b/tests/integration/tools/mongodb/read/find.test.ts
@@ -9,12 +9,7 @@ import {
     defaultTestConfig,
 } from "../../../helpers.js";
 import * as constants from "../../../../../src/helpers/constants.js";
-import {
-    defaultTestSuiteConfig,
-    describeWithMongoDB,
-    getDocsFromUntrustedContent,
-    validateAutoConnectBehavior,
-} from "../mongodbHelpers.js";
+import { describeWithMongoDB, getDocsFromUntrustedContent, validateAutoConnectBehavior } from "../mongodbHelpers.js";
 
 export async function freshInsertDocuments({
     collection,
@@ -347,7 +342,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getUserConfig: () => ({ ...defaultTestConfig, maxDocumentsPerQuery: 10 }),
     }
 );
@@ -400,7 +394,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getUserConfig: () => ({ ...defaultTestConfig, maxBytesPerQuery: 100 }),
     }
 );
@@ -453,7 +446,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         getUserConfig: () => ({ ...defaultTestConfig, maxDocumentsPerQuery: -1, maxBytesPerQuery: -1 }),
     }
 );

--- a/tests/integration/tools/mongodb/search/listSearchIndexes.test.ts
+++ b/tests/integration/tools/mongodb/search/listSearchIndexes.test.ts
@@ -1,4 +1,4 @@
-import { defaultTestSuiteConfig, describeWithMongoDB, getSingleDocFromUntrustedContent } from "../mongodbHelpers.js";
+import { describeWithMongoDB, getSingleDocFromUntrustedContent } from "../mongodbHelpers.js";
 import { describe, it, expect, beforeEach } from "vitest";
 import {
     getResponseContent,
@@ -118,7 +118,6 @@ describeWithMongoDB(
         });
     },
     {
-        ...defaultTestSuiteConfig,
         downloadOptions: { search: true },
     }
 );


### PR DESCRIPTION
## Proposed changes
In some places we were doing the same wiring as the one that is already done in `describeWithMongoDB` and the reason for that was we needed some extra configuration to be passed down to `setupIntegrationTest` or to `setupMongoDBIntegrationTest`. This PR modifies `describeWithMongoDB` to accept the additional parameters and pass them down to `setupIntegrationTest` and `setupMongoDBIntegrationTest` and unify the usage in tests to use `describeWithMongoDB` instead of manual wiring.

The motivation is to have one place to have checks like skipping test on specific environments.

## Notes for reviewers
Review individual commits.
- The first commit is only a refactor, changes the describeWithMongoDB interface to accept test suite config instead of individual function parameters.
- The second commit adds elicitation related options to the interface of describeWithMongoDB and adapts elicitation tests to use describeWithMongoDB.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
