### PR TITLE
chore: skip atlas tests in mongodb forks

### DIFF
--- a/.github/workflows/code-health-fork.yml
+++ b/.github/workflows/code-health-fork.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm test
         env:
           SKIP_ATLAS_TESTS: "true"
-          SKIP_ATLAS_LOCAL_TESTS: "true"        
+          SKIP_ATLAS_LOCAL_TESTS: "true"
       - name: Upload test results
         if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Proposed changes

- dependabot prs were failing because we were not properly skipping local tests 

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
