### PR TITLE
chore: use latest MCP schema for MCP publish

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mongodb-js/mongodb-mcp-server",
   "description": "MongoDB Model Context Protocol Server",
   "repository": {


### PR DESCRIPTION
## Proposed changes
MCP registry released new version of schema and we were still using old version which led to failure [when publishing v1.4.0 to MCP registry](https://github.com/mongodb-js/mongodb-mcp-server/actions/runs/20747865917/job/59577397570).

This PR fixes that following the recommendation pointed out in the output of the mcp publish command.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
