### PR TITLE
chore: extend accuracy tests

### DIFF
--- a/tests/accuracy/insertMany.test.ts
+++ b/tests/accuracy/insertMany.test.ts
@@ -1,6 +1,5 @@
 import { describeAccuracyTests } from "./sdk/describeAccuracyTests.js";
 import { Matcher } from "./sdk/matcher.js";
-import type { LLMToolCall } from "./sdk/accuracyResultStorage/resultStorage.js";
 
 // Generate documents with large descriptions to test payload splitting
 // Each document is ~12KB, so 10 docs = ~120KB which exceeds the 100KB HTTP limit

--- a/tests/accuracy/insertMany.test.ts
+++ b/tests/accuracy/insertMany.test.ts
@@ -1,5 +1,21 @@
 import { describeAccuracyTests } from "./sdk/describeAccuracyTests.js";
 import { Matcher } from "./sdk/matcher.js";
+import type { LLMToolCall } from "./sdk/accuracyResultStorage/resultStorage.js";
+
+// Generate documents with large descriptions to test payload splitting
+// Each document is ~12KB, so 10 docs = ~120KB which exceeds the 100KB HTTP limit
+function generateLargeDocuments(
+    count: number,
+    descriptionSize: number
+): Array<{ id: number; name: string; description: string }> {
+    return Array.from({ length: count }, (_, i) => ({
+        id: i + 1,
+        name: `user${i + 1}`,
+        description: "X".repeat(descriptionSize),
+    }));
+}
+
+const LARGE_DOCS = generateLargeDocuments(10, 12000); // 10 docs × ~12KB each = ~120KB total
 
 describeAccuracyTests([
     {
@@ -42,6 +58,40 @@ describeAccuracyTests([
                     collection: "movies",
                     documents: [{ _id: Matcher.anyValue }, { _id: Matcher.anyValue }, { _id: Matcher.anyValue }],
                 },
+            },
+        ],
+    },
+    {
+        prompt: [
+            "Insert the following documents into 'test.users'.",
+            "Here are the documents:",
+            JSON.stringify(LARGE_DOCS, null, 2),
+        ].join("\n"),
+        expectedToolCalls: [
+            {
+                toolName: "insert-many",
+                parameters: {
+                    database: "test",
+                    collection: "users",
+                    documents: Matcher.anyValue, // First batch
+                },
+            },
+            {
+                toolName: "insert-many",
+                parameters: {
+                    database: "test",
+                    collection: "users",
+                    documents: Matcher.anyValue, // Second batch
+                },
+            },
+            {
+                toolName: "insert-many",
+                parameters: {
+                    database: "test",
+                    collection: "users",
+                    documents: Matcher.anyValue, // Third batch (or more)
+                },
+                optional: true,
             },
         ],
     },


### PR DESCRIPTION
## Proposed changes
- add accuracy test to check that large files are proactively split in batches for the `insertMany` command

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
