### PR TITLE
fix: fixes vector stage input parsing for aggregate tool MCP-336

### DIFF
--- a/src/tools/mongodb/read/aggregate.ts
+++ b/src/tools/mongodb/read/aggregate.ts
@@ -43,7 +43,7 @@ const genericPipelineDescription = "An array of aggregation stages to execute.";
 export const getAggregateArgs = (vectorSearchEnabled: boolean) =>
     ({
         pipeline: z
-            .array(vectorSearchEnabled ? z.union([AnyAggregateStage, VectorSearchStage]) : AnyAggregateStage)
+            .array(vectorSearchEnabled ? z.union([VectorSearchStage, AnyAggregateStage]) : AnyAggregateStage)
             .describe(vectorSearchEnabled ? pipelineDescriptionWithVectorSearch : genericPipelineDescription),
         responseBytesLimit: z.number().optional().default(ONE_MB).describe(`\
 The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. \


### PR DESCRIPTION
## Proposed changes
Users were unable to use VectorSearch stage because Zod was using our catch all stage (AnyAggregateStage) before VectorSearchStage to parse and validate even the vector search stage input and it passed through because that schema is a catch all schema.

Because of that, in the input that we received, outputDimension was not transformed ever.

This commit changes the order of application of schema so that VectorSearchStage schema is validated first and then the catch all stage schema.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
