### PR TITLE
fix: ensure we don't log errors to console MCP-382

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Tests",
-      "runtimeExecutable": "npm",
+      "runtimeExecutable": "pnpm",
       "runtimeArgs": ["test"],
       "cwd": "${workspaceFolder}",
       "envFile": "${workspaceFolder}/.env"
@@ -25,7 +25,7 @@
       "request": "launch",
       "name": "Launch Program",
       "skipFiles": ["<node_internals>/**"],
-      "runtimeExecutable": "npm",
+      "runtimeExecutable": "pnpm",
       "runtimeArgs": ["start"],
       "preLaunchTask": "tsc: build - tsconfig.build.json",
       "outFiles": ["${workspaceFolder}/dist/**/*.js"]

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "dist"
   ],
   "scripts": {
-    "start": "node dist/index.js --transport http --loggers stderr mcp --previewFeatures search",
-    "start:stdio": "node dist/index.js --transport stdio --loggers stderr mcp",
+    "start": "node dist/index.js --transport http --loggers 'stderr, mcp' --previewFeatures search",
+    "start:stdio": "node dist/index.js --transport stdio --loggers 'stderr, mcp' --previewFeatures search",
     "prepare": "husky && pnpm run build",
     "build:update-package-version": "tsx scripts/updatePackageVersion.ts",
     "build:esm": "tsc --project tsconfig.esm.json && chmod +x dist/esm/index.js",

--- a/src/common/config/parseUserConfig.ts
+++ b/src/common/config/parseUserConfig.ts
@@ -173,6 +173,8 @@ function registerKnownSecretsInRootKeychain(userConfig: Partial<UserConfig>): vo
     maybeRegister(userConfig.tlsCertificateKeyFile, "url");
     maybeRegister(userConfig.tlsCertificateKeyFilePassword, "password");
     maybeRegister(userConfig.username, "user");
+    maybeRegister(userConfig.voyageApiKey, "password");
+    maybeRegister(userConfig.connectionString, "mongodb uri");
 }
 
 function getWarnings(config: Partial<UserConfig>, cliArguments: string[]): string[] {

--- a/src/server.ts
+++ b/src/server.ts
@@ -286,8 +286,6 @@ export class Server {
             try {
                 validateConnectionString(this.userConfig.connectionString, false);
             } catch (error) {
-                // eslint-disable-next-line no-console
-                console.error("Connection string validation failed with error: ", error);
                 throw new Error(
                     "Connection string validation failed with error: " +
                         (error instanceof Error ? error.message : String(error))
@@ -304,25 +302,16 @@ export class Server {
                 if (!this.userConfig.apiBaseUrl.startsWith("https://")) {
                     const message =
                         "Failed to validate MongoDB Atlas the credentials from config: apiBaseUrl must start with https://";
-                    // eslint-disable-next-line no-console
-                    console.error(message);
                     throw new Error(message);
                 }
 
                 await this.session.apiClient.validateAuthConfig();
             } catch (error) {
                 if (this.userConfig.connectionString === undefined) {
-                    // eslint-disable-next-line no-console
-                    console.error("Failed to validate MongoDB Atlas the credentials from the config: ", error);
-
                     throw new Error(
-                        "Failed to connect to MongoDB Atlas instance using the credentials from the config"
+                        `Failed to connect to MongoDB Atlas instance using the credentials from the config: ${error instanceof Error ? error.message : String(error)}`
                     );
                 }
-                // eslint-disable-next-line no-console
-                console.error(
-                    "Failed to validate MongoDB Atlas credentials from the config, but validated the connection string."
-                );
             }
         }
     }

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -12,6 +12,7 @@ import type { Secret } from "../../../src/common/keychain.js";
 import { createEnvironment } from "../../utils/index.js";
 import path from "path";
 import { TRANSPORT_PAYLOAD_LIMITS } from "../../../src/transports/constants.js";
+import { getConfigMeta } from "../../../src/common/config/configOverrides.js";
 
 // Expected hardcoded values (what we had before)
 const expectedDefaults = {
@@ -896,6 +897,20 @@ describe("keychain management", () => {
         it(`should register ${cliArg} as a secret of kind ${secretKind} in the root keychain`, () => {
             parseUserConfig({ args: [`--${cliArg}`, cliArg] });
             expect(keychain.allSecrets).toEqual([{ value: cliArg, kind: secretKind }]);
+        });
+    }
+
+    const secretsFromSchema = Object.keys(UserConfigSchema.shape).filter((key) => {
+        const meta = getConfigMeta(key as keyof UserConfig);
+        return meta?.isSecret === true;
+    });
+
+    for (const secretKey of secretsFromSchema) {
+        it(`should register ${secretKey} as a secret in the root keychain`, () => {
+            parseUserConfig({ args: [`--${secretKey}`, secretKey] });
+
+            const registeredSecret = keychain.allSecrets.find((s) => s.value === secretKey);
+            expect(registeredSecret).toBeDefined();
         });
     }
 });


### PR DESCRIPTION
## Proposed changes

This removes a few console statements which could leak internal details (e.g. the connection string upon validation failure). Additionally, it makes sure that we register config secrets correctly and adds a test to catch future regressions.