### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,17 @@
+name: HOL Skill Validate
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+jobs:
+  validate-skill:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Validate skill package
+        uses: hashgraph-online/skill-publish@ee40f6501dee6e687a04c285b5b94343cbf64c42 # v1
+        with:
+          mode: validate
+          skill-dir: .


### PR DESCRIPTION
I opened this as a small validate-only check for the skill metadata in the repo.

A couple of repo-specific details I checked first:
- A Model Context Protocol server to connect to MongoDB databases and MongoDB Atlas Clusters
- A Model Context Protocol server for interacting with MongoDB Databases and MongoDB Atlas
- A MongoDB connection string or Atlas API credentials, _the Server will not start unless configured_

This adds one workflow for `.` and leaves the runtime code alone.
It only runs the schema and trust checks for the skill metadata in validate mode.

If you would rather place the workflow under a different filename or point it at a different skill directory, I can adjust the branch.