### PR TITLE
chore: skip coverage if tests fail

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -133,7 +133,7 @@ jobs:
 
   coverage:
     name: Report Coverage
-    if: always() && (github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
+    if: github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     needs:
       [run-tests, run-atlas-tests, run-atlas-local-tests, run-browser-tests]


### PR DESCRIPTION
Coverage will always fail if any of the tests fail so it's not useful for us to be always running it. It also forces us to wait for the coverage test to finish before restarting tests
