### PR TITLE
fix: handle setup without credentials

### DIFF
--- a/src/common/logging/index.ts
+++ b/src/common/logging/index.ts
@@ -1,6 +1,7 @@
 export { LogId } from "./loggingDefinitions.js";
 export type * from "./loggingTypes.js";
 export * from "./loggerBase.js";
+export { NullLogger } from "./nullLogger.js";
 export { CompositeLogger } from "./compositeLogger.js";
 export { ConsoleLogger } from "./consoleLogger.js";
 export { DiskLogger } from "./diskLogger.js";

--- a/src/common/logging/loggerBase.ts
+++ b/src/common/logging/loggerBase.ts
@@ -102,15 +102,3 @@ export abstract class LoggerBase<T extends EventMap<T> = DefaultEventMap> extend
         }
     }
 }
-
-export class NullLogger extends LoggerBase {
-    protected type?: LoggerType;
-
-    constructor() {
-        super(undefined);
-    }
-
-    protected logCore(): void {
-        // No-op logger, does not log anything
-    }
-}

--- a/src/common/logging/nullLogger.ts
+++ b/src/common/logging/nullLogger.ts
@@ -1,0 +1,14 @@
+import type { LoggerType } from "./loggingTypes.js";
+import { LoggerBase } from "./loggerBase.js";
+
+export class NullLogger extends LoggerBase {
+    protected type?: LoggerType;
+
+    constructor() {
+        super(undefined);
+    }
+
+    protected logCore(): void {
+        // No-op logger, does not log anything
+    }
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -31,6 +31,7 @@ export {
     type LoggerType,
     type LogLevel,
     CompositeLogger,
+    NullLogger,
 } from "./common/logging/index.js";
 export { StreamableHttpRunner } from "./transports/streamableHttp.js";
 export { StdioRunner } from "./transports/stdio.js";

--- a/src/setup/setupMcpServer.ts
+++ b/src/setup/setupMcpServer.ts
@@ -13,7 +13,7 @@ import { packageInfo } from "../common/packageInfo.js";
 import { getAuthType } from "../common/connectionInfo.js";
 import { type UserConfig } from "../common/config/userConfig.js";
 import { defaultCreateAtlasLocalClient } from "../common/atlasLocal.js";
-import { NullLogger } from "../common/logging/loggerBase.js";
+import { NullLogger } from "../common/logging/index.js";
 
 const buildEnvObject = (
     connectionString: string,
@@ -244,13 +244,13 @@ const validateCredentials = (
         if (hasDocker) {
             console.log(
                 chalk.yellow(
-                    "Since you have Docker installed, you can still use the MCP server with a local Atlas instance running in a container."
+                    "Since you have Docker running, you can still use the MCP server with a local Atlas instance running in a container."
                 )
             );
         } else {
             console.log(
                 chalk.red(
-                    "Since you don't have Docker installed, you can only connect to a MongoDB instance dynamically, " +
+                    "Since you don't have Docker running, you can only connect to a MongoDB instance dynamically, " +
                         chalk.bold(
                             chalk.red(
                                 "which is strongly discouraged as it will expose your connection string to the LLM."

--- a/tests/integration/common/apiClient.test.ts
+++ b/tests/integration/common/apiClient.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { AccessToken } from "../../../src/common/atlas/auth/authProvider.js";
 import { ApiClient } from "../../../src/common/atlas/apiClient.js";
 import { HTTPServerProxyTestSetup } from "../fixtures/httpsServerProxyTest.js";
-import { NullLogger } from "../../../src/common/logging/loggerBase.js";
+import { NullLogger } from "../../../src/common/logging/index.js";
 
 describe("ApiClient integration test", () => {
     describe(`atlas API proxy integration`, () => {

--- a/tests/unit/accessListUtils.test.ts
+++ b/tests/unit/accessListUtils.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import type { ApiClient } from "../../src/common/atlas/apiClient.js";
 import { ensureCurrentIpInAccessList, DEFAULT_ACCESS_LIST_COMMENT } from "../../src/common/atlas/accessListUtils.js";
 import { ApiClientError } from "../../src/common/atlas/apiClientError.js";
-import { NullLogger } from "../../src/common/logging/loggerBase.js";
+import { NullLogger } from "../../src/common/logging/index.js";
 
 describe("accessListUtils", () => {
     it("should add the current IP to the access list", async () => {

--- a/tests/unit/common/apiClient.test.ts
+++ b/tests/unit/common/apiClient.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiClient } from "../../../src/common/atlas/apiClient.js";
 import { packageInfo } from "../../../src/common/packageInfo.js";
 import type { CommonProperties, TelemetryEvent, TelemetryResult } from "../../../src/telemetry/types.js";
-import { NullLogger } from "../../../src/common/logging/loggerBase.js";
+import { NullLogger } from "../../../src/common/logging/index.js";
 
 describe("ApiClient", () => {
     let apiClient: ApiClient;

--- a/tests/unit/common/atlasLocal.test.ts
+++ b/tests/unit/common/atlasLocal.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { defaultCreateAtlasLocalClient, type LibraryLoader } from "../../../src/common/atlasLocal.js";
 import type { Client } from "@mongodb-js/atlas-local";
-import { NullLogger } from "../../../src/common/logging/loggerBase.js";
+import { NullLogger } from "../../../src/common/logging/index.js";
 
 describe("Atlas Local", () => {
     describe("defaultCreateAtlasLocalClient", () => {

--- a/tests/unit/common/auth/clientCredentials.test.ts
+++ b/tests/unit/common/auth/clientCredentials.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as oauth from "oauth4webapi";
 import { ClientCredentialsAuthProvider } from "../../../../src/common/atlas/auth/clientCredentials.js";
-import { NullLogger } from "../../../../src/common/logging/loggerBase.js";
+import { NullLogger } from "../../../../src/common/logging/index.js";
 
 vi.mock("oauth4webapi", () => ({
     clientCredentialsGrantRequest: vi.fn(),

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -4,7 +4,7 @@ import { Telemetry } from "../../src/telemetry/telemetry.js";
 import type { BaseEvent, CommonProperties, TelemetryEvent, TelemetryResult } from "../../src/telemetry/types.js";
 import { EventCache } from "../../src/telemetry/eventCache.js";
 import { afterEach, beforeAll, beforeEach, describe, it, vi, expect } from "vitest";
-import { NullLogger } from "../../src/common/logging/loggerBase.js";
+import { NullLogger } from "../../src/common/logging/nullLogger.js";
 import type { MockedFunction } from "vitest";
 import type { DeviceId } from "../../src/helpers/deviceId.js";
 import { defaultTestConfig, expectDefined } from "../integration/helpers.js";


### PR DESCRIPTION
## Proposed changes

Setting up the MCP server without credentials is a valid use case. This change enables it and adds an additional check for docker. If it's available, clarifies that local atlas tools are available and how to connect to them. If it isn't, warns users that they can only connect dynamically as well as the risks involved with it.