### PR TITLE
chore: pin Atlas image to working tag

### DIFF
--- a/tests/integration/tools/mongodb/create/createIndex.test.ts
+++ b/tests/integration/tools/mongodb/create/createIndex.test.ts
@@ -510,7 +510,7 @@ describeWithMongoDB(
                 expect(indexes).toHaveLength(1);
                 expect(indexes[0]?.name).toEqual("vector_1_vector");
                 expect(indexes[0]?.type).toEqual("vectorSearch");
-                expect(indexes[0]?.status).toEqual("PENDING");
+                expect(indexes[0]?.status).toEqual(expect.stringMatching(/PENDING|BUILDING/));
                 expect(indexes[0]?.queryable).toEqual(false);
                 expect(indexes[0]?.latestDefinition).toEqual({
                     fields: [

--- a/tests/integration/tools/mongodb/mongodbClusterProcess.ts
+++ b/tests/integration/tools/mongodb/mongodbClusterProcess.ts
@@ -16,7 +16,9 @@ export type MongoClusterConfiguration = MongoRunnerConfiguration | MongoSearchCo
 
 const DOWNLOAD_RETRIES = 10;
 
-const DEFAULT_LOCAL_IMAGE = "mongodb/mongodb-atlas-local:8";
+// TODO: Revert this to generic tag 8, once the problem with atlas-local image
+// is addressed.
+const DEFAULT_LOCAL_IMAGE = "mongodb/mongodb-atlas-local:8.2.2-20251125T154829Z";
 export class MongoDBClusterProcess {
     static async spinUp(config: MongoClusterConfiguration): Promise<MongoDBClusterProcess> {
         if (MongoDBClusterProcess.isSearchOptions(config)) {


### PR DESCRIPTION
## Proposed changes

This temporarily pins the Atlas image to a tag with which our tests were working fine.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
