### PR TITLE
chore: fix perf advisor test

### DIFF
--- a/tests/integration/tools/atlas/performanceAdvisor.test.ts
+++ b/tests/integration/tools/atlas/performanceAdvisor.test.ts
@@ -247,7 +247,7 @@ describe("mocked atlas-get-performance-advisor", () => {
             },
         });
 
-        expect(response.isError).toBe(undefined);
+        expect(response.isError).toBeUndefined();
 
         const elements = getResponseElements(response.content);
         expect(elements).toHaveLength(2);


### PR DESCRIPTION
## Proposed changes
fixes perf advisor test that was checking for false `isError` but it's actually undefined

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
