### PR TITLE
chore(ci): improve release workflow MCP-447

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - "type: chore"
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - "type: feature"
+    - title: "🐛 Bug Fixes"
+      labels:
+        - "type: bug"
+    - title: "📖 Documentation"
+      labels:
+        - "type: docs"
+    - title: "📦 Dependencies"
+      labels:
+        - "type: dependencies"

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -20,7 +20,9 @@ jobs:
           app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
           private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          gh pr edit "$PR_URL" --add-label "type: dependencies"
+          gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -6,12 +6,14 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
       - name: Apply label based on conventional commit prefix
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,44 @@
+name: Label PR
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply label based on conventional commit prefix
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -e
+
+          TITLE="$PR_TITLE"
+
+          if [[ "$TITLE" =~ ^feat(\(|!|:) ]]; then
+            LABEL="type: feature"
+          elif [[ "$TITLE" =~ ^fix(\(|!|:) ]]; then
+            LABEL="type: bug"
+          elif [[ "$TITLE" =~ ^docs(\(|!|:) ]]; then
+            LABEL="type: docs"
+          elif [[ "$TITLE" =~ ^chore\(deps ]]; then
+            LABEL="type: dependencies"
+          else
+            # covers: chore, ci, refactor, style, test, build, ops, revert
+            # and any PR using the no-title-validation escape hatch
+            LABEL="type: chore"
+          fi
+
+          # Remove any existing type: * label before applying the new one
+          EXISTING=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name | select(startswith("type: "))] | join(",")')
+          if [[ -n "$EXISTING" ]]; then
+            gh pr edit "$PR_NUMBER" --remove-label "$EXISTING"
+          fi
+
+          gh pr edit "$PR_NUMBER" --add-label "$LABEL"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -10,10 +10,15 @@ permissions:
 
 jobs:
   label:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Apply label based on conventional commit prefix
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,7 +1,6 @@
+#  Bumps the version in package.json and creates a release PR. Once merged, the new
+#  version will be published to npm.
 name: Prepare release
-description: |
-  Bumps the version in package.json and creates a release PR. Once merged, the new
-  version will be published to npm.
 on:
   workflow_dispatch:
     inputs:
@@ -43,6 +42,57 @@ jobs:
         run: |
           pnpm run generate:arguments
 
+      - name: Check Jira vNext ticket status
+        id: jira-status
+        continue-on-error: true
+        env:
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          JIRA_URL="https://jira.mongodb.org"
+          PROJECT_KEY="MCP"
+          AUTH_HEADER="Authorization: Bearer ${JIRA_API_TOKEN}"
+
+          # Fetch all project versions and find vNext
+          versions=$(curl -sSf -H "${AUTH_HEADER}" "${JIRA_URL}/rest/api/2/project/${PROJECT_KEY}/versions")
+          vnext_id=$(echo "${versions}" | jq -r '.[] | select(.name == "vNext") | .id')
+
+          if [[ -z "${vnext_id}" ]]; then
+            echo "::warning::vNext version not found in Jira project ${PROJECT_KEY}"
+            exit 0
+          fi
+
+          urlencode() { echo -n "$1" | jq -sRr @uri; }
+
+          ALL_JQL="project = ${PROJECT_KEY} AND fixVersion = vNext"
+          RESOLVED_JQL="${ALL_JQL} AND resolution != Unresolved"
+          UNRESOLVED_JQL="${ALL_JQL} AND resolution = Unresolved"
+
+          total=$(curl -sSf -H "${AUTH_HEADER}" \
+            "${JIRA_URL}/rest/api/2/search?maxResults=0&jql=$(urlencode "${ALL_JQL}")" \
+            | jq '.total')
+
+          resolved=$(curl -sSf -H "${AUTH_HEADER}" \
+            "${JIRA_URL}/rest/api/2/search?maxResults=0&jql=$(urlencode "${RESOLVED_JQL}")" \
+            | jq '.total')
+
+          unresolved=$((total - resolved))
+
+          vnext_url="${JIRA_URL}/projects/${PROJECT_KEY}/versions/${vnext_id}"
+          all_url="${JIRA_URL}/issues/?jql=$(urlencode "${ALL_JQL}")"
+          resolved_url="${JIRA_URL}/issues/?jql=$(urlencode "${RESOLVED_JQL}")"
+          unresolved_url="${JIRA_URL}/issues/?jql=$(urlencode "${UNRESOLVED_JQL}")"
+
+          if [[ "${unresolved}" -eq 0 ]]; then
+            status="All [${total} tickets](${all_url}) in [vNext](${vnext_url}) are in resolved state."
+          else
+            status="There are [${resolved} resolved](${resolved_url}) and [${unresolved} unresolved](${unresolved_url}) tickets in [vNext](${vnext_url}). Please review and update if necessary."
+          fi
+
+          echo "JIRA_STATUS=${status}" >> "${GITHUB_OUTPUT}"
+
       - name: Create release PR
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # 8.1.0
         id: create-pr
@@ -53,6 +103,8 @@ jobs:
           body: |
             This PR bumps the package version to ${{ steps.bump-version.outputs.NEW_VERSION }}.
             Once merged, the new version will be published to npm.
+
+            ${{ steps.jira-status.outputs.JIRA_STATUS }}
           base: main
           branch: chore_release_${{ steps.bump-version.outputs.NEW_VERSION }}
           author: "${{ steps.app-token.outputs.app-slug}}[bot] <${{ steps.app-token.outputs.app-email }}>"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -155,3 +155,46 @@ jobs:
     permissions:
       id-token: write
       contents: read
+
+  jira-release:
+    runs-on: ubuntu-latest
+    needs: [check, publish]
+    if: needs.check.outputs.VERSION_EXISTS == 'false' && needs.check.outputs.RELEASE_CHANNEL == 'latest'
+    permissions: {}
+    steps:
+      - name: Update Jira release versions
+        env:
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          VERSION_NUMBER: ${{ needs.check.outputs.NPM_VERSION }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          JIRA_URL="https://jira.mongodb.org"
+          PROJECT_KEY="MCP"
+          TODAY=$(date -u +%Y-%m-%d)
+          AUTH_HEADER="Authorization: Bearer ${JIRA_API_TOKEN}"
+
+          # Fetch all project versions and find vNext
+          versions=$(curl -sSf -H "${AUTH_HEADER}" "${JIRA_URL}/rest/api/2/project/${PROJECT_KEY}/versions")
+          vnext_id=$(echo "${versions}" | jq -r '.[] | select(.name == "vNext") | .id')
+          project_id=$(echo "${versions}" | jq -r '.[0].projectId')
+
+          if [[ -z "${vnext_id}" ]]; then
+            echo "::error::vNext version not found in Jira project ${PROJECT_KEY}"
+            exit 1
+          fi
+
+          # Rename vNext to the release version and mark it as released
+          curl -sSf -X PUT \
+            -H "${AUTH_HEADER}" -H "Content-Type: application/json" \
+            -d "{\"name\": \"${VERSION_NUMBER}\", \"released\": true, \"releaseDate\": \"${TODAY}\"}" \
+            "${JIRA_URL}/rest/api/2/version/${vnext_id}" > /dev/null
+          echo "Renamed vNext to ${VERSION_NUMBER} and marked as released on ${TODAY}"
+
+          # Create a new vNext version with start date today
+          curl -sSf -X POST \
+            -H "${AUTH_HEADER}" -H "Content-Type: application/json" \
+            -d "{\"name\": \"vNext\", \"projectId\": ${project_id}, \"startDate\": \"${TODAY}\"}" \
+            "${JIRA_URL}/rest/api/2/version" > /dev/null
+          echo "Created new vNext version with start date ${TODAY}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,6 +82,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
@@ -96,11 +97,23 @@ jobs:
       - name: Publish to NPM
         run: pnpm publish --tag ${{ needs.check.outputs.RELEASE_CHANNEL }} --no-git-checks
 
+      - name: Generate AI release summary
+        id: ai-summary
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/generate-release-notes.sh ${{ needs.check.outputs.GIT_TAG_VERSION }} ${{ github.sha }}
+        shell: bash
+
       - name: Publish git release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ needs.check.outputs.GIT_TAG_VERSION }} --title "${{ needs.check.outputs.GIT_TAG_VERSION }}" --generate-notes --target ${{ github.sha }} ${{ (needs.check.outputs.RELEASE_CHANNEL != 'latest' && '--prerelease') || ''}}
+          gh release create ${{ needs.check.outputs.GIT_TAG_VERSION }} \
+            --title "${{ needs.check.outputs.GIT_TAG_VERSION }}" \
+            --notes-file "${{ steps.ai-summary.outputs.notes_file }}" \
+            --target ${{ github.sha }} \
+            ${{ (needs.check.outputs.RELEASE_CHANNEL != 'latest' && '--prerelease') || ''}}
 
       - name: Wait for package to be available on npm
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,9 +149,7 @@ When adding new tools to the MCP server:
 
 To release a new version of the MCP server, follow these steps:
 
-1. Ensure there is a Jira _Release_ ticket in the [`MCP` project](https://jira.mongodb.org/projects/MCP) for the new release and move it to _In Progress_.
-2. Verify that the Jira tickets you expect to be released are correctly mapped to the expected Release version. Add any additional required documentation to the release ticket.
-3. To create a new version, go to the GitHub repository Actions tab and run the "Prepare Release" workflow with one of the following options:
+1. To create a new version, go to the GitHub repository Actions tab and run the "Prepare Release" workflow with one of the following options:
    - `patch` (e.g., 1.0.0 → 1.0.1) for backward-compatible bug fixes
    - `minor` (e.g., 1.0.0 → 1.1.0) for backward-compatible new features
    - `major` (e.g., 1.0.0 → 2.0.0) for breaking changes
@@ -160,15 +158,13 @@ To release a new version of the MCP server, follow these steps:
 
    > **Note**: Stable releases are published under the `latest` tag on NPM and are intended for production use. Pre-release versions are published under the `prerelease` tag and serve as release candidates for early access and feedback before being released as stable versions.
 
-4. This creates a pull request with the version change.
-5. Merge this pull request if all looks correct. This will trigger the "Publish" workflow which will publish it to **NPM**, **Docker** and the **MCP Registry**.
-6. Verify that the new version is published correctly by checking:
+2. This creates a pull request with the version change. The PR body includes a summary of the Jira `vNext` ticket status — check it for any unresolved tickets and ensure they are either resolved or moved out of `vNext` before merging.
+3. Merge this pull request if all looks correct. This will trigger the "Publish" workflow which will publish it to **NPM**, **Docker** and the **MCP Registry**. It will also automatically rename the Jira `vNext` version to the released version number and create a new `vNext` for the next release.
+4. Verify that the new version is published correctly by checking:
    - NPM: https://www.npmjs.com/package/mongodb-mcp-server
    - Docker: https://hub.docker.com/r/mongodb/mongodb-mcp-server
    - MCP Registry: `curl "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.mongodb-js%2Fmongodb-mcp-server/versions/latest"`
-7. Close the Jira ticket for the release.
-8. Go to the [Releases](https://jira.mongodb.org/projects/MCP?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page&status=released-unreleased) section the and rename the `vNext` to the new version number and mark it as Released. Create a new `vNext` for the next release.
-9. Post an update in the `#mongodb-mcp` Slack channel.
+5. Post an update in the `#mongodb-mcp` Slack channel.
 
 ### Code Quality
 

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -10,6 +10,9 @@ TARGET="${2:-$(git rev-parse HEAD)}"
 
 GH_TOKEN="${GH_TOKEN:-$(gh auth token)}"
 
+STRUCTURED_NOTES=$(mktemp)
+trap 'rm -f "$STRUCTURED_NOTES"' EXIT
+
 # Find the previous tag
 PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
 if [[ -z "$PREV_TAG" ]]; then
@@ -33,7 +36,6 @@ FEAT_FIX_TITLES=$(gh pr list \
   --limit 500)
 
 # Generate structured release notes (always, regardless of AI result)
-STRUCTURED_NOTES=$(mktemp)
 gh api repos/mongodb-js/mongodb-mcp-server/releases/generate-notes \
   --method POST \
   --field tag_name="$GIT_TAG_VERSION" \
@@ -48,7 +50,9 @@ if [[ -z "$FEAT_FIX_TITLES" ]]; then
   echo "No feat/fix PRs found since $PREV_TAG, using structured notes only"
   cp "$STRUCTURED_NOTES" "$NOTES_FILE"
 else
-  PROMPT="You are writing release notes for MongoDB MCP Server, a tool that lets AI assistants interact with MongoDB databases and MongoDB Atlas. Given these merged PR titles, write 2-3 sentences for end-users describing what's new in plain English. Be concrete and avoid internal jargon. Only describe user-visible changes. Focus primarily on new features (feat: titles) — mention bug fixes only if they address something particularly significant.\n\nPR titles:\n$FEAT_FIX_TITLES"
+  PROMPT=$(printf '%s\n\nPR titles:\n%s' \
+    "You are writing release notes for MongoDB MCP Server, a tool that lets AI assistants interact with MongoDB databases and MongoDB Atlas. Given these merged PR titles, write 2-3 sentences for end-users describing what's new in plain English. Be concrete and avoid internal jargon. Only describe user-visible changes. Focus primarily on new features (feat: titles) — mention bug fixes only if they address something particularly significant." \
+    "$FEAT_FIX_TITLES")
 
   AI_RESPONSE=$(curl -s --fail \
     -H "Authorization: Bearer $GH_TOKEN" \
@@ -74,8 +78,6 @@ else
     } > "$NOTES_FILE"
   fi
 fi
-
-rm -f "$STRUCTURED_NOTES"
 
 if [[ -n "$GITHUB_OUTPUT" ]]; then
   echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Generates release notes combining an AI summary with structured GitHub release notes.
+#
+# Usage: scripts/generate-release-notes.sh [GIT_TAG_VERSION] [TARGET]
+
+set -e
+
+GIT_TAG_VERSION="${1:-vNext}"
+TARGET="${2:-$(git rev-parse HEAD)}"
+
+GH_TOKEN="${GH_TOKEN:-$(gh auth token)}"
+
+# Find the previous tag
+PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+if [[ -z "$PREV_TAG" ]]; then
+  echo "No previous tag found, skipping release notes generation"
+  exit 0
+fi
+
+echo "Previous tag: $PREV_TAG"
+
+# Get the timestamp of the previous tag's commit
+PREV_TAG_DATE=$(git log -1 --format=%cI "$PREV_TAG")
+
+echo "Previous tag date: $PREV_TAG_DATE"
+
+# Fetch feat/fix PR titles merged since the previous tag (server-side filtered)
+FEAT_FIX_TITLES=$(gh pr list \
+  --state merged --base main \
+  --search "merged:>$PREV_TAG_DATE" \
+  --json title \
+  --jq '[.[] | .title | select(test("^(feat|fix)(\\(|!|:)"))] | join("\n")' \
+  --limit 500)
+
+# Generate structured release notes (always, regardless of AI result)
+STRUCTURED_NOTES=$(mktemp)
+gh api repos/mongodb-js/mongodb-mcp-server/releases/generate-notes \
+  --method POST \
+  --field tag_name="$GIT_TAG_VERSION" \
+  --field previous_tag_name="$PREV_TAG" \
+  --field target_commitish="$TARGET" \
+  --jq '.body' \
+  > "$STRUCTURED_NOTES"
+
+NOTES_FILE="$(git rev-parse --show-toplevel)/release-notes.md"
+
+if [[ -z "$FEAT_FIX_TITLES" ]]; then
+  echo "No feat/fix PRs found since $PREV_TAG, using structured notes only"
+  cp "$STRUCTURED_NOTES" "$NOTES_FILE"
+else
+  PROMPT="You are writing release notes for MongoDB MCP Server, a tool that lets AI assistants interact with MongoDB databases and MongoDB Atlas. Given these merged PR titles, write 2-3 sentences for end-users describing what's new in plain English. Be concrete and avoid internal jargon. Only describe user-visible changes. Focus primarily on new features (feat: titles) — mention bug fixes only if they address something particularly significant.\n\nPR titles:\n$FEAT_FIX_TITLES"
+
+  AI_RESPONSE=$(curl -s --fail \
+    -H "Authorization: Bearer $GH_TOKEN" \
+    -H "Content-Type: application/json" \
+    "https://models.inference.ai.azure.com/chat/completions" \
+    -d "$(jq -n --arg prompt "$PROMPT" '{
+      "model": "gpt-4o-mini",
+      "messages": [{"role": "user", "content": $prompt}],
+      "max_tokens": 300
+    }')" | jq -r '.choices[0].message.content')
+
+  if [[ -z "$AI_RESPONSE" || "$AI_RESPONSE" == "null" ]]; then
+    echo "Empty response from GitHub Models, using structured notes only"
+    cp "$STRUCTURED_NOTES" "$NOTES_FILE"
+  else
+    echo "AI summary generated successfully"
+    {
+      echo "## What's New"
+      echo ""
+      echo "$AI_RESPONSE"
+      echo ""
+      cat "$STRUCTURED_NOTES"
+    } > "$NOTES_FILE"
+  fi
+fi
+
+rm -f "$STRUCTURED_NOTES"
+
+if [[ -n "$GITHUB_OUTPUT" ]]; then
+  echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+else
+  echo "Release notes written to: $NOTES_FILE"
+fi


### PR DESCRIPTION
## Proposed changes

Modifies our release workflow:
1. Adds a PR label action that applies a label based on the conventional commit title
2. Adds a release.yml to categorize the notes based on the PR label
3. Adds an AI-generated summary for the release (this is something I'd like us to experiment with to see if it'll be beneficial in the long-run)
4. Adds a job to update vNext to mark it as released and create a new vNext in Jira