### PR TITLE
fix: don't setup node in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,6 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
       - name: Get version
         id: get-version
         shell: bash


### PR DESCRIPTION
## Proposed changes

This was unnecessary as we don't install any packages and will now fail due to missing pnpm cache.