### PR TITLE
fix: improve wording of count response to include info about the query MCP-352

### DIFF
--- a/src/tools/mongodb/read/count.ts
+++ b/src/tools/mongodb/read/count.ts
@@ -44,7 +44,7 @@ export class CountTool extends MongoDBToolBase {
         return {
             content: [
                 {
-                    text: `Found ${count} documents in the collection "${collection}"`,
+                    text: `Found ${count} documents in the collection "${collection}"${query ? " that matched the query" : ""}.`,
                     type: "text",
                 },
             ],

--- a/tests/integration/tools/mongodb/read/count.test.ts
+++ b/tests/integration/tools/mongodb/read/count.test.ts
@@ -40,7 +40,7 @@ describeWithMongoDB("count tool", (integration) => {
             arguments: { database: "non-existent", collection: "foos" },
         });
         const content = getResponseContent(response.content);
-        expect(content).toEqual('Found 0 documents in the collection "foos"');
+        expect(content).toEqual('Found 0 documents in the collection "foos".');
     });
 
     it("returns 0 when collection doesn't exist", async () => {
@@ -52,7 +52,7 @@ describeWithMongoDB("count tool", (integration) => {
             arguments: { database: integration.randomDbName(), collection: "non-existent" },
         });
         const content = getResponseContent(response.content);
-        expect(content).toEqual('Found 0 documents in the collection "non-existent"');
+        expect(content).toEqual('Found 0 documents in the collection "non-existent".');
     });
 
     describe("with existing database", () => {
@@ -83,7 +83,9 @@ describeWithMongoDB("count tool", (integration) => {
                 });
 
                 const content = getResponseContent(response.content);
-                expect(content).toEqual(`Found ${testCase.expectedCount} documents in the collection "foo"`);
+                expect(content).toEqual(
+                    `Found ${testCase.expectedCount} documents in the collection "foo"${testCase.filter ? " that matched the query" : ""}.`
+                );
             });
         }
     });
@@ -91,7 +93,7 @@ describeWithMongoDB("count tool", (integration) => {
     validateAutoConnectBehavior(integration, "count", () => {
         return {
             args: { database: integration.randomDbName(), collection: "coll1" },
-            expectedResponse: 'Found 0 documents in the collection "coll1"',
+            expectedResponse: 'Found 0 documents in the collection "coll1".',
         };
     });
 });


### PR DESCRIPTION
## Proposed changes

Tweaks the wording of `count` to indicate whether a query was applied or not.