### PR TITLE
chore: bump mongodb-redact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "lru-cache": "^11.1.0",
         "mongodb-connection-string-url": "^3.0.2",
         "mongodb-log-writer": "^2.4.1",
-        "mongodb-redact": "^1.2.0",
+        "mongodb-redact": "^1.3.0",
         "mongodb-schema": "^12.6.2",
         "node-fetch": "^3.3.2",
         "node-machine-id": "1.1.12",
@@ -10167,11 +10167,12 @@
       "optional": true
     },
     "node_modules/mongodb-redact": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-1.2.1.tgz",
-      "integrity": "sha512-waZV5KuNXSihjIu3mgewjAxhOejDRq7W4CEbd9eb5abpKIKxP4sZm29tOaxVoCsNYhicYm4Aw9aHNERCW8uIyQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-1.3.0.tgz",
+      "integrity": "sha512-6qMkQ9RnB7Z92G8c4mCkrDGaqwekuaUreaX+XnjAl/t3oKHJ+u7C+kfFLxSueJIBc1qtI4AtK0TO4yxOHyJqTw==",
       "license": "Apache-2.0",
       "dependencies": {
+        "mongodb-connection-string-url": "^3.0.1 || ^7.0.0",
         "regexp.escape": "^2.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "lru-cache": "^11.1.0",
     "mongodb-connection-string-url": "^3.0.2",
     "mongodb-log-writer": "^2.4.1",
-    "mongodb-redact": "^1.2.0",
+    "mongodb-redact": "^1.3.0",
     "mongodb-schema": "^12.6.2",
     "node-fetch": "^3.3.2",
     "node-machine-id": "1.1.12",


### PR DESCRIPTION
The new version of mongodb-redact fixes issues with credential redaction with special characters so it's good to bump this.

See https://github.com/mongodb-js/devtools-shared/pull/597 and https://github.com/mongodb-js/devtools-shared/pull/599,