### PR TITLE
chore(ci): use oidc publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,8 +95,6 @@ jobs:
           pnpm run build
       - name: Publish to NPM
         run: pnpm publish --tag ${{ needs.check.outputs.RELEASE_CHANNEL }} --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish git release
         env:


### PR DESCRIPTION
## Proposed changes

Use [trusted publishing](https://docs.npmjs.com/trusted-publishers) instead of access tokens.