### PR TITLE
feat(atlas): use elicitation for create DB user password

### DIFF
--- a/src/tools/atlas/create/createDBUser.ts
+++ b/src/tools/atlas/create/createDBUser.ts
@@ -6,6 +6,7 @@ import type { CloudDatabaseUser, DatabaseUserRole } from "../../../common/atlas/
 import { ensureCurrentIpInAccessList } from "../../../common/atlas/accessListUtils.js";
 import { AtlasArgs, CommonArgs } from "../../args.js";
 import type { ElicitRequestFormParams } from "@modelcontextprotocol/sdk/types.js";
+import { generateSecurePassword } from "../../../helpers/generatePassword.js";
 
 export const CreateDBUserArgs = {
     projectId: AtlasArgs.projectId().describe("Atlas project ID"),
@@ -60,6 +61,8 @@ export class CreateDBUserTool extends AtlasToolBase {
         roles,
         clusters,
     }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
+        let shouldGeneratePassword = false;
+
         if (!password) {
             const elicited = await this.elicitation.requestInput(
                 "A password is required to create this Atlas database user.",
@@ -70,15 +73,8 @@ export class CreateDBUserTool extends AtlasToolBase {
         }
 
         if (!password) {
-            return {
-                content: [
-                    {
-                        type: "text",
-                        text: "Password is required to create an Atlas database user. Provide `password` in tool arguments.",
-                    },
-                ],
-                isError: true,
-            };
+            shouldGeneratePassword = true;
+            password = await generateSecurePassword();
         }
 
         await ensureCurrentIpInAccessList(this.apiClient, projectId);
@@ -119,7 +115,7 @@ export class CreateDBUserTool extends AtlasToolBase {
             content: [
                 {
                     type: "text",
-                    text: `User "${username}" created successfully.`,
+                    text: `User "${username}" created successfully${shouldGeneratePassword ? ` with password: \`${password}\`` : ""}.`,
                 },
             ],
         };
@@ -135,7 +131,7 @@ export class CreateDBUserTool extends AtlasToolBase {
         return (
             `You are about to create a database user in Atlas project \`${projectId}\`:\n\n` +
             `**Username**: \`${username}\`\n\n` +
-            `**Password**: ${password ? "(User-provided password)" : "(Will be requested via elicitation)"}\n\n` +
+            `**Password**: ${password ? "(User-provided password)" : "(Will be requested via elicitation; auto-generated if not provided)"}\n\n` +
             `**Roles**: ${roles.map((role) => `${role.roleName}${role.collectionName ? ` on ${role.databaseName}.${role.collectionName}` : ` on ${role.databaseName}`}`).join(", ")}\n\n` +
             `**Cluster Access**: ${clusters?.length ? clusters.join(", ") : "All clusters in the project"}\n\n` +
             "This will create a new database user with the specified permissions. " +

--- a/src/tools/atlas/create/createDBUser.ts
+++ b/src/tools/atlas/create/createDBUser.ts
@@ -3,9 +3,9 @@ import type { ToolArgs, OperationType } from "../../tool.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasToolBase } from "../atlasTool.js";
 import type { CloudDatabaseUser, DatabaseUserRole } from "../../../common/atlas/openapi.js";
-import { generateSecurePassword } from "../../../helpers/generatePassword.js";
 import { ensureCurrentIpInAccessList } from "../../../common/atlas/accessListUtils.js";
 import { AtlasArgs, CommonArgs } from "../../args.js";
+import type { ElicitRequestFormParams } from "@modelcontextprotocol/sdk/types.js";
 
 export const CreateDBUserArgs = {
     projectId: AtlasArgs.projectId().describe("Atlas project ID"),
@@ -33,6 +33,18 @@ export const CreateDBUserArgs = {
         .optional(),
 };
 
+const DB_USER_PASSWORD_SCHEMA = {
+    type: "object" as const,
+    properties: {
+        password: {
+            type: "string" as const,
+            title: "Database user password",
+            description: "Provide a password for the new Atlas database user.",
+        },
+    },
+    required: ["password"],
+} satisfies ElicitRequestFormParams["requestedSchema"];
+
 export class CreateDBUserTool extends AtlasToolBase {
     static toolName = "atlas-create-db-user";
     public description = "Create an MongoDB Atlas database user";
@@ -48,11 +60,28 @@ export class CreateDBUserTool extends AtlasToolBase {
         roles,
         clusters,
     }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
-        await ensureCurrentIpInAccessList(this.apiClient, projectId);
-        const shouldGeneratePassword = !password;
-        if (shouldGeneratePassword) {
-            password = await generateSecurePassword();
+        if (!password) {
+            const elicited = await this.elicitation.requestInput(
+                "A password is required to create this Atlas database user.",
+                DB_USER_PASSWORD_SCHEMA
+            );
+
+            password = elicited.accepted ? elicited.fields.password : undefined;
         }
+
+        if (!password) {
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: "Password is required to create an Atlas database user. Provide `password` in tool arguments.",
+                    },
+                ],
+                isError: true,
+            };
+        }
+
+        await ensureCurrentIpInAccessList(this.apiClient, projectId);
 
         const input = {
             groupId: projectId,
@@ -90,7 +119,7 @@ export class CreateDBUserTool extends AtlasToolBase {
             content: [
                 {
                     type: "text",
-                    text: `User "${username}" created successfully${shouldGeneratePassword ? ` with password: \`${password}\`` : ""}.`,
+                    text: `User "${username}" created successfully.`,
                 },
             ],
         };
@@ -106,7 +135,7 @@ export class CreateDBUserTool extends AtlasToolBase {
         return (
             `You are about to create a database user in Atlas project \`${projectId}\`:\n\n` +
             `**Username**: \`${username}\`\n\n` +
-            `**Password**: ${password ? "(User-provided password)" : "(Auto-generated secure password)"}\n\n` +
+            `**Password**: ${password ? "(User-provided password)" : "(Will be requested via elicitation)"}\n\n` +
             `**Roles**: ${roles.map((role) => `${role.roleName}${role.collectionName ? ` on ${role.databaseName}.${role.collectionName}` : ` on ${role.databaseName}`}`).join(", ")}\n\n` +
             `**Cluster Access**: ${clusters?.length ? clusters.join(", ") : "All clusters in the project"}\n\n` +
             "This will create a new database user with the specified permissions. " +

--- a/tests/integration/elicitation.test.ts
+++ b/tests/integration/elicitation.test.ts
@@ -117,7 +117,15 @@ describe("Elicitation Integration Tests", () => {
                 });
 
                 it("should request confirmation for create-db-user tool", async () => {
-                    mockElicitInput.confirmYes();
+                    mockElicitInput.mock
+                        .mockResolvedValueOnce({
+                            action: "accept",
+                            content: { confirmation: "Yes" },
+                        })
+                        .mockResolvedValueOnce({
+                            action: "accept",
+                            content: { password: "test-password-from-elicitation" },
+                        });
 
                     await integration.mcpClient().callTool({
                         name: "atlas-create-db-user",
@@ -128,11 +136,24 @@ describe("Elicitation Integration Tests", () => {
                         },
                     });
 
-                    expect(mockElicitInput.mock).toHaveBeenCalledTimes(1);
-                    expect(mockElicitInput.mock).toHaveBeenCalledWith(
+                    expect(mockElicitInput.mock).toHaveBeenCalledTimes(2);
+                    expect(mockElicitInput.mock).toHaveBeenNthCalledWith(
+                        1,
                         {
                             message: expect.stringContaining("You are about to create a database user"),
                             requestedSchema: expect.objectContaining(Elicitation.CONFIRMATION_SCHEMA),
+                            mode: "form",
+                        },
+                        { timeout: 300000 }
+                    );
+                    expect(mockElicitInput.mock).toHaveBeenNthCalledWith(
+                        2,
+                        {
+                            message: "A password is required to create this Atlas database user.",
+                            requestedSchema: expect.objectContaining({
+                                type: "object",
+                                required: ["password"],
+                            }),
                             mode: "form",
                         },
                         { timeout: 300000 }

--- a/tests/integration/tools/atlas/dbUsers.test.ts
+++ b/tests/integration/tools/atlas/dbUsers.test.ts
@@ -98,31 +98,12 @@ describeWithAtlas("db users", (integration) => {
                 });
             });
 
-            it("should create a database user with generated password", async () => {
+            it("should require password when creating a database user", async () => {
                 const response = await createUserWithMCP();
+                expect(response.isError).toBe(true);
                 const elements = getResponseElements(response);
                 expect(elements).toHaveLength(1);
-                expect(elements[0]?.text).toContain("created successfully");
-                expect(elements[0]?.text).toContain(userName);
-                expect(elements[0]?.text).toContain("with password: `");
-
-                const passwordStart = elements[0]?.text.lastIndexOf(":") ?? -1;
-                const passwordEnd = elements[0]?.text.length ?? 1 - 1;
-
-                const password = elements[0]?.text
-                    .substring(passwordStart + 1, passwordEnd - 1)
-                    .replace(/`/g, "")
-                    .trim();
-
-                expect(integration.mcpServer().session.keychain.allSecrets).toContainEqual({
-                    value: userName,
-                    kind: "user",
-                });
-
-                expect(integration.mcpServer().session.keychain.allSecrets).toContainEqual({
-                    value: password,
-                    kind: "password",
-                });
+                expect(elements[0]?.text).toContain("Password is required");
             });
 
             it("should add current IP to access list when creating a database user", async () => {
@@ -130,7 +111,7 @@ describeWithAtlas("db users", (integration) => {
                 const session = integration.mcpServer().session;
                 assertApiClientIsAvailable(session);
                 const ipInfo = await session.apiClient.getIpInfo();
-                await createUserWithMCP();
+                await createUserWithMCP("testpassword");
                 const accessList = await session.apiClient.listAccessListEntries({
                     params: { path: { groupId: projectId } },
                 });
@@ -151,7 +132,7 @@ describeWithAtlas("db users", (integration) => {
             it("returns database users by project", async () => {
                 const projectId = getProjectId();
 
-                await createUserWithMCP();
+                await createUserWithMCP("testpassword");
 
                 const response = await integration
                     .mcpClient()

--- a/tests/integration/tools/atlas/dbUsers.test.ts
+++ b/tests/integration/tools/atlas/dbUsers.test.ts
@@ -98,12 +98,31 @@ describeWithAtlas("db users", (integration) => {
                 });
             });
 
-            it("should require password when creating a database user", async () => {
+            it("should create a database user with generated password", async () => {
                 const response = await createUserWithMCP();
-                expect(response.isError).toBe(true);
                 const elements = getResponseElements(response);
                 expect(elements).toHaveLength(1);
-                expect(elements[0]?.text).toContain("Password is required");
+                expect(elements[0]?.text).toContain("created successfully");
+                expect(elements[0]?.text).toContain(userName);
+                expect(elements[0]?.text).toContain("with password: `");
+
+                const passwordStart = elements[0]?.text.lastIndexOf(":") ?? -1;
+                const passwordEnd = elements[0]?.text.length ?? 1 - 1;
+
+                const password = elements[0]?.text
+                    .substring(passwordStart + 1, passwordEnd - 1)
+                    .replace(/`/g, "")
+                    .trim();
+
+                expect(integration.mcpServer().session.keychain.allSecrets).toContainEqual({
+                    value: userName,
+                    kind: "user",
+                });
+
+                expect(integration.mcpServer().session.keychain.allSecrets).toContainEqual({
+                    value: password,
+                    kind: "password",
+                });
             });
 
             it("should add current IP to access list when creating a database user", async () => {
@@ -111,7 +130,7 @@ describeWithAtlas("db users", (integration) => {
                 const session = integration.mcpServer().session;
                 assertApiClientIsAvailable(session);
                 const ipInfo = await session.apiClient.getIpInfo();
-                await createUserWithMCP("testpassword");
+                await createUserWithMCP();
                 const accessList = await session.apiClient.listAccessListEntries({
                     params: { path: { groupId: projectId } },
                 });
@@ -132,7 +151,7 @@ describeWithAtlas("db users", (integration) => {
             it("returns database users by project", async () => {
                 const projectId = getProjectId();
 
-                await createUserWithMCP("testpassword");
+                await createUserWithMCP();
 
                 const response = await integration
                     .mcpClient()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

- update `atlas-create-db-user` to acquire a missing password via elicitation first
- keep secure password auto-generation as fallback when password is still missing (unsupported elicitation, declined, or empty)
- keep generated passwords redacted from args flow while preserving existing success output behavior for fallback-generated passwords
- update create-db-user confirmation text to reflect elicitation-first with generator fallback
- add integration coverage for the confirmation + password-elicitation flow in `tests/integration/elicitation.test.ts`
- align Atlas db user integration expectations with elicitation-first + auto-generate fallback behavior

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fec147b1-c95e-4e89-a006-dc3167c115a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fec147b1-c95e-4e89-a006-dc3167c115a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

