### PR TITLE
chore: update release process documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ To release a new version of the MCP server, follow these steps:
    - NPM: https://www.npmjs.com/package/mongodb-mcp-server
    - Docker: https://hub.docker.com/r/mongodb/mongodb-mcp-server
    - MCP Registry: `curl "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.mongodb-js%2Fmongodb-mcp-server/versions/latest"`
-7. Close the Jira ticket for the release. 
+7. Close the Jira ticket for the release.
 8. Go to the [Releases](https://jira.mongodb.org/projects/MCP?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=released-unreleased) section the and rename the `vNext` to the new version number and mark it as Released. Create a new `vNext` for the next release.
 9. Post an update in the `#mongodb-mcp` Slack channel.
 


### PR DESCRIPTION
This uses the [wording from the mongosh release process](https://github.com/mongodb-js/mongosh/blob/c3c5abe9a826cf6bd2dd56a5701dfa59d3952c81/packages/build/README.md#L26) to better direct our process with Jira and publicizing our release.