### PR TITLE
chore: allow adding pre-route middlewares CLOUDP-395173

### DIFF
--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -33,6 +33,7 @@ export class MCPHttpServer<
     private readonly userConfig: UserConfig;
     private readonly metrics: Metrics<DefaultMetrics>;
     private readonly pendingInitializations = new Map<string, Promise<void>>();
+    private readonly preRouteMiddleware: express.RequestHandler[];
 
     private createServerForRequest: (createParams: {
         request: TransportRequestContext;
@@ -48,6 +49,7 @@ export class MCPHttpServer<
         logger,
         metrics,
         sessionStore,
+        preRouteMiddleware,
     }: {
         userConfig: TUserConfig;
         createServerForRequest: (createParams: {
@@ -60,6 +62,7 @@ export class MCPHttpServer<
         sessionOptions?: CustomizableSessionOptions<TUserConfig>;
         metrics: Metrics<DefaultMetrics>;
         sessionStore: ISessionStore<StreamableHTTPServerTransport>;
+        preRouteMiddleware?: express.RequestHandler[];
     }) {
         super({
             port: userConfig.httpPort,
@@ -73,6 +76,7 @@ export class MCPHttpServer<
         this.userConfig = userConfig;
         this.metrics = metrics;
         this.sessionStore = sessionStore;
+        this.preRouteMiddleware = preRouteMiddleware ?? [];
     }
 
     public async stop(): Promise<void> {
@@ -315,6 +319,11 @@ export class MCPHttpServer<
 
             next();
         });
+
+        // Apply any pre-route middleware (e.g., session validation from downstream services)
+        for (const middleware of this.preRouteMiddleware) {
+            this.app.use(middleware);
+        }
 
         const handleSessionRequest = async (req: express.Request, res: express.Response): Promise<void> => {
             const sessionId = req.headers["mcp-session-id"];

--- a/src/transports/streamableHttp.ts
+++ b/src/transports/streamableHttp.ts
@@ -1,4 +1,5 @@
 import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type express from "express";
 import type { LoggerBase } from "../common/logging/index.js";
 import { CompositeLogger, LogId } from "../common/logging/index.js";
 import { type ISessionStore, type CreateSessionStoreFn, createDefaultSessionStore } from "../common/sessionStore.js";
@@ -105,11 +106,14 @@ export class StreamableHttpRunner<
     async start({
         serverOptions,
         sessionOptions,
+        preRouteMiddleware,
     }: {
         /** Server options to use when creating the server. */
         serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
         /** Session options to use when creating the session. */
         sessionOptions?: CustomizableSessionOptions<TUserConfig>;
+        /** Optional Express middleware to run after body parsing but before route handlers. */
+        preRouteMiddleware?: express.RequestHandler[];
     } = {}): Promise<void> {
         this.validateConfig();
 
@@ -120,6 +124,7 @@ export class StreamableHttpRunner<
             logger: this.logger,
             metrics: this.metrics,
             sessionStore: this.sessionStore,
+            preRouteMiddleware,
         });
         await this.mcpServer.start();
 

--- a/tests/integration/transports/streamableHttp.test.ts
+++ b/tests/integration/transports/streamableHttp.test.ts
@@ -788,6 +788,92 @@ describe("StreamableHttpRunner", () => {
         }
     });
 
+    describe("preRouteMiddleware", () => {
+        it("should execute middleware before route handlers", async () => {
+            const middlewareCalls: string[] = [];
+
+            runner = new StreamableHttpRunner({ userConfig: config });
+            await runner.start({
+                preRouteMiddleware: [
+                    (_req, _res, next) => {
+                        middlewareCalls.push("middleware-executed");
+                        next();
+                    },
+                ],
+            });
+
+            const client = await connectClient({});
+            const response = await client.listTools();
+            expect(response).toBeDefined();
+            expect(response.tools).toBeDefined();
+            // Middleware should have been called for the initialize and listTools requests
+            expect(middlewareCalls.length).toBeGreaterThanOrEqual(1);
+        });
+
+        it("should allow middleware to reject requests", async () => {
+            runner = new StreamableHttpRunner({ userConfig: config });
+            await runner.start({
+                preRouteMiddleware: [
+                    (_req, res, _next) => {
+                        // Block all requests
+                        res.status(403).json({ error: "blocked by middleware" });
+                    },
+                ],
+            });
+
+            const response = await fetch(`${runner["mcpServer"]!.serverAddress}/mcp`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json", accept: "application/json, text/event-stream" },
+                body: JSON.stringify({
+                    jsonrpc: "2.0",
+                    method: "initialize",
+                    id: 1,
+                    params: {
+                        protocolVersion: "2024-11-05",
+                        capabilities: {},
+                        clientInfo: { name: "test", version: "0.0.0" },
+                    },
+                }),
+            });
+
+            expect(response.status).toBe(403);
+            const data = (await response.json()) as { error?: string };
+            expect(data.error).toBe("blocked by middleware");
+        });
+
+        it("should run middleware in the order provided", async () => {
+            const order: number[] = [];
+
+            runner = new StreamableHttpRunner({ userConfig: config });
+            await runner.start({
+                preRouteMiddleware: [
+                    (_req, _res, next) => {
+                        order.push(1);
+                        next();
+                    },
+                    (_req, _res, next) => {
+                        order.push(2);
+                        next();
+                    },
+                ],
+            });
+
+            await connectClient({});
+            expect(order[0]).toBe(1);
+            expect(order[1]).toBe(2);
+        });
+
+        it("should work without preRouteMiddleware (default behavior)", async () => {
+            runner = new StreamableHttpRunner({ userConfig: config });
+            await runner.start();
+
+            const client = await connectClient({});
+            const response = await client.listTools();
+            expect(response).toBeDefined();
+            expect(response.tools.length).toBeGreaterThan(0);
+        });
+    });
+
     describe("monitoring server", () => {
         describe("using legacy healthCheck config (backwards compat)", () => {
             beforeEach(() => {


### PR DESCRIPTION
## Proposed changes
This PR builds on https://github.com/10gen/mms/pull/163767 and enables https://github.com/10gen/mms/pull/163773.

The idea is for Atlas MCP service to ensure protocol correctness by checking whether MMS proxy had to generate a session id also for non-initialize request and reject any such request.

To enable this, we need to add a pre-route middleware that performs this check. Atlas MCP will provide that middleware but OSS MCP needs to allow that extension.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
