### PR TITLE
chore: allow mongodb-connection-string-url to be 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "bson": "^6.10.4",
     "express": "^5.1.0",
     "lru-cache": "^11.1.0",
-    "mongodb-connection-string-url": "^7.0.0",
+    "mongodb-connection-string-url": "^3.0.1 || ^7.0.0",
     "mongodb-log-writer": "^2.4.1",
     "mongodb-redact": "^1.3.0",
     "mongodb-schema": "^12.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         specifier: ^11.1.0
         version: 11.2.4
       mongodb-connection-string-url:
-        specifier: ^7.0.0
+        specifier: ^3.0.1 || ^7.0.0
         version: 7.0.0
       mongodb-log-writer:
         specifier: ^2.4.1


### PR DESCRIPTION
This helps unblock Compass Assistant which is still on 3.0.1. Both versions should be largely the same despite the big "jump", `@mongodb-js/devtools-connect` uses the same conditional for this
