### PR TITLE
chore: remove preview search from start

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "dist"
   ],
   "scripts": {
-    "start": "node dist/index.js --transport http --loggers 'stderr, mcp' --previewFeatures search",
-    "start:stdio": "node dist/index.js --transport stdio --loggers 'stderr, mcp' --previewFeatures search",
+    "start": "node dist/index.js --transport http --loggers 'stderr, mcp'",
+    "start:stdio": "node dist/index.js --transport stdio --loggers 'stderr, mcp'",
     "start:setup": "pnpm run build && node dist/index.js setup",
     "prepare": "husky && pnpm run build",
     "build:update-package-version": "tsx scripts/updatePackageVersion.ts",


### PR DESCRIPTION
## Proposed changes

Search is not a valid option anymore: https://github.com/mongodb-js/mongodb-mcp-server/pull/1004.
But also, given that noone noticed this not working for a couple of weeks and I don't see the start script being used/referred to anywhere, is it still needed?
