### PR TITLE
chore: refactors components composing StreamableHttpRunner into their own files and moves nested function to their own methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import { parseUserConfig } from "./common/config/parseUserConfig.js";
 import { type UserConfig } from "./common/config/userConfig.js";
 import { packageInfo } from "./common/packageInfo.js";
 import { StdioRunner } from "./transports/stdio.js";
-import { StreamableHttpRunner } from "./transports/streamableHttp.js";
+import { StreamableHttpRunner } from "./transports/streamableHttp/streamableHttpRunner.js";
 import { systemCA } from "@mongodb-js/devtools-proxy-support";
 import { Keychain } from "./common/keychain.js";
 import { DryRunModeRunner } from "./transports/dryModeRunner.js";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -32,7 +32,7 @@ export {
     type LogLevel,
     CompositeLogger,
 } from "./common/logging/index.js";
-export { StreamableHttpRunner } from "./transports/streamableHttp.js";
+export { StreamableHttpRunner } from "./transports/streamableHttp/streamableHttpRunner.js";
 export { StdioRunner } from "./transports/stdio.js";
 export {
     TransportRunnerBase,

--- a/src/transports/streamableHttp/httpServers/expressBasedHttpServer.ts
+++ b/src/transports/streamableHttp/httpServers/expressBasedHttpServer.ts
@@ -1,0 +1,97 @@
+import express from "express";
+import type http from "http";
+import { type LoggerBase, LogId } from "../../../common/logging/index.js";
+
+type ExpressConfig = {
+    port: number;
+    hostname: string;
+};
+
+export abstract class ExpressBasedHttpServer {
+    protected httpServer: http.Server | undefined;
+    protected app: express.Express;
+
+    protected readonly logger: LoggerBase;
+    protected readonly logContext: string;
+
+    protected readonly expressConfig: ExpressConfig;
+
+    constructor(config: { logger: LoggerBase; logContext: string } & ExpressConfig) {
+        this.app = express();
+        this.app.enable("trust proxy"); // needed for reverse proxy support
+        this.expressConfig = { port: config.port, hostname: config.hostname };
+
+        this.logger = config.logger;
+        this.logContext = config.logContext;
+    }
+
+    public get serverAddress(): string {
+        const result = this.httpServer?.address();
+        if (typeof result === "string") {
+            return result;
+        }
+        if (typeof result === "object" && result) {
+            return `http://${result.address}:${result.port}`;
+        }
+
+        throw new Error("Server is not started yet");
+    }
+
+    protected abstract setupRoutes(): Promise<void>;
+
+    public async start(): Promise<void> {
+        await this.setupRoutes();
+
+        const { port, hostname } = this.expressConfig;
+
+        this.httpServer = await new Promise<http.Server>((resolve, reject) => {
+            const result = this.app.listen(port, hostname, (err?: Error) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(result);
+                }
+            });
+        });
+
+        this.logger.info({
+            message: `Http server started on address: ${this.serverAddress}`,
+            context: this.logContext,
+            noRedaction: true,
+            id: LogId.httpServerStarted,
+        });
+    }
+
+    public async stop(): Promise<void> {
+        if (this.httpServer) {
+            this.logger.info({
+                message: "Stopping server...",
+                context: this.logContext,
+                id: LogId.httpServerStopping,
+            });
+
+            const server = this.httpServer;
+
+            await new Promise((resolve, reject) => {
+                server.close((err?: Error) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(undefined);
+                    }
+                });
+            });
+            this.logger.info({
+                message: "Server stopped",
+                context: this.logContext,
+                id: LogId.httpServerStopped,
+            });
+        } else {
+            this.logger.info({
+                message: "Server is not running",
+                context: this.logContext,
+                id: LogId.httpServerStopped,
+            });
+        }
+    }
+}

--- a/src/transports/streamableHttp/httpServers/healthCheckServer.ts
+++ b/src/transports/streamableHttp/httpServers/healthCheckServer.ts
@@ -1,0 +1,24 @@
+import type express from "express";
+import { ExpressBasedHttpServer } from "./expressBasedHttpServer.js";
+import { type LoggerBase } from "../../../common/logging/index.js";
+
+export class HealthCheckServer extends ExpressBasedHttpServer {
+    constructor(healthCheckHost: string, healthCheckPort: number, logger: LoggerBase) {
+        super({
+            port: healthCheckPort,
+            hostname: healthCheckHost,
+            logger,
+            logContext: "healthCheckServer",
+        });
+    }
+
+    protected override setupRoutes(): Promise<void> {
+        this.app.get("/health", (_req: express.Request, res: express.Response) => {
+            res.json({
+                status: "ok",
+            });
+        });
+
+        return Promise.resolve();
+    }
+}

--- a/src/transports/streamableHttp/httpServers/mcpHttpServer.ts
+++ b/src/transports/streamableHttp/httpServers/mcpHttpServer.ts
@@ -66,9 +66,8 @@ export class MCPHttpServer<
         await Promise.all([this.sessionStore.closeAllSessions(), super.stop()]);
     }
 
+    // eslint-disable-next-line @typescript-eslint/require-await
     protected override async setupRoutes(): Promise<void> {
-        const { StreamableHTTPServerTransport } = await import("@modelcontextprotocol/sdk/server/streamableHttp.js");
-
         this.sessionStore = new SessionStore(
             this.userConfig.idleTimeoutMs,
             this.userConfig.notificationTimeoutMs,
@@ -88,201 +87,12 @@ export class MCPHttpServer<
             next();
         });
 
-        const reportSessionError = (res: express.Response, errorCode: number): void => {
-            let message: string;
-            let statusCode = 400;
-
-            switch (errorCode) {
-                case JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED:
-                    message = "session id is required";
-                    break;
-                case JSON_RPC_ERROR_CODE_SESSION_ID_INVALID:
-                    message = "session id is invalid";
-                    break;
-                case JSON_RPC_ERROR_CODE_INVALID_REQUEST:
-                    message = "invalid request";
-                    break;
-                case JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND:
-                    message = "session not found";
-                    statusCode = 404;
-                    break;
-                case JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION:
-                    message = "cannot provide sessionId when externally managed sessions are disabled";
-                    break;
-                default:
-                    message = "unknown error";
-                    statusCode = 500;
-            }
-            res.status(statusCode).json({
-                jsonrpc: "2.0",
-                error: {
-                    code: errorCode,
-                    message,
-                },
-            });
-        };
-
-        const handleSessionRequest = async (req: express.Request, res: express.Response): Promise<void> => {
-            const sessionId = req.headers["mcp-session-id"];
-            if (!sessionId) {
-                return reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED);
-            }
-
-            if (typeof sessionId !== "string") {
-                return reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_INVALID);
-            }
-
-            const transport = this.sessionStore.getSession(sessionId);
-            if (!transport) {
-                if (this.userConfig.externallyManagedSessions) {
-                    this.logger.debug({
-                        id: LogId.streamableHttpTransportSessionNotFound,
-                        context: "streamableHttpTransport",
-                        message: `Session with ID ${sessionId} not found, initializing new session`,
-                    });
-
-                    return await initializeServer(req, res, { sessionId, isImplicitInitialization: true });
-                }
-
-                this.logger.debug({
-                    id: LogId.streamableHttpTransportSessionNotFound,
-                    context: "streamableHttpTransport",
-                    message: `Session with ID ${sessionId} not found`,
-                });
-
-                return reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND);
-            }
-
-            await transport.handleRequest(req, res, req.body);
-        };
-
-        /**
-         * Initializes a new server and session. This can be done either explicitly via an initialize request
-         * or implicitly when externally managed sessions are enabled and a request is received for a session
-         * that does not exist.
-         */
-        const initializeServer = async (
-            req: express.Request,
-            res: express.Response,
-            {
-                sessionId,
-                isImplicitInitialization,
-            }:
-                | { sessionId?: string; isImplicitInitialization?: false }
-                | { sessionId: string; isImplicitInitialization: true }
-        ): Promise<void> => {
-            if (isImplicitInitialization && !sessionId) {
-                throw new Error("Implicit initialization requires externally-passed sessionId");
-            }
-
-            const request: RequestContext = {
-                headers: req.headers as Record<string, string | string[] | undefined>,
-                query: req.query as Record<string, string | string[] | undefined>,
-            };
-            const server = await this.createServerForRequest({
-                request,
-                serverOptions: this.serverOptions,
-                sessionOptions: this.sessionOptions,
-            });
-
-            const options: WebStandardStreamableHTTPServerTransportOptions = {
-                enableJsonResponse: this.userConfig.httpResponseType === "json",
-            };
-
-            const sessionInitialized = (sessionId: string): void => {
-                server.session.logger.setAttribute("sessionId", sessionId);
-
-                this.sessionStore.setSession(sessionId, transport, server.session.logger);
-                server.session.logger.info({
-                    id: LogId.streamableHttpTransportSessionInitialized,
-                    context: "streamableHttpTransport",
-                    message: `Session ${sessionId} initialized, response type: ${options.enableJsonResponse ? "JSON" : "SSE"}`,
-                });
-            };
-
-            // When we're implicitly initializing a session, the client is not going through the initialization
-            // flow. This means that it won't do proper session lifecycle management, so we should not add hooks for
-            // onsessioninitialized and onsessionclosed.
-            if (!isImplicitInitialization) {
-                options.sessionIdGenerator = (): string => sessionId ?? getRandomUUID();
-                options.onsessioninitialized = sessionInitialized.bind(this);
-                options.onsessionclosed = async (sessionId): Promise<void> => {
-                    try {
-                        await this.sessionStore.closeSession(sessionId, false);
-                    } catch (error) {
-                        this.logger.error({
-                            id: LogId.streamableHttpTransportSessionCloseFailure,
-                            context: "streamableHttpTransport",
-                            message: `Error closing session ${sessionId}: ${error instanceof Error ? error.message : String(error)}`,
-                        });
-                    }
-                };
-            }
-
-            const transport = new StreamableHTTPServerTransport(options);
-
-            if (isImplicitInitialization) {
-                sessionInitialized(sessionId);
-            }
-
-            let failedPings = 0;
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            const keepAliveLoop: NodeJS.Timeout = setInterval(async () => {
-                try {
-                    server.session.logger.debug({
-                        id: LogId.streamableHttpTransportKeepAlive,
-                        context: "streamableHttpTransport",
-                        message: "Sending ping",
-                    });
-
-                    await transport.send({
-                        jsonrpc: "2.0",
-                        method: "ping",
-                    });
-                    failedPings = 0;
-                } catch (err) {
-                    try {
-                        failedPings++;
-                        server.session.logger.warning({
-                            id: LogId.streamableHttpTransportKeepAliveFailure,
-                            context: "streamableHttpTransport",
-                            message: `Error sending ping (attempt #${failedPings}): ${err instanceof Error ? err.message : String(err)}`,
-                        });
-
-                        if (failedPings > 3) {
-                            clearInterval(keepAliveLoop);
-                            await transport.close();
-                        }
-                    } catch {
-                        // Ignore the error of the transport close as there's nothing else
-                        // we can do at this point.
-                    }
-                }
-            }, 30_000);
-
-            transport.onclose = (): void => {
-                clearInterval(keepAliveLoop);
-
-                server.close().catch((error) => {
-                    this.logger.error({
-                        id: LogId.streamableHttpTransportCloseFailure,
-                        context: "streamableHttpTransport",
-                        message: `Error closing server: ${error instanceof Error ? error.message : String(error)}`,
-                    });
-                });
-            };
-
-            await server.connect(transport);
-
-            await transport.handleRequest(req, res, req.body);
-        };
-
         this.app.post(
             "/mcp",
             this.withErrorHandling(async (req: express.Request, res: express.Response) => {
                 const sessionId = req.headers["mcp-session-id"];
                 if (sessionId && typeof sessionId !== "string") {
-                    return reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_INVALID);
+                    return this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_INVALID);
                 }
 
                 if (isInitializeRequest(req.body)) {
@@ -293,22 +103,212 @@ export class MCPHttpServer<
                             message: `Client provided session ID ${sessionId}, but externallyManagedSessions is disabled`,
                         });
 
-                        return reportSessionError(res, JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION);
+                        return this.reportSessionError(res, JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION);
                     }
 
-                    return await initializeServer(req, res, { sessionId });
+                    return await this.initializeServer(req, res, { sessionId });
                 }
 
                 if (sessionId) {
-                    return await handleSessionRequest(req, res);
+                    return await this.handleSessionRequest(req, res);
                 }
 
-                return reportSessionError(res, JSON_RPC_ERROR_CODE_INVALID_REQUEST);
+                return this.reportSessionError(res, JSON_RPC_ERROR_CODE_INVALID_REQUEST);
             })
         );
 
-        this.app.get("/mcp", this.withErrorHandling(handleSessionRequest));
-        this.app.delete("/mcp", this.withErrorHandling(handleSessionRequest));
+        this.app.get("/mcp", this.withErrorHandling(this.handleSessionRequest.bind(this)));
+        this.app.delete("/mcp", this.withErrorHandling(this.handleSessionRequest.bind(this)));
+    }
+
+    private reportSessionError(res: express.Response, errorCode: number): void {
+        let message: string;
+        let statusCode = 400;
+
+        switch (errorCode) {
+            case JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED:
+                message = "session id is required";
+                break;
+            case JSON_RPC_ERROR_CODE_SESSION_ID_INVALID:
+                message = "session id is invalid";
+                break;
+            case JSON_RPC_ERROR_CODE_INVALID_REQUEST:
+                message = "invalid request";
+                break;
+            case JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND:
+                message = "session not found";
+                statusCode = 404;
+                break;
+            case JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION:
+                message = "cannot provide sessionId when externally managed sessions are disabled";
+                break;
+            default:
+                message = "unknown error";
+                statusCode = 500;
+        }
+        res.status(statusCode).json({
+            jsonrpc: "2.0",
+            error: {
+                code: errorCode,
+                message,
+            },
+        });
+    }
+
+    private async handleSessionRequest(req: express.Request, res: express.Response): Promise<void> {
+        const sessionId = req.headers["mcp-session-id"];
+        if (!sessionId) {
+            return this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED);
+        }
+
+        if (typeof sessionId !== "string") {
+            return this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_INVALID);
+        }
+
+        const transport = this.sessionStore.getSession(sessionId);
+        if (!transport) {
+            if (this.userConfig.externallyManagedSessions) {
+                this.logger.debug({
+                    id: LogId.streamableHttpTransportSessionNotFound,
+                    context: "streamableHttpTransport",
+                    message: `Session with ID ${sessionId} not found, initializing new session`,
+                });
+
+                return await this.initializeServer(req, res, { sessionId, isImplicitInitialization: true });
+            }
+
+            this.logger.debug({
+                id: LogId.streamableHttpTransportSessionNotFound,
+                context: "streamableHttpTransport",
+                message: `Session with ID ${sessionId} not found`,
+            });
+
+            return this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND);
+        }
+
+        await transport.handleRequest(req, res, req.body);
+    }
+
+    /**
+     * Initializes a new server and session. This can be done either explicitly via an initialize request
+     * or implicitly when externally managed sessions are enabled and a request is received for a session
+     * that does not exist.
+     */
+    private async initializeServer(
+        req: express.Request,
+        res: express.Response,
+        {
+            sessionId,
+            isImplicitInitialization,
+        }:
+            | { sessionId?: string; isImplicitInitialization?: false }
+            | { sessionId: string; isImplicitInitialization: true }
+    ): Promise<void> {
+        const { StreamableHTTPServerTransport } = await import("@modelcontextprotocol/sdk/server/streamableHttp.js");
+        if (isImplicitInitialization && !sessionId) {
+            throw new Error("Implicit initialization requires externally-passed sessionId");
+        }
+
+        const request: RequestContext = {
+            headers: req.headers as Record<string, string | string[] | undefined>,
+            query: req.query as Record<string, string | string[] | undefined>,
+        };
+        const server = await this.createServerForRequest({
+            request,
+            serverOptions: this.serverOptions,
+            sessionOptions: this.sessionOptions,
+        });
+
+        const options: WebStandardStreamableHTTPServerTransportOptions = {
+            enableJsonResponse: this.userConfig.httpResponseType === "json",
+        };
+
+        const sessionInitialized = (sessionId: string): void => {
+            server.session.logger.setAttribute("sessionId", sessionId);
+
+            this.sessionStore.setSession(sessionId, transport, server.session.logger);
+            server.session.logger.info({
+                id: LogId.streamableHttpTransportSessionInitialized,
+                context: "streamableHttpTransport",
+                message: `Session ${sessionId} initialized, response type: ${options.enableJsonResponse ? "JSON" : "SSE"}`,
+            });
+        };
+
+        // When we're implicitly initializing a session, the client is not going through the initialization
+        // flow. This means that it won't do proper session lifecycle management, so we should not add hooks for
+        // onsessioninitialized and onsessionclosed.
+        if (!isImplicitInitialization) {
+            options.sessionIdGenerator = (): string => sessionId ?? getRandomUUID();
+            options.onsessioninitialized = sessionInitialized.bind(this);
+            options.onsessionclosed = async (sessionId): Promise<void> => {
+                try {
+                    await this.sessionStore.closeSession(sessionId, false);
+                } catch (error) {
+                    this.logger.error({
+                        id: LogId.streamableHttpTransportSessionCloseFailure,
+                        context: "streamableHttpTransport",
+                        message: `Error closing session ${sessionId}: ${error instanceof Error ? error.message : String(error)}`,
+                    });
+                }
+            };
+        }
+
+        const transport = new StreamableHTTPServerTransport(options);
+
+        if (isImplicitInitialization) {
+            sessionInitialized(sessionId);
+        }
+
+        let failedPings = 0;
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        const keepAliveLoop: NodeJS.Timeout = setInterval(async () => {
+            try {
+                server.session.logger.debug({
+                    id: LogId.streamableHttpTransportKeepAlive,
+                    context: "streamableHttpTransport",
+                    message: "Sending ping",
+                });
+
+                await transport.send({
+                    jsonrpc: "2.0",
+                    method: "ping",
+                });
+                failedPings = 0;
+            } catch (err) {
+                try {
+                    failedPings++;
+                    server.session.logger.warning({
+                        id: LogId.streamableHttpTransportKeepAliveFailure,
+                        context: "streamableHttpTransport",
+                        message: `Error sending ping (attempt #${failedPings}): ${err instanceof Error ? err.message : String(err)}`,
+                    });
+
+                    if (failedPings > 3) {
+                        clearInterval(keepAliveLoop);
+                        await transport.close();
+                    }
+                } catch {
+                    // Ignore the error of the transport close as there's nothing else
+                    // we can do at this point.
+                }
+            }
+        }, 30_000);
+
+        transport.onclose = (): void => {
+            clearInterval(keepAliveLoop);
+
+            server.close().catch((error) => {
+                this.logger.error({
+                    id: LogId.streamableHttpTransportCloseFailure,
+                    context: "streamableHttpTransport",
+                    message: `Error closing server: ${error instanceof Error ? error.message : String(error)}`,
+                });
+            });
+        };
+
+        await server.connect(transport);
+
+        await transport.handleRequest(req, res, req.body);
     }
 
     private withErrorHandling(

--- a/src/transports/streamableHttp/httpServers/mcpHttpServer.ts
+++ b/src/transports/streamableHttp/httpServers/mcpHttpServer.ts
@@ -1,20 +1,16 @@
 import express from "express";
-import type http from "http";
-import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
-import type { LoggerBase } from "../common/logging/index.js";
-import { CompositeLogger, LogId } from "../common/logging/index.js";
-import { SessionStore } from "../common/sessionStore.js";
-import {
-    TransportRunnerBase,
-    type TransportRunnerConfig,
-    type RequestContext,
-    type CustomizableSessionOptions,
-} from "./base.js";
-import { getRandomUUID } from "../helpers/getRandomUUID.js";
-import type { CustomizableServerOptions, Server, UserConfig } from "../lib.js";
+import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { WebStandardStreamableHTTPServerTransportOptions } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import { applyConfigOverrides } from "../common/config/configOverrides.js";
+
+import type { Server } from "../../../server.js";
+import { SessionStore } from "../../../common/sessionStore.js";
+import { getRandomUUID } from "../../../helpers/getRandomUUID.js";
+import { ExpressBasedHttpServer } from "./expressBasedHttpServer.js";
+import type { UserConfig } from "../../../common/config/userConfig.js";
+import { type LoggerBase, LogId } from "../../../common/logging/index.js";
+import type { CustomizableServerOptions, CustomizableSessionOptions, RequestContext } from "../../base.js";
+
 const JSON_RPC_ERROR_CODE_PROCESSING_REQUEST_FAILED = -32000;
 const JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED = -32001;
 const JSON_RPC_ERROR_CODE_SESSION_ID_INVALID = -32002;
@@ -22,262 +18,10 @@ const JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND = -32003;
 const JSON_RPC_ERROR_CODE_INVALID_REQUEST = -32004;
 const JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION = -32005;
 
-export class StreamableHttpRunner<
+export class MCPHttpServer<
     TUserConfig extends UserConfig = UserConfig,
     TContext = unknown,
-> extends TransportRunnerBase<TUserConfig, TContext> {
-    private mcpServer: MCPHttpServer<TUserConfig, TContext> | undefined;
-    private healthCheckServer: HealthCheckServer | undefined;
-
-    constructor(config: TransportRunnerConfig<TUserConfig>) {
-        super(config);
-    }
-
-    /** Starts the transport runner. */
-    async start({
-        serverOptions,
-        sessionOptions,
-    }: {
-        /** Server options to use when creating the server. */
-        serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
-        /** Session options to use when creating the session. */
-        sessionOptions?: CustomizableSessionOptions<TUserConfig>;
-    } = {}): Promise<void> {
-        this.validateConfig();
-
-        await this.startMCPServer({ serverOptions, sessionOptions });
-        await this.startHealthCheckServer();
-
-        this.logger.info({
-            message: "Streamable HTTP Transport started",
-            context: "streamableHttpTransport",
-            id: LogId.streamableHttpTransportStarted,
-        });
-    }
-
-    async closeTransport(): Promise<void> {
-        await Promise.all([this.mcpServer?.stop(), this.healthCheckServer?.stop()]);
-    }
-
-    private shouldWarnAboutHttpHost(httpHost: string): boolean {
-        const host = httpHost.trim();
-        const safeHosts = new Set(["127.0.0.1", "localhost", "::1"]);
-        return host === "0.0.0.0" || host === "::" || (!safeHosts.has(host) && host !== "");
-    }
-
-    /**
-     * Creates a new MCP server instance for a given request.
-     */
-    protected async createServerForRequest({
-        request,
-        serverOptions,
-        sessionOptions,
-    }: {
-        request: RequestContext;
-        /** Upstream `serverOptions` passed from running `runner.start({ serverOptions })` method */
-        serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
-        /** Upstream `sessionOptions` passed from running `runner.start({ sessionOptions })` method */
-        sessionOptions?: CustomizableSessionOptions<TUserConfig>;
-    }): Promise<Server<TUserConfig, TContext>> {
-        let userConfig: TUserConfig = sessionOptions?.userConfig ?? this.userConfig;
-
-        if (this.createSessionConfig) {
-            userConfig = await this.createSessionConfig({ userConfig, request });
-        } else {
-            userConfig = applyConfigOverrides({ baseConfig: userConfig, request });
-        }
-
-        const logger = new CompositeLogger(this.logger);
-
-        return this.createServer({
-            userConfig,
-            logger,
-            serverOptions: {
-                tools: this.tools,
-                ...serverOptions,
-            },
-            sessionOptions: {
-                ...sessionOptions,
-                connectionErrorHandler: sessionOptions?.connectionErrorHandler ?? this.connectionErrorHandler,
-                connectionManager:
-                    sessionOptions?.connectionManager ??
-                    (await this.createConnectionManager({
-                        logger,
-                        deviceId: this.deviceId,
-                        userConfig,
-                    })),
-                atlasLocalClient: sessionOptions?.atlasLocalClient ?? (await this.createAtlasLocalClient({ logger })),
-                apiClient:
-                    sessionOptions?.apiClient ??
-                    (userConfig.apiClientId && userConfig.apiClientSecret
-                        ? this.createApiClient(
-                              {
-                                  baseUrl: userConfig.apiBaseUrl,
-                                  credentials: {
-                                      clientId: userConfig.apiClientId,
-                                      clientSecret: userConfig.apiClientSecret,
-                                  },
-                                  requestContext: request,
-                              },
-                              logger
-                          )
-                        : undefined),
-            },
-        });
-    }
-
-    private async startMCPServer({
-        serverOptions,
-        sessionOptions,
-    }: {
-        serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
-        sessionOptions?: CustomizableSessionOptions<TUserConfig>;
-    }): Promise<void> {
-        this.mcpServer = new MCPHttpServer<TUserConfig, TContext>({
-            userConfig: this.userConfig,
-            serverOptions,
-            sessionOptions,
-            createServerForRequest: ({
-                request,
-                serverOptions: requestServerOptions,
-                sessionOptions: requestSessionOptions,
-            }): Promise<Server<TUserConfig, TContext>> =>
-                this.createServerForRequest({
-                    request,
-                    serverOptions: requestServerOptions,
-                    sessionOptions: requestSessionOptions,
-                }),
-            logger: this.logger,
-        });
-        await this.mcpServer.start();
-    }
-
-    private async startHealthCheckServer(): Promise<void> {
-        const { healthCheckHost, healthCheckPort } = this.userConfig;
-        if (healthCheckHost && healthCheckPort !== undefined) {
-            this.healthCheckServer = new HealthCheckServer(healthCheckHost, healthCheckPort, this.logger);
-
-            await this.healthCheckServer.start();
-        }
-    }
-
-    private validateConfig(): void {
-        if ((this.userConfig.healthCheckHost === undefined) !== (this.userConfig.healthCheckPort === undefined)) {
-            throw new Error("Both healthCheckHost and healthCheckPort must be defined to enable health checks.");
-        }
-
-        if (this.userConfig.healthCheckHost !== undefined && this.userConfig.healthCheckPort !== undefined) {
-            if (this.userConfig.healthCheckPort === this.userConfig.httpPort && this.userConfig.healthCheckPort !== 0) {
-                throw new Error("healthCheckPort cannot be the same as httpPort.");
-            }
-        }
-
-        if (this.shouldWarnAboutHttpHost(this.userConfig.httpHost)) {
-            this.logger.warning({
-                id: LogId.streamableHttpTransportHttpHostWarning,
-                context: "streamableHttpTransport",
-                message: `Binding to ${this.userConfig.httpHost} can expose the MCP Server to the entire local network, which allows other devices on the same network to potentially access the MCP Server. This is a security risk and could allow unauthorized access to your database context.`,
-                noRedaction: true,
-            });
-        }
-    }
-}
-
-type ExpressConfig = {
-    port: number;
-    hostname: string;
-};
-
-abstract class ExpressBasedHttpServer {
-    protected httpServer: http.Server | undefined;
-    protected app: express.Express;
-
-    protected readonly logger: LoggerBase;
-    protected readonly logContext: string;
-
-    protected readonly expressConfig: ExpressConfig;
-
-    constructor(config: { logger: LoggerBase; logContext: string } & ExpressConfig) {
-        this.app = express();
-        this.app.enable("trust proxy"); // needed for reverse proxy support
-        this.expressConfig = { port: config.port, hostname: config.hostname };
-
-        this.logger = config.logger;
-        this.logContext = config.logContext;
-    }
-
-    public get serverAddress(): string {
-        const result = this.httpServer?.address();
-        if (typeof result === "string") {
-            return result;
-        }
-        if (typeof result === "object" && result) {
-            return `http://${result.address}:${result.port}`;
-        }
-
-        throw new Error("Server is not started yet");
-    }
-
-    protected abstract setupRoutes(): Promise<void>;
-
-    public async start(): Promise<void> {
-        await this.setupRoutes();
-
-        const { port, hostname } = this.expressConfig;
-
-        this.httpServer = await new Promise<http.Server>((resolve, reject) => {
-            const result = this.app.listen(port, hostname, (err?: Error) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(result);
-                }
-            });
-        });
-
-        this.logger.info({
-            message: `Http server started on address: ${this.serverAddress}`,
-            context: this.logContext,
-            noRedaction: true,
-            id: LogId.httpServerStarted,
-        });
-    }
-
-    public async stop(): Promise<void> {
-        if (this.httpServer) {
-            this.logger.info({
-                message: "Stopping server...",
-                context: this.logContext,
-                id: LogId.httpServerStopping,
-            });
-
-            const server = this.httpServer;
-
-            await new Promise((resolve, reject) => {
-                server.close((err?: Error) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(undefined);
-                    }
-                });
-            });
-            this.logger.info({
-                message: "Server stopped",
-                context: this.logContext,
-                id: LogId.httpServerStopped,
-            });
-        } else {
-            this.logger.info({
-                message: "Server is not running",
-                context: this.logContext,
-                id: LogId.httpServerStopped,
-            });
-        }
-    }
-}
-
-class MCPHttpServer<TUserConfig extends UserConfig = UserConfig, TContext = unknown> extends ExpressBasedHttpServer {
+> extends ExpressBasedHttpServer {
     private sessionStore!: SessionStore<StreamableHTTPServerTransport>;
     private serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
     private sessionOptions?: CustomizableSessionOptions<TUserConfig>;
@@ -587,26 +331,5 @@ class MCPHttpServer<TUserConfig extends UserConfig = UserConfig, TContext = unkn
                 });
             });
         };
-    }
-}
-
-class HealthCheckServer extends ExpressBasedHttpServer {
-    constructor(healthCheckHost: string, healthCheckPort: number, logger: LoggerBase) {
-        super({
-            port: healthCheckPort,
-            hostname: healthCheckHost,
-            logger,
-            logContext: "healthCheckServer",
-        });
-    }
-
-    protected override setupRoutes(): Promise<void> {
-        this.app.get("/health", (_req: express.Request, res: express.Response) => {
-            res.json({
-                status: "ok",
-            });
-        });
-
-        return Promise.resolve();
     }
 }

--- a/src/transports/streamableHttp/streamableHttpRunner.ts
+++ b/src/transports/streamableHttp/streamableHttpRunner.ts
@@ -1,0 +1,172 @@
+import { CompositeLogger, LogId } from "../../common/logging/index.js";
+import {
+    TransportRunnerBase,
+    type TransportRunnerConfig,
+    type RequestContext,
+    type CustomizableSessionOptions,
+} from "../base.js";
+import type { CustomizableServerOptions, Server, UserConfig } from "../../lib.js";
+import { applyConfigOverrides } from "../../common/config/configOverrides.js";
+import { HealthCheckServer } from "./httpServers/healthCheckServer.js";
+import { MCPHttpServer } from "./httpServers/mcpHttpServer.js";
+
+export class StreamableHttpRunner<
+    TUserConfig extends UserConfig = UserConfig,
+    TContext = unknown,
+> extends TransportRunnerBase<TUserConfig, TContext> {
+    private mcpServer: MCPHttpServer<TUserConfig, TContext> | undefined;
+    private healthCheckServer: HealthCheckServer | undefined;
+
+    constructor(config: TransportRunnerConfig<TUserConfig>) {
+        super(config);
+    }
+
+    /** Starts the transport runner. */
+    async start({
+        serverOptions,
+        sessionOptions,
+    }: {
+        /** Server options to use when creating the server. */
+        serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
+        /** Session options to use when creating the session. */
+        sessionOptions?: CustomizableSessionOptions<TUserConfig>;
+    } = {}): Promise<void> {
+        this.validateConfig();
+
+        await this.startMCPServer({ serverOptions, sessionOptions });
+        await this.startHealthCheckServer();
+
+        this.logger.info({
+            message: "Streamable HTTP Transport started",
+            context: "streamableHttpTransport",
+            id: LogId.streamableHttpTransportStarted,
+        });
+    }
+
+    async closeTransport(): Promise<void> {
+        await Promise.all([this.mcpServer?.stop(), this.healthCheckServer?.stop()]);
+    }
+
+    private shouldWarnAboutHttpHost(httpHost: string): boolean {
+        const host = httpHost.trim();
+        const safeHosts = new Set(["127.0.0.1", "localhost", "::1"]);
+        return host === "0.0.0.0" || host === "::" || (!safeHosts.has(host) && host !== "");
+    }
+
+    /**
+     * Creates a new MCP server instance for a given request.
+     */
+    protected async createServerForRequest({
+        request,
+        serverOptions,
+        sessionOptions,
+    }: {
+        request: RequestContext;
+        /** Upstream `serverOptions` passed from running `runner.start({ serverOptions })` method */
+        serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
+        /** Upstream `sessionOptions` passed from running `runner.start({ sessionOptions })` method */
+        sessionOptions?: CustomizableSessionOptions<TUserConfig>;
+    }): Promise<Server<TUserConfig, TContext>> {
+        let userConfig: TUserConfig = sessionOptions?.userConfig ?? this.userConfig;
+
+        if (this.createSessionConfig) {
+            userConfig = await this.createSessionConfig({ userConfig, request });
+        } else {
+            userConfig = applyConfigOverrides({ baseConfig: userConfig, request });
+        }
+
+        const logger = new CompositeLogger(this.logger);
+
+        return this.createServer({
+            userConfig,
+            logger,
+            serverOptions: {
+                tools: this.tools,
+                ...serverOptions,
+            },
+            sessionOptions: {
+                ...sessionOptions,
+                connectionErrorHandler: sessionOptions?.connectionErrorHandler ?? this.connectionErrorHandler,
+                connectionManager:
+                    sessionOptions?.connectionManager ??
+                    (await this.createConnectionManager({
+                        logger,
+                        deviceId: this.deviceId,
+                        userConfig,
+                    })),
+                atlasLocalClient: sessionOptions?.atlasLocalClient ?? (await this.createAtlasLocalClient({ logger })),
+                apiClient:
+                    sessionOptions?.apiClient ??
+                    (userConfig.apiClientId && userConfig.apiClientSecret
+                        ? this.createApiClient(
+                              {
+                                  baseUrl: userConfig.apiBaseUrl,
+                                  credentials: {
+                                      clientId: userConfig.apiClientId,
+                                      clientSecret: userConfig.apiClientSecret,
+                                  },
+                                  requestContext: request,
+                              },
+                              logger
+                          )
+                        : undefined),
+            },
+        });
+    }
+
+    private async startMCPServer({
+        serverOptions,
+        sessionOptions,
+    }: {
+        serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
+        sessionOptions?: CustomizableSessionOptions<TUserConfig>;
+    }): Promise<void> {
+        this.mcpServer = new MCPHttpServer<TUserConfig, TContext>({
+            userConfig: this.userConfig,
+            serverOptions,
+            sessionOptions,
+            createServerForRequest: ({
+                request,
+                serverOptions: requestServerOptions,
+                sessionOptions: requestSessionOptions,
+            }): Promise<Server<TUserConfig, TContext>> =>
+                this.createServerForRequest({
+                    request,
+                    serverOptions: requestServerOptions,
+                    sessionOptions: requestSessionOptions,
+                }),
+            logger: this.logger,
+        });
+        await this.mcpServer.start();
+    }
+
+    private async startHealthCheckServer(): Promise<void> {
+        const { healthCheckHost, healthCheckPort } = this.userConfig;
+        if (healthCheckHost && healthCheckPort !== undefined) {
+            this.healthCheckServer = new HealthCheckServer(healthCheckHost, healthCheckPort, this.logger);
+
+            await this.healthCheckServer.start();
+        }
+    }
+
+    private validateConfig(): void {
+        if ((this.userConfig.healthCheckHost === undefined) !== (this.userConfig.healthCheckPort === undefined)) {
+            throw new Error("Both healthCheckHost and healthCheckPort must be defined to enable health checks.");
+        }
+
+        if (this.userConfig.healthCheckHost !== undefined && this.userConfig.healthCheckPort !== undefined) {
+            if (this.userConfig.healthCheckPort === this.userConfig.httpPort && this.userConfig.healthCheckPort !== 0) {
+                throw new Error("healthCheckPort cannot be the same as httpPort.");
+            }
+        }
+
+        if (this.shouldWarnAboutHttpHost(this.userConfig.httpHost)) {
+            this.logger.warning({
+                id: LogId.streamableHttpTransportHttpHostWarning,
+                context: "streamableHttpTransport",
+                message: `Binding to ${this.userConfig.httpHost} can expose the MCP Server to the entire local network, which allows other devices on the same network to potentially access the MCP Server. This is a security risk and could allow unauthorized access to your database context.`,
+                noRedaction: true,
+            });
+        }
+    }
+}

--- a/tests/integration/transports/base.test.ts
+++ b/tests/integration/transports/base.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { StreamableHttpRunner } from "../../../src/transports/streamableHttp.js";
+import { StreamableHttpRunner } from "../../../src/transports/streamableHttp/streamableHttpRunner.js";
 import { defaultTestConfig } from "../helpers.js";
 import type { UIRegistry } from "../../../src/ui/registry/index.js";
 import type { Server } from "../../../src/server.js";

--- a/tests/integration/transports/configOverrides.test.ts
+++ b/tests/integration/transports/configOverrides.test.ts
@@ -1,4 +1,4 @@
-import { StreamableHttpRunner } from "../../../src/transports/streamableHttp.js";
+import { StreamableHttpRunner } from "../../../src/transports/streamableHttp/streamableHttpRunner.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { describe, expect, it, afterEach, beforeEach } from "vitest";

--- a/tests/integration/transports/createSessionConfig.test.ts
+++ b/tests/integration/transports/createSessionConfig.test.ts
@@ -1,4 +1,4 @@
-import { StreamableHttpRunner } from "../../../src/transports/streamableHttp.js";
+import { StreamableHttpRunner } from "../../../src/transports/streamableHttp/streamableHttpRunner.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { afterEach, describe, expect, it } from "vitest";

--- a/tests/integration/transports/streamableHttp.test.ts
+++ b/tests/integration/transports/streamableHttp.test.ts
@@ -1,4 +1,4 @@
-import { StreamableHttpRunner } from "../../../src/transports/streamableHttp.js";
+import { StreamableHttpRunner } from "../../../src/transports/streamableHttp/streamableHttpRunner.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";


### PR DESCRIPTION
## Proposed changes
The StreamableHttpRunner starts a HealthCheckServer and an McpHttpServer both based on Express. All these components currently live in the same file. This PR splits the inidividual components into their own files and moves the nested function created in setupRoutes method to their own class methods.

The PR has no logic changes, pure refactor.

Please review the PR commit by commit:
1. [Commit 1](https://github.com/mongodb-js/mongodb-mcp-server/commit/ffe89a5931d4fde089e6a6596b2d9b89f171f4cf): Moves individual components in StreamableHttpRunner file to their own files. This change improves scanability of the code.
2. [Commit 2](https://github.com/mongodb-js/mongodb-mcp-server/pull/972/commits/dac6ebb723883374c5e564c56b9c82696028973a) Moves the nested functions in setupRoutes method of McpHttpServer to their own class methods. This is a good change to ensure that we don't depend on lexical scope in the callbacks for some of the variables to be present.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
