### PR TITLE
chore: retry the whole test with fixtures in case of error

### DIFF
--- a/tests/integration/common/connectionManager.oidc.test.ts
+++ b/tests/integration/common/connectionManager.oidc.test.ts
@@ -13,7 +13,8 @@ import type { OIDCMockProviderConfig } from "@mongodb-js/oidc-mock-provider";
 import { OIDCMockProvider } from "@mongodb-js/oidc-mock-provider";
 import { type TestConnectionManager } from "../../utils/index.js";
 
-const DEFAULT_TIMEOUT = 30_000;
+const DEFAULT_TIMEOUT = 60_000;
+const DEFAULT_RETRIES = 5;
 
 // OIDC is only supported on Linux servers
 describe.skipIf(process.platform !== "linux")("ConnectionManager OIDC Tests", async () => {
@@ -107,7 +108,7 @@ describe.skipIf(process.platform !== "linux")("ConnectionManager OIDC Tests", as
             (integration) => {
                 function oidcIt(name: string, cb: Parameters<OidcIt>[1]): void {
                     /* eslint-disable vitest/expect-expect */
-                    it(name, { timeout: DEFAULT_TIMEOUT, retry: 5 }, async (context) => {
+                    it(name, { timeout: DEFAULT_TIMEOUT, retry: DEFAULT_RETRIES }, async (context) => {
                         context.skip(
                             await isCommunityServer(integration),
                             "OIDC is not supported in MongoDB Community"


### PR DESCRIPTION
## Proposed changes

This adds a retry mechanism to OIDC tests in case the fail. It reuses the retry mechanism from vitest, which should also run fixtures.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
