### PR TITLE
feat: add db level aggregate tool MCP-459

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ For more information about configuring OpenCode as an MCP client, including the 
 #### MongoDB Database Tools
 
 - `aggregate` - Run an aggregation against a MongoDB collection
+- `aggregate-db` - Run an aggregation against a MongoDB database
 - `collection-indexes` - Describe the indexes for a collection
 - `collection-schema` - Describe the schema for a collection
 - `collection-storage-size` - Gets the size of the collection

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -96,10 +96,10 @@ export class CollectionIndexesTool extends MongoDBToolBase {
     };
     // (undocumented)
     description: string;
-    // Warning: (ae-forgotten-export) The symbol "DbOperationArgs" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "CollOperationArgs" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    protected execute(input: ToolArgs<typeof DbOperationArgs>): Promise<ToolResult<typeof CollectionIndexesTool.outputSchema>>;
+    protected execute(input: ToolArgs<typeof CollOperationArgs>): Promise<ToolResult<typeof CollectionIndexesTool.outputSchema>>;
     // Warning: (ae-forgotten-export) The symbol "SearchIndexStatus" needs to be exported by the entry point index.d.ts
     protected extractSearchIndexDetails(indexes: Record<string, unknown>[]): SearchIndexStatus[];
     // (undocumented)
@@ -170,7 +170,7 @@ export class CollectionStorageSizeTool extends MongoDBToolBase {
     // (undocumented)
     description: string;
     // (undocumented)
-    protected execute(input: ToolArgs<typeof DbOperationArgs>, input2: ToolExecutionContext): Promise<ToolResult<typeof CollectionStorageSizeTool.outputSchema>>;
+    protected execute(input: ToolArgs<typeof CollOperationArgs>, input2: ToolExecutionContext): Promise<ToolResult<typeof CollectionStorageSizeTool.outputSchema>>;
     // (undocumented)
     protected handleError(error: unknown, args: ToolArgs<typeof CollectionStorageSizeTool.argsShape>): Promise<CallToolResult>;
     // (undocumented)

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -39,7 +39,7 @@ export class AggregateDBTool extends MongoDBToolBase {
     // (undocumented)
     argsShape: {
         responseBytesLimit: z.ZodDefault<z.ZodOptional<z.ZodNumber>>;
-        pipeline: z.ZodArray<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
+        pipeline: z.ZodTuple<[z.ZodPipe<z.ZodRecord<z.ZodUnion<readonly [z.ZodLiteral<"$changeStream">, z.ZodLiteral<"$currentOp">, z.ZodLiteral<"$documents">, z.ZodLiteral<"$listLocalSessions">, z.ZodLiteral<"$queryStats">]>, z.ZodUnknown>, z.ZodTransform<Record<"$changeStream" | "$currentOp" | "$documents" | "$listLocalSessions" | "$queryStats", unknown>, Record<"$changeStream" | "$currentOp" | "$documents" | "$listLocalSessions" | "$queryStats", unknown>>>], z.ZodRecord<z.ZodString, z.ZodUnknown>>;
         database: z.ZodString;
     };
     // (undocumented)

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -35,6 +35,24 @@ import { ZodString } from 'zod';
 import { ZodUnknown } from 'zod';
 
 // @public (undocumented)
+export class AggregateDBTool extends MongoDBToolBase {
+    // (undocumented)
+    argsShape: {
+        responseBytesLimit: z.ZodDefault<z.ZodOptional<z.ZodNumber>>;
+        pipeline: z.ZodArray<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
+        database: z.ZodString;
+    };
+    // (undocumented)
+    description: string;
+    // (undocumented)
+    protected execute(input: ToolArgs<typeof AggregateDBTool.argsShape>, input2: ToolExecutionContext): Promise<CallToolResult>;
+    // (undocumented)
+    static operationType: OperationType;
+    // (undocumented)
+    static toolName: string;
+}
+
+// @public (undocumented)
 export class AggregateTool extends MongoDBToolBase {
     // (undocumented)
     argsShape: {
@@ -66,8 +84,8 @@ export class AggregateTool extends MongoDBToolBase {
                 }>>;
             }, z.core.$strip>]>;
         }, z.core.$strip>, z.ZodRecord<z.ZodString, z.ZodUnknown>]>>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -91,15 +109,15 @@ export type CollectionIndexesOutput = z.infer<z.ZodObject<typeof CollectionIndex
 export class CollectionIndexesTool extends MongoDBToolBase {
     // (undocumented)
     argsShape: {
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
-    // Warning: (ae-forgotten-export) The symbol "DbOperationArgs" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "CollOperationArgs" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    protected execute(input: ToolArgs<typeof DbOperationArgs>): Promise<ToolResult<typeof CollectionIndexesTool.outputSchema>>;
+    protected execute(input: ToolArgs<typeof CollOperationArgs>): Promise<ToolResult<typeof CollectionIndexesTool.outputSchema>>;
     // Warning: (ae-forgotten-export) The symbol "SearchIndexStatus" needs to be exported by the entry point index.d.ts
     protected extractSearchIndexDetails(indexes: Record<string, unknown>[]): SearchIndexStatus[];
     // (undocumented)
@@ -137,8 +155,8 @@ export class CollectionSchemaTool extends MongoDBToolBase {
     argsShape: {
         sampleSize: z.ZodDefault<z.ZodOptional<z.ZodNumber>>;
         responseBytesLimit: z.ZodDefault<z.ZodOptional<z.ZodNumber>>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -164,13 +182,13 @@ export type CollectionStorageSizeOutput = z.infer<z.ZodObject<typeof CollectionS
 export class CollectionStorageSizeTool extends MongoDBToolBase {
     // (undocumented)
     argsShape: {
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
     // (undocumented)
-    protected execute(input: ToolArgs<typeof DbOperationArgs>, input2: ToolExecutionContext): Promise<ToolResult<typeof CollectionStorageSizeTool.outputSchema>>;
+    protected execute(input: ToolArgs<typeof CollOperationArgs>, input2: ToolExecutionContext): Promise<ToolResult<typeof CollectionStorageSizeTool.outputSchema>>;
     // (undocumented)
     protected handleError(error: unknown, args: ToolArgs<typeof CollectionStorageSizeTool.argsShape>): Promise<CallToolResult>;
     // (undocumented)
@@ -264,8 +282,8 @@ export class CountTool extends MongoDBToolBase {
     // (undocumented)
     argsShape: {
         query: ZodOptional<ZodRecord<ZodString, ZodUnknown>>;
-        database: ZodString;
         collection: ZodString;
+        database: ZodString;
     };
     // (undocumented)
     description: string;
@@ -308,8 +326,8 @@ export type CreateCollectionOutput = z.infer<z.ZodObject<typeof CreateCollection
 export class CreateCollectionTool extends MongoDBToolBase {
     // (undocumented)
     argsShape: {
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -459,8 +477,8 @@ export class CreateIndexTool extends MongoDBToolBase {
             }, z.core.$strip>;
             numPartitions: z.ZodPipe<z.ZodDefault<z.ZodUnion<readonly [z.ZodLiteral<"1">, z.ZodLiteral<"2">, z.ZodLiteral<"4">]>>, z.ZodTransform<number, "1" | "2" | "4">>;
         }, z.core.$strip>], "type">>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -553,8 +571,8 @@ export class DeleteManyTool extends MongoDBToolBase {
     // (undocumented)
     argsShape: {
         filter: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -583,8 +601,8 @@ export type DropCollectionOutput = z.infer<z.ZodObject<typeof DropCollectionOutp
 export class DropCollectionTool extends MongoDBToolBase {
     // (undocumented)
     argsShape: {
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -646,8 +664,8 @@ export class DropIndexTool extends MongoDBToolBase {
             search: "search";
             classic: "classic";
         }>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -730,8 +748,8 @@ export class ExplainTool extends MongoDBToolBase {
             executionStats: "executionStats";
             allPlansExecution: "allPlansExecution";
         }>>>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -800,8 +818,8 @@ export class ExportTool extends MongoDBToolBase {
             relaxed: "relaxed";
             canonical: "canonical";
         }>>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -824,8 +842,8 @@ export class FindTool extends MongoDBToolBase {
         sort: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<readonly [z.ZodLiteral<1>, z.ZodLiteral<-1>, z.ZodLiteral<"asc">, z.ZodLiteral<"desc">, z.ZodLiteral<"ascending">, z.ZodLiteral<"descending">, z.ZodObject<{
             $meta: z.ZodString;
         }, z.core.$strip>]>>>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -878,8 +896,8 @@ export class InsertManyTool extends MongoDBToolBase {
     // (undocumented)
     argsShape: {
         documents: z.ZodArray<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -1171,8 +1189,8 @@ export class RenameCollectionTool extends MongoDBToolBase {
     argsShape: {
         newName: z.ZodString;
         dropTarget: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -1642,8 +1660,8 @@ export class UpdateManyTool extends MongoDBToolBase {
         filter: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
         update: z.ZodRecord<z.ZodString, z.ZodUnknown>;
         upsert: z.ZodOptional<z.ZodBoolean>;
-        database: z.ZodString;
         collection: z.ZodString;
+        database: z.ZodString;
     };
     // (undocumented)
     description: string;

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -96,10 +96,10 @@ export class CollectionIndexesTool extends MongoDBToolBase {
     };
     // (undocumented)
     description: string;
-    // Warning: (ae-forgotten-export) The symbol "CollOperationArgs" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "DbOperationArgs" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    protected execute(input: ToolArgs<typeof CollOperationArgs>): Promise<ToolResult<typeof CollectionIndexesTool.outputSchema>>;
+    protected execute(input: ToolArgs<typeof DbOperationArgs>): Promise<ToolResult<typeof CollectionIndexesTool.outputSchema>>;
     // Warning: (ae-forgotten-export) The symbol "SearchIndexStatus" needs to be exported by the entry point index.d.ts
     protected extractSearchIndexDetails(indexes: Record<string, unknown>[]): SearchIndexStatus[];
     // (undocumented)
@@ -170,7 +170,7 @@ export class CollectionStorageSizeTool extends MongoDBToolBase {
     // (undocumented)
     description: string;
     // (undocumented)
-    protected execute(input: ToolArgs<typeof CollOperationArgs>, input2: ToolExecutionContext): Promise<ToolResult<typeof CollectionStorageSizeTool.outputSchema>>;
+    protected execute(input: ToolArgs<typeof DbOperationArgs>, input2: ToolExecutionContext): Promise<ToolResult<typeof CollectionStorageSizeTool.outputSchema>>;
     // (undocumented)
     protected handleError(error: unknown, args: ToolArgs<typeof CollectionStorageSizeTool.argsShape>): Promise<CallToolResult>;
     // (undocumented)

--- a/src/tools/args.ts
+++ b/src/tools/args.ts
@@ -75,7 +75,7 @@ export const AtlasArgs = {
         z.string().min(1, "Password is required").max(100, "Password must be 100 characters or less"),
 };
 
-function toEJSON<T extends object | undefined>(value: T): T {
+export function toEJSON<T extends object | undefined>(value: T): T {
     if (!value) {
         return value;
     }

--- a/src/tools/mongodb/create/createCollection.ts
+++ b/src/tools/mongodb/create/createCollection.ts
@@ -1,4 +1,4 @@
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { OperationType, ToolArgs, ToolResult } from "../../tool.js";
 import { z } from "zod";
 
@@ -14,7 +14,7 @@ export class CreateCollectionTool extends MongoDBToolBase {
     static toolName = "create-collection";
     public description =
         "Creates a new collection in a database. If the database doesn't exist, it will be created automatically.";
-    public argsShape = DbOperationArgs;
+    public argsShape = CollOperationArgs;
     public override outputSchema = CreateCollectionOutputSchema;
 
     static operationType: OperationType = "create";

--- a/src/tools/mongodb/create/createIndex.ts
+++ b/src/tools/mongodb/create/createIndex.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import { type ToolArgs, type OperationType, type ToolResult } from "../../tool.js";
 import { IndexDirectionSchema, modelsSupportingAutoEmbedIndexes } from "../mongodbSchemas.js";
 
@@ -191,7 +191,7 @@ Use 'filter' for additional fields to filter on. At least one 'vector' or 'autoE
     static toolName = "create-index";
     public description = "Create an index for a collection";
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         name: z.string().optional().describe("The name of the index"),
         // Note: Although it is not required to wrap the discriminated union in
         // an array here because we only expect exactly one definition to be

--- a/src/tools/mongodb/create/insertMany.ts
+++ b/src/tools/mongodb/create/insertMany.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import { type ToolArgs, type OperationType, formatUntrustedData, type ToolResult } from "../../tool.js";
 import { zEJSON } from "../../args.js";
 import { type Document } from "bson";
@@ -18,7 +18,7 @@ export class InsertManyTool extends MongoDBToolBase {
     public description =
         "Insert an array of documents into a MongoDB collection. If the list of documents is above com.mongodb/maxRequestPayloadBytes, consider inserting them in batches.";
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         documents: z
             .array(zEJSON().describe("An individual MongoDB document"))
             .describe(

--- a/src/tools/mongodb/delete/deleteMany.ts
+++ b/src/tools/mongodb/delete/deleteMany.ts
@@ -1,4 +1,4 @@
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
 import { checkIndexUsage } from "../../../helpers/indexCheck.js";
 import { EJSON } from "bson";
@@ -17,7 +17,7 @@ export class DeleteManyTool extends MongoDBToolBase {
     static toolName = "delete-many";
     public description = "Removes all documents that match the filter from a MongoDB collection";
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         filter: zEJSON()
             .optional()
             .describe(

--- a/src/tools/mongodb/delete/dropCollection.ts
+++ b/src/tools/mongodb/delete/dropCollection.ts
@@ -1,4 +1,4 @@
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
 import { z } from "zod";
 
@@ -15,7 +15,7 @@ export class DropCollectionTool extends MongoDBToolBase {
     public description =
         "Removes a collection or view from the database. The method also removes any indexes associated with the dropped collection.";
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
     };
     public override outputSchema = DropCollectionOutputSchema;
     static operationType: OperationType = "delete";

--- a/src/tools/mongodb/delete/dropDatabase.ts
+++ b/src/tools/mongodb/delete/dropDatabase.ts
@@ -1,4 +1,4 @@
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { DBOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
 import { z } from "zod";
 
@@ -12,9 +12,7 @@ export type DropDatabaseOutput = z.infer<z.ZodObject<typeof DropDatabaseOutputSc
 export class DropDatabaseTool extends MongoDBToolBase {
     static toolName = "drop-database";
     public description = "Removes the specified database, deleting the associated data files";
-    public argsShape = {
-        database: DbOperationArgs.database,
-    };
+    public argsShape = DBOperationArgs;
     public override outputSchema = DropDatabaseOutputSchema;
     static operationType: OperationType = "delete";
 

--- a/src/tools/mongodb/delete/dropIndex.ts
+++ b/src/tools/mongodb/delete/dropIndex.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import { type ToolArgs, type OperationType, formatUntrustedData, type ToolResult } from "../../tool.js";
 
 const DropIndexOutputSchema = {
@@ -16,7 +16,7 @@ export class DropIndexTool extends MongoDBToolBase {
     static toolName = "drop-index";
     public description = "Drop an index for the provided database and collection.";
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         indexName: z.string().nonempty().describe("The name of the index to be dropped."),
         type: z
             .enum(["classic", "search"])

--- a/src/tools/mongodb/metadata/collectionIndexes.ts
+++ b/src/tools/mongodb/metadata/collectionIndexes.ts
@@ -1,4 +1,4 @@
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
 import { formatUntrustedData } from "../../tool.js";
 import { z } from "zod";
@@ -32,14 +32,14 @@ type IndexStatus = CollectionIndexesOutput["classicIndexes"][number];
 export class CollectionIndexesTool extends MongoDBToolBase {
     static toolName = "collection-indexes";
     public description = "Describe the indexes for a collection";
-    public argsShape = DbOperationArgs;
+    public argsShape = CollOperationArgs;
     public override outputSchema = CollectionIndexesOutputSchema;
     static operationType: OperationType = "metadata";
 
     protected async execute({
         database,
         collection,
-    }: ToolArgs<typeof DbOperationArgs>): Promise<ToolResult<typeof this.outputSchema>> {
+    }: ToolArgs<typeof CollOperationArgs>): Promise<ToolResult<typeof this.outputSchema>> {
         const provider = await this.ensureConnected();
         const indexes = await provider.getIndexes(database, collection);
         const classicIndexes: IndexStatus[] = indexes.map((index) => ({

--- a/src/tools/mongodb/metadata/collectionSchema.ts
+++ b/src/tools/mongodb/metadata/collectionSchema.ts
@@ -1,4 +1,4 @@
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolExecutionContext, ToolResult } from "../../tool.js";
 import { formatUntrustedData } from "../../tool.js";
 import { getSimplifiedSchema } from "mongodb-schema";
@@ -20,7 +20,7 @@ export class CollectionSchemaTool extends MongoDBToolBase {
     static toolName = "collection-schema";
     public description = "Describe the schema for a collection";
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         sampleSize: z.number().optional().default(50).describe("Number of documents to sample for schema inference"),
         responseBytesLimit: z
             .number()

--- a/src/tools/mongodb/metadata/collectionStorageSize.ts
+++ b/src/tools/mongodb/metadata/collectionStorageSize.ts
@@ -1,4 +1,4 @@
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolExecutionContext, ToolResult } from "../../tool.js";
 import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -13,13 +13,13 @@ export type CollectionStorageSizeOutput = z.infer<z.ZodObject<typeof CollectionS
 export class CollectionStorageSizeTool extends MongoDBToolBase {
     static toolName = "collection-storage-size";
     public description = "Gets the size of the collection";
-    public argsShape = DbOperationArgs;
+    public argsShape = CollOperationArgs;
     public override outputSchema = CollectionStorageSizeOutputSchema;
 
     static operationType: OperationType = "metadata";
 
     protected async execute(
-        { database, collection }: ToolArgs<typeof DbOperationArgs>,
+        { database, collection }: ToolArgs<typeof CollOperationArgs>,
         { signal }: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
         const provider = await this.ensureConnected();

--- a/src/tools/mongodb/metadata/dbStats.ts
+++ b/src/tools/mongodb/metadata/dbStats.ts
@@ -1,4 +1,4 @@
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { DBOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolExecutionContext, ToolResult } from "../../tool.js";
 import { formatUntrustedData } from "../../tool.js";
 import { EJSON } from "bson";
@@ -13,9 +13,7 @@ export type DbStatsOutput = z.infer<z.ZodObject<typeof DbStatsOutputSchema>>;
 export class DbStatsTool extends MongoDBToolBase {
     static toolName = "db-stats";
     public description = "Returns statistics that reflect the use state of a single database";
-    public argsShape = {
-        database: DbOperationArgs.database,
-    };
+    public argsShape = DBOperationArgs;
     public override outputSchema = DbStatsOutputSchema;
 
     static operationType: OperationType = "metadata";

--- a/src/tools/mongodb/metadata/explain.ts
+++ b/src/tools/mongodb/metadata/explain.ts
@@ -1,4 +1,4 @@
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolExecutionContext, ToolResult } from "../../tool.js";
 import { formatUntrustedData } from "../../tool.js";
 import { z } from "zod";
@@ -21,7 +21,7 @@ export class ExplainTool extends MongoDBToolBase {
         "Returns statistics describing the execution of the winning plan chosen by the query optimizer for the evaluated method";
 
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         // Note: Although it is not required to wrap the discriminated union in
         // an array here because we only expect exactly one method to be
         // provided here, we unfortunately cannot use the discriminatedUnion as

--- a/src/tools/mongodb/metadata/listCollections.ts
+++ b/src/tools/mongodb/metadata/listCollections.ts
@@ -1,4 +1,4 @@
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { DBOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolExecutionContext, ToolResult } from "../../tool.js";
 import { formatUntrustedData } from "../../tool.js";
 import { z } from "zod";
@@ -17,9 +17,7 @@ export type ListCollectionsOutput = z.infer<z.ZodObject<typeof ListCollectionsOu
 export class ListCollectionsTool extends MongoDBToolBase {
     static toolName = "list-collections";
     public description = "List all collections for a given database";
-    public argsShape = {
-        database: DbOperationArgs.database,
-    };
+    public argsShape = DBOperationArgs;
     public override outputSchema = ListCollectionsOutputSchema;
 
     static operationType: OperationType = "metadata";

--- a/src/tools/mongodb/mongodbSchemas.ts
+++ b/src/tools/mongodb/mongodbSchemas.ts
@@ -3,16 +3,18 @@ import { toEJSON, zEJSON } from "../args.js";
 
 export const AnyAggregateStage = zEJSON();
 
-export const DBAggregateStage = z.record(
-    z.union([
-        z.literal("$changeStream"),
-        z.literal("$currentOp"),
-        z.literal("$documents"),
-        z.literal("$listLocalSessions"),
-        z.literal("$queryStats"),
-    ]),
-    z.unknown()
-).transform(toEJSON);
+export const DBAggregateStage = z
+    .record(
+        z.union([
+            z.literal("$changeStream"),
+            z.literal("$currentOp"),
+            z.literal("$documents"),
+            z.literal("$listLocalSessions"),
+            z.literal("$queryStats"),
+        ]),
+        z.unknown()
+    )
+    .transform(toEJSON);
 
 // Mirrors mongodb's IndexDirection type. The driver additionally accepts
 // arbitrary `number` values, but only 1 and -1 are meaningful in practice -

--- a/src/tools/mongodb/mongodbSchemas.ts
+++ b/src/tools/mongodb/mongodbSchemas.ts
@@ -1,7 +1,18 @@
 import z from "zod";
-import { zEJSON } from "../args.js";
+import { toEJSON, zEJSON } from "../args.js";
 
 export const AnyAggregateStage = zEJSON();
+
+export const DBAggregateStage = z.record(
+    z.union([
+        z.literal("$changeStream"),
+        z.literal("$currentOp"),
+        z.literal("$documents"),
+        z.literal("$listLocalSessions"),
+        z.literal("$queryStats"),
+    ]),
+    z.unknown()
+).transform(toEJSON);
 
 // Mirrors mongodb's IndexDirection type. The driver additionally accepts
 // arbitrary `number` values, but only 1 and -1 are meaningful in practice -

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -8,8 +8,12 @@ import { LogId } from "../../common/logging/index.js";
 import type { Server } from "../../server.js";
 import type { ConnectionMetadata } from "../../telemetry/types.js";
 
-export const DbOperationArgs = {
+export const DBOperationArgs = {
     database: z.string().describe("Database name"),
+};
+
+export const CollOperationArgs = {
+    ...DBOperationArgs,
     collection: z.string().describe("Collection name"),
 };
 

--- a/src/tools/mongodb/read/aggregate.ts
+++ b/src/tools/mongodb/read/aggregate.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { AggregationCursor } from "mongodb";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolExecutionContext } from "../../tool.js";
 import { formatUntrustedData } from "../../tool.js";
 import { checkIndexUsage } from "../../../helpers/indexCheck.js";
@@ -52,7 +52,7 @@ export class AggregateTool extends MongoDBToolBase {
     static toolName = "aggregate";
     public description = "Run an aggregation against a MongoDB collection";
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         ...AggregateArgs,
         responseBytesLimit: z.number().optional().default(ONE_MB).describe(`\
 The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. \

--- a/src/tools/mongodb/read/aggregateDB.ts
+++ b/src/tools/mongodb/read/aggregateDB.ts
@@ -44,7 +44,7 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
             if (pipeline.some((stage) => this.isWriteStage(stage))) {
                 // This is a write pipeline, so special-case it and don't attempt to apply limits or caps
                 aggregationCursor = provider.aggregateDb(database, pipeline, {
-                    signal,
+                    ...this.getOperationOptions(signal),
                 });
 
                 documents = await aggregationCursor.toArray();
@@ -55,7 +55,7 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
                     cappedResultsPipeline.push({ $limit: this.config.maxDocumentsPerQuery });
                 }
                 aggregationCursor = provider.aggregateDb(database, cappedResultsPipeline, {
-                    signal,
+                    ...this.getOperationOptions(signal),
                 });
 
                 const [totalDocuments, cursorResults] = await Promise.all([
@@ -156,7 +156,11 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
                 .aggregateDb(database, resultsCountAggregation, {
                     signal: abortSignal,
                 })
-                .maxTimeMS(AGG_COUNT_MAX_TIME_MS_CAP)
+                .maxTimeMS(
+                    this.config.maxTimeMS !== undefined
+                        ? Math.min(this.config.maxTimeMS, AGG_COUNT_MAX_TIME_MS_CAP)
+                        : AGG_COUNT_MAX_TIME_MS_CAP
+                )
                 .toArray();
 
             const documentWithCount: unknown = aggregationResults.length === 1 ? aggregationResults[0] : undefined;

--- a/src/tools/mongodb/read/aggregateDB.ts
+++ b/src/tools/mongodb/read/aggregateDB.ts
@@ -14,8 +14,11 @@ import { LogId } from "../../../common/logging/index.js";
 import { AnyAggregateStage, DBAggregateStage } from "../mongodbSchemas.js";
 
 export const AggregateArgs = {
-    pipeline: z.tuple([DBAggregateStage], AnyAggregateStage)
-        .describe("An array of aggregation stages to execute. Has to start with a database aggregation stage. https://www.mongodb.com/docs/manual/reference/mql/aggregation-stages/#db.aggregate---stages"),
+    pipeline: z
+        .tuple([DBAggregateStage], AnyAggregateStage)
+        .describe(
+            "An array of aggregation stages to execute. Has to start with a database aggregation stage. https://www.mongodb.com/docs/manual/reference/mql/aggregation-stages/#db.aggregate---stages"
+        ),
 };
 
 export class AggregateDBTool extends MongoDBToolBase {

--- a/src/tools/mongodb/read/aggregateDB.ts
+++ b/src/tools/mongodb/read/aggregateDB.ts
@@ -1,0 +1,207 @@
+import { z } from "zod";
+import type { AggregationCursor } from "mongodb";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import { DBOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import type { ToolArgs, OperationType, ToolExecutionContext } from "../../tool.js";
+import { formatUntrustedData } from "../../tool.js";
+import { type Document, EJSON } from "bson";
+import { ErrorCodes, MongoDBError } from "../../../common/errors.js";
+import { collectCursorUntilMaxBytesLimit } from "../../../helpers/collectCursorUntilMaxBytes.js";
+import { operationWithFallback } from "../../../helpers/operationWithFallback.js";
+import { AGG_COUNT_MAX_TIME_MS_CAP, ONE_MB, CURSOR_LIMITS_TO_LLM_TEXT } from "../../../helpers/constants.js";
+import { LogId } from "../../../common/logging/index.js";
+import { AnyAggregateStage } from "../mongodbSchemas.js";
+
+export const AggregateArgs = {
+    pipeline: z.array(AnyAggregateStage).describe("An array of aggregation stages to execute."),
+};
+
+export class AggregateDBTool extends MongoDBToolBase {
+    static toolName = "aggregateDB";
+    public description = "Run an aggregation against a MongoDB database";
+    public argsShape = {
+        ...DBOperationArgs,
+        ...AggregateArgs,
+        responseBytesLimit: z.number().optional().default(ONE_MB).describe(`\
+The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. \
+Note to LLM: If the entire aggregation result is required, use the "export" tool instead of increasing this limit.\
+`),
+    };
+    static operationType: OperationType = "read";
+
+    protected async execute(
+        { database, pipeline, responseBytesLimit }: ToolArgs<typeof this.argsShape>,
+        { signal }: ToolExecutionContext
+    ): Promise<CallToolResult> {
+        let aggregationCursor: AggregationCursor | undefined = undefined;
+        try {
+            const provider = await this.ensureConnected();
+            await this.assertOnlyUsesPermittedStages(pipeline);
+
+            let successMessage: string;
+            let documents: unknown[];
+            if (pipeline.some((stage) => this.isWriteStage(stage))) {
+                // This is a write pipeline, so special-case it and don't attempt to apply limits or caps
+                aggregationCursor = provider.aggregateDb(database, pipeline, {
+                    signal,
+                });
+
+                documents = await aggregationCursor.toArray();
+                successMessage = "The aggregation pipeline executed successfully.";
+            } else {
+                const cappedResultsPipeline = [...pipeline];
+                if (this.config.maxDocumentsPerQuery > 0) {
+                    cappedResultsPipeline.push({ $limit: this.config.maxDocumentsPerQuery });
+                }
+                aggregationCursor = provider.aggregateDb(database, cappedResultsPipeline, {
+                    signal,
+                });
+
+                const [totalDocuments, cursorResults] = await Promise.all([
+                    this.countAggregationResultDocuments({
+                        provider,
+                        database,
+                        pipeline,
+                        abortSignal: signal,
+                    }),
+                    collectCursorUntilMaxBytesLimit({
+                        cursor: aggregationCursor,
+                        configuredMaxBytesPerQuery: this.config.maxBytesPerQuery,
+                        toolResponseBytesLimit: responseBytesLimit,
+                        abortSignal: signal,
+                    }),
+                ]);
+
+                // If the total number of documents that the aggregation would've
+                // resulted in would be greater than the configured
+                // maxDocumentsPerQuery then we know for sure that the results were
+                // capped.
+                const aggregationResultsCappedByMaxDocumentsLimit =
+                    this.config.maxDocumentsPerQuery > 0 &&
+                    !!totalDocuments &&
+                    totalDocuments > this.config.maxDocumentsPerQuery;
+
+                documents = cursorResults.documents;
+                successMessage = this.generateMessage({
+                    aggResultsCount: totalDocuments,
+                    documents: cursorResults.documents,
+                    appliedLimits: [
+                        aggregationResultsCappedByMaxDocumentsLimit ? "config.maxDocumentsPerQuery" : undefined,
+                        cursorResults.cappedBy,
+                    ].filter((limit): limit is keyof typeof CURSOR_LIMITS_TO_LLM_TEXT => !!limit),
+                });
+            }
+
+            return {
+                content: formatUntrustedData(
+                    successMessage,
+                    ...(documents.length > 0 ? [EJSON.stringify(documents)] : [])
+                ),
+            };
+        } finally {
+            if (aggregationCursor) {
+                void this.safeCloseCursor(aggregationCursor);
+            }
+        }
+    }
+
+    private async safeCloseCursor(cursor: AggregationCursor<unknown>): Promise<void> {
+        try {
+            await cursor.close();
+        } catch (error) {
+            this.session.logger.warning({
+                id: LogId.mongodbCursorCloseError,
+                context: "aggregate tool",
+                message: `Error when closing the cursor - ${error instanceof Error ? error.message : String(error)}`,
+            });
+        }
+    }
+
+    private async assertOnlyUsesPermittedStages(pipeline: Record<string, unknown>[]): Promise<void> {
+        const writeOperations: OperationType[] = ["update", "create", "delete"];
+        let writeStageForbiddenError = "";
+
+        if (this.config.readOnly) {
+            writeStageForbiddenError = "In readOnly mode you can not run pipelines with $out or $merge stages.";
+        } else if (this.config.disabledTools.some((t) => writeOperations.includes(t as OperationType))) {
+            writeStageForbiddenError =
+                "When 'create', 'update', or 'delete' operations are disabled, you can not run pipelines with $out or $merge stages.";
+        }
+
+        for (const stage of pipeline) {
+            // This validates that in readOnly mode or "write" operations are disabled, we can't use $out or $merge.
+            // This is really important because aggregates are the only "multi-faceted" tool in the MQL, where you
+            // can both read and write.
+            if (this.isWriteStage(stage) && writeStageForbiddenError) {
+                throw new MongoDBError(ErrorCodes.ForbiddenWriteOperation, writeStageForbiddenError);
+            }
+        }
+    }
+
+    private async countAggregationResultDocuments({
+        provider,
+        database,
+        pipeline,
+        abortSignal,
+    }: {
+        provider: NodeDriverServiceProvider;
+        database: string;
+        pipeline: Document[];
+        abortSignal?: AbortSignal;
+    }): Promise<number | undefined> {
+        const resultsCountAggregation = [...pipeline, { $count: "totalDocuments" }];
+        return await operationWithFallback(async (): Promise<number | undefined> => {
+            const aggregationResults = await provider
+                .aggregateDB(database, resultsCountAggregation, {
+                    signal: abortSignal,
+                })
+                .maxTimeMS(AGG_COUNT_MAX_TIME_MS_CAP)
+                .toArray();
+
+            const documentWithCount: unknown = aggregationResults.length === 1 ? aggregationResults[0] : undefined;
+            const totalDocuments =
+                documentWithCount &&
+                typeof documentWithCount === "object" &&
+                "totalDocuments" in documentWithCount &&
+                typeof documentWithCount.totalDocuments === "number"
+                    ? documentWithCount.totalDocuments
+                    : 0;
+
+            return totalDocuments;
+        }, undefined);
+    }
+
+    private generateMessage({
+        aggResultsCount,
+        documents,
+        appliedLimits,
+    }: {
+        aggResultsCount: number | undefined;
+        documents: unknown[];
+        appliedLimits: (keyof typeof CURSOR_LIMITS_TO_LLM_TEXT)[];
+    }): string {
+        let message = `The aggregation resulted in ${aggResultsCount === undefined ? "indeterminable number of" : aggResultsCount} documents.`;
+
+        // If we applied a limit or the count is different from the aggregation result count,
+        // communicate what is the actual number of returned documents
+        if (documents.length !== aggResultsCount || appliedLimits.length) {
+            message += ` Returning ${documents.length} documents`;
+            if (appliedLimits.length) {
+                message += ` while respecting the applied limits of ${appliedLimits
+                    .map((limit) => CURSOR_LIMITS_TO_LLM_TEXT[limit])
+                    .join(
+                        ", "
+                    )}. Note to LLM: If the entire query result is required then use "export" tool to export the query results`;
+            }
+
+            message += ".";
+        }
+
+        return message;
+    }
+
+    private isWriteStage(stage: Record<string, unknown>): boolean {
+        return "$out" in stage || "$merge" in stage;
+    }
+}

--- a/src/tools/mongodb/read/aggregateDB.ts
+++ b/src/tools/mongodb/read/aggregateDB.ts
@@ -28,9 +28,7 @@ export class AggregateDBTool extends MongoDBToolBase {
         ...DBOperationArgs,
         ...AggregateArgs,
         responseBytesLimit: z.number().optional().default(ONE_MB).describe(`\
-The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. \
-Note to LLM: If the entire aggregation result is required, use the "export" tool instead of increasing this limit.\
-`),
+The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded.`),
     };
     static operationType: OperationType = "read";
 
@@ -116,7 +114,7 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
         } catch (error) {
             this.session.logger.warning({
                 id: LogId.mongodbCursorCloseError,
-                context: "aggregate tool",
+                context: "aggregate-db tool",
                 message: `Error when closing the cursor - ${error instanceof Error ? error.message : String(error)}`,
             });
         }
@@ -198,9 +196,7 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
             if (appliedLimits.length) {
                 message += ` while respecting the applied limits of ${appliedLimits
                     .map((limit) => CURSOR_LIMITS_TO_LLM_TEXT[limit])
-                    .join(
-                        ", "
-                    )}. Note to LLM: If the entire query result is required then use "export" tool to export the query results`;
+                    .join(", ")}`;
             }
 
             message += ".";

--- a/src/tools/mongodb/read/aggregateDB.ts
+++ b/src/tools/mongodb/read/aggregateDB.ts
@@ -37,7 +37,7 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
         let aggregationCursor: AggregationCursor | undefined = undefined;
         try {
             const provider = await this.ensureConnected();
-            await this.assertOnlyUsesPermittedStages(pipeline);
+            this.assertOnlyUsesPermittedStages(pipeline);
 
             let successMessage: string;
             let documents: unknown[];
@@ -118,7 +118,7 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
         }
     }
 
-    private async assertOnlyUsesPermittedStages(pipeline: Record<string, unknown>[]): Promise<void> {
+    private assertOnlyUsesPermittedStages(pipeline: Record<string, unknown>[]): void {
         const writeOperations: OperationType[] = ["update", "create", "delete"];
         let writeStageForbiddenError = "";
 

--- a/src/tools/mongodb/read/aggregateDB.ts
+++ b/src/tools/mongodb/read/aggregateDB.ts
@@ -11,10 +11,11 @@ import { collectCursorUntilMaxBytesLimit } from "../../../helpers/collectCursorU
 import { operationWithFallback } from "../../../helpers/operationWithFallback.js";
 import { AGG_COUNT_MAX_TIME_MS_CAP, ONE_MB, CURSOR_LIMITS_TO_LLM_TEXT } from "../../../helpers/constants.js";
 import { LogId } from "../../../common/logging/index.js";
-import { AnyAggregateStage } from "../mongodbSchemas.js";
+import { AnyAggregateStage, DBAggregateStage } from "../mongodbSchemas.js";
 
 export const AggregateArgs = {
-    pipeline: z.array(AnyAggregateStage).describe("An array of aggregation stages to execute."),
+    pipeline: z.tuple([DBAggregateStage], AnyAggregateStage)
+        .describe("An array of aggregation stages to execute. Has to start with a database aggregation stage. https://www.mongodb.com/docs/manual/reference/mql/aggregation-stages/#db.aggregate---stages"),
 };
 
 export class AggregateDBTool extends MongoDBToolBase {

--- a/src/tools/mongodb/read/aggregateDB.ts
+++ b/src/tools/mongodb/read/aggregateDB.ts
@@ -18,7 +18,7 @@ export const AggregateArgs = {
 };
 
 export class AggregateDBTool extends MongoDBToolBase {
-    static toolName = "aggregateDB";
+    static toolName = "aggregate-db";
     public description = "Run an aggregation against a MongoDB database";
     public argsShape = {
         ...DBOperationArgs,
@@ -153,7 +153,7 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
         const resultsCountAggregation = [...pipeline, { $count: "totalDocuments" }];
         return await operationWithFallback(async (): Promise<number | undefined> => {
             const aggregationResults = await provider
-                .aggregateDB(database, resultsCountAggregation, {
+                .aggregateDb(database, resultsCountAggregation, {
                     signal: abortSignal,
                 })
                 .maxTimeMS(AGG_COUNT_MAX_TIME_MS_CAP)

--- a/src/tools/mongodb/read/count.ts
+++ b/src/tools/mongodb/read/count.ts
@@ -1,5 +1,5 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolExecutionContext } from "../../tool.js";
 import { checkIndexUsage } from "../../../helpers/indexCheck.js";
 import { zEJSON } from "../../args.js";
@@ -17,7 +17,7 @@ export class CountTool extends MongoDBToolBase {
     public description =
         "Gets the number of documents in a MongoDB collection using db.collection.count() and query as an optional filter parameter";
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         ...CountArgs,
     };
 

--- a/src/tools/mongodb/read/export.ts
+++ b/src/tools/mongodb/read/export.ts
@@ -3,7 +3,7 @@ import { ObjectId } from "bson";
 import type { AggregationCursor, FindCursor } from "mongodb";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { OperationType, ToolArgs, ToolExecutionContext } from "../../tool.js";
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import { FindArgs } from "./find.js";
 import { jsonExportFormat } from "../../../common/exportsManager.js";
 import { AggregateArgs } from "./aggregate.js";
@@ -12,7 +12,7 @@ export class ExportTool extends MongoDBToolBase {
     static toolName = "export";
     public description = "Export a query or aggregation results in the specified EJSON format.";
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         exportTitle: z.string().describe("A short description to uniquely identify the export."),
         // Note: Although it is not required to wrap the discriminated union in
         // an array here because we only expect exactly one exportTarget to be

--- a/src/tools/mongodb/read/find.ts
+++ b/src/tools/mongodb/read/find.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolExecutionContext } from "../../tool.js";
 import { formatUntrustedData } from "../../tool.js";
 import type { FindCursor } from "mongodb";
@@ -35,7 +35,7 @@ export class FindTool extends MongoDBToolBase {
     static toolName = "find";
     public description = "Run a find query against a MongoDB collection";
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         ...FindArgs,
         responseBytesLimit: z.number().optional().default(ONE_MB).describe(`\
 The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. \

--- a/src/tools/mongodb/tools.ts
+++ b/src/tools/mongodb/tools.ts
@@ -11,6 +11,7 @@ export { CollectionStorageSizeTool, type CollectionStorageSizeOutput } from "./m
 export { CountTool } from "./read/count.js";
 export { DbStatsTool, type DbStatsOutput } from "./metadata/dbStats.js";
 export { AggregateTool } from "./read/aggregate.js";
+export { AggregateDBTool } from "./read/aggregateDB.js";
 export { UpdateManyTool, type UpdateManyOutput } from "./update/updateMany.js";
 export { RenameCollectionTool, type RenameCollectionOutput } from "./update/renameCollection.js";
 export { DropDatabaseTool, type DropDatabaseOutput } from "./delete/dropDatabase.js";

--- a/src/tools/mongodb/update/renameCollection.ts
+++ b/src/tools/mongodb/update/renameCollection.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
 
 const RenameCollectionOutputSchema = {
@@ -16,7 +16,7 @@ export class RenameCollectionTool extends MongoDBToolBase {
     public description = "Renames a collection in a MongoDB database";
     public override outputSchema = RenameCollectionOutputSchema;
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         newName: z.string().describe("The new name for the collection"),
         dropTarget: z.boolean().optional().default(false).describe("If true, drops the target collection if it exists"),
     };

--- a/src/tools/mongodb/update/updateMany.ts
+++ b/src/tools/mongodb/update/updateMany.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { DbOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
+import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
 import { checkIndexUsage } from "../../../helpers/indexCheck.js";
 import { zEJSON } from "../../args.js";
@@ -21,7 +21,7 @@ export class UpdateManyTool extends MongoDBToolBase {
         "Updates all documents that match the specified filter for a collection. If the list of documents is above com.mongodb/maxRequestPayloadBytes, consider updating them in batches.";
     public override outputSchema = UpdateManyOutputSchema;
     public argsShape = {
-        ...DbOperationArgs,
+        ...CollOperationArgs,
         filter: zEJSON()
             .optional()
             .describe(

--- a/tests/accuracy/aggregateDB.test.ts
+++ b/tests/accuracy/aggregateDB.test.ts
@@ -26,7 +26,7 @@ describeAccuracyTests([
         ],
     },
     {
-        prompt: "I want to test this query: { $match: { age: { $gt: 28 } } }, I don't have a collection yet. Can you test it with sample data: Alice (age 25), Bob (age 30), and Charlie (age 35)?",
+        prompt: "I want to test this query: { $match: { age: { $gt: 28 } } }. I don't have a collection yet. Can you test it using $documents with these records: {name: 'Alice', age: 25}, {name: 'Bob', age: 30}, {name: 'Charlie', age: 35}?",
         expectedToolCalls: [
             {
                 toolName: "aggregate-db",
@@ -34,11 +34,11 @@ describeAccuracyTests([
                     database: Matcher.string(),
                     pipeline: [
                         {
-                            $documents: Matcher.arrayOrSingle([
-                                Matcher.containing({ age: 30 }),
-                                Matcher.containing({ age: 25 }),
-                                Matcher.containing({ age: 35 }),
-                            ]),
+                            $documents: [
+                                { name: "Alice", age: 25 },
+                                { name: "Bob", age: 30 },
+                                { name: "Charlie", age: 35 },
+                            ],
                         },
                         {
                             $match: {

--- a/tests/accuracy/aggregateDB.test.ts
+++ b/tests/accuracy/aggregateDB.test.ts
@@ -1,0 +1,71 @@
+import { describeAccuracyTests } from "./sdk/describeAccuracyTests.js";
+import { Matcher } from "./sdk/matcher.js";
+
+describeAccuracyTests([
+    {
+        prompt: "Get the current operations running on the admin database, limit to 5 results",
+        expectedToolCalls: [
+            {
+                toolName: "aggregate-db",
+                parameters: {
+                    database: "admin",
+                    pipeline: [
+                        {
+                            $currentOp: {
+                                allUsers: true,
+                                idleSessions: Matcher.anyOf(Matcher.undefined, Matcher.boolean(false)),
+                            },
+                        },
+                        {
+                            $limit: 5,
+                        },
+                    ],
+                    responseBytesLimit: Matcher.anyOf(Matcher.number(), Matcher.undefined),
+                },
+            },
+        ],
+    },
+    {
+        prompt: "I want to test this query: { $match: { age: { $gt: 28 } } }, I don't have a collection yet. Can you test it with sample data: Alice (age 25), Bob (age 30), and Charlie (age 35)?",
+        expectedToolCalls: [
+            {
+                toolName: "aggregate-db",
+                parameters: {
+                    database: Matcher.string(),
+                    pipeline: [
+                        {
+                            $documents: Matcher.arrayOrSingle([
+                                Matcher.containing({ age: 30 }),
+                                Matcher.containing({ age: 25 }),
+                                Matcher.containing({ age: 35 }),
+                            ]),
+                        },
+                        {
+                            $match: {
+                                age: Matcher.value({ $gt: 28 }),
+                            },
+                        },
+                    ],
+                    responseBytesLimit: Matcher.anyOf(Matcher.number(), Matcher.undefined),
+                },
+            },
+        ],
+    },
+    {
+        prompt: "List all local sessions on the admin database",
+        expectedToolCalls: [
+            {
+                toolName: "aggregate-db",
+                parameters: {
+                    database: "admin",
+                    pipeline: [
+                        {
+                            $listLocalSessions: Matcher.value({}),
+                        },
+                    ],
+                    responseBytesLimit: Matcher.anyOf(Matcher.number(), Matcher.undefined),
+                },
+            },
+        ],
+    },
+]);

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -8,7 +8,6 @@ import {
 } from "../../../helpers.js";
 import { expect, it, afterEach } from "vitest";
 import { describeWithMongoDB, getDocsFromUntrustedContent, validateAutoConnectBehavior } from "../mongodbHelpers.js";
-import { freshInsertDocuments } from "./find.test.js";
 import type { Client } from "@modelcontextprotocol/sdk/client";
 
 describeWithMongoDB("aggregate-db tool", (integration) => {

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -186,7 +186,9 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
                 database: "admin",
                 pipeline: [{ $currentOp: { allUsers: true, idleSessions: true } }, { $limit: 10 }],
             },
-            expectedResponse: "The aggregation resulted in 0 documents",
+            validate: (content) => {
+                expect(getResponseContent(content)).toMatch(/The aggregation resulted in \d+ documents/);
+            },
         };
     });
 });

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -186,7 +186,7 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
                 database: "admin",
                 pipeline: [{ $currentOp: { allUsers: true, idleSessions: true } }, { $limit: 10 }],
             },
-            validate: (content) => {
+            validate: (content): void => {
                 expect(getResponseContent(content)).toMatch(/The aggregation resulted in \d+ documents/);
             },
         };

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -279,7 +279,7 @@ describeWithMongoDB(
 );
 
 describeWithMongoDB(
-    "aggregate tool with configured max bytes per query",
+    "aggregate-db tool with configured max bytes per query",
     (integration) => {
         const initialDocsCount = 1000;
         const initialDocuments = Array.from({ length: initialDocsCount }).map((_, idx) => ({
@@ -335,7 +335,7 @@ describeWithMongoDB(
 );
 
 describeWithMongoDB(
-    "aggregate tool with disabled max documents and max bytes per query",
+    "aggregate-db tool with disabled max documents and max bytes per query",
     (integration) => {
         it("should return all the documents that could fit in responseBytesLimit", async () => {
             const initialDocsCount = 1000;
@@ -365,9 +365,9 @@ describeWithMongoDB(
 );
 
 describeWithMongoDB(
-    "aggregate tool with abort signal",
+    "aggregate-db tool with abort signal",
     (integration) => {
-        const initialDocsCount = 10000;
+        const initialDocsCount = 1000;
         const initialDocuments = Array.from({ length: initialDocsCount }).map((_, idx) => ({
             _id: idx,
             description: `Document ${idx}`,
@@ -438,7 +438,7 @@ describeWithMongoDB(
             };
         };
 
-        it("should abort aggregate operation when signal is triggered immediately", async () => {
+        it("should abort aggregate-db operation when signal is triggered immediately", async () => {
             await integration.connectMcpClient();
             const abortController = new AbortController();
 
@@ -455,7 +455,7 @@ describeWithMongoDB(
             expect(error.message).toContain("This operation was aborted");
         });
 
-        it("should abort aggregate operation during cursor iteration", async () => {
+        it("should abort aggregate-db operation during cursor iteration", async () => {
             await integration.connectMcpClient();
             const abortController = new AbortController();
 

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -438,7 +438,7 @@ describeWithMongoDB(
 
             const { result, error, executionTime } = await aggregatePromise;
 
-            expect(executionTime).toBeLessThan(25); // Ensure it aborted quickly
+            expect(executionTime).toBeLessThan(100); // Ensure it aborted quickly
             expect(result).toBeUndefined();
             expectDefined(error);
             expect(error.message).toContain("This operation was aborted");

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -117,7 +117,6 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
             name: "aggregate-db",
             arguments: {
                 database: integration.randomDbName(),
-                collection: "people",
                 pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $out: "outpeople" }],
             },
         });
@@ -156,7 +155,6 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
                 name: "aggregate-db",
                 arguments: {
                     database: integration.randomDbName(),
-                    collection: "people",
                     pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $out: "outpeople" }],
                 },
             });
@@ -173,7 +171,6 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
                 name: "aggregate-db",
                 arguments: {
                     database: integration.randomDbName(),
-                    collection: "people",
                     pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $merge: "outpeople" }],
                 },
             });
@@ -187,9 +184,8 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
     validateAutoConnectBehavior(integration, "aggregate-db", () => {
         return {
             args: {
-                database: integration.randomDbName(),
-                collection: "coll1",
-                pipeline: [{ $match: { name: "Liva" } }],
+                database: "admin",
+                pipeline: [{ $currentOp: { allUsers: true, idleSessions: true } }, { $limit: 10 }],
             },
             expectedResponse: "The aggregation resulted in 0 documents",
         };
@@ -305,13 +301,6 @@ describeWithMongoDB(
         });
 
         it("should return only the documents that could fit in responseBytesLimit", async () => {
-            await freshInsertDocuments({
-                collection: integration.mongoClient().db(integration.randomDbName()).collection("people"),
-                count: 1000,
-                documentMapper(index) {
-                    return { name: `Person ${index}`, age: index };
-                },
-            });
             await integration.connectMcpClient();
             const response = await integration.mcpClient().callTool({
                 name: "aggregate-db",
@@ -349,7 +338,6 @@ describeWithMongoDB(
                 name: "aggregate-db",
                 arguments: {
                     database: integration.randomDbName(),
-                    collection: "people",
                     pipeline: [{ $documents: initialDocuments }, { $sort: { name: -1 } }],
                     responseBytesLimit: 1 * 1024 * 1024, // 1MB
                 },

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -1,0 +1,497 @@
+import {
+    databaseParameters,
+    validateToolMetadata,
+    validateThrowsForInvalidArguments,
+    getResponseContent,
+    defaultTestConfig,
+    expectDefined,
+} from "../../../helpers.js";
+import { expect, it, afterEach } from "vitest";
+import { describeWithMongoDB, getDocsFromUntrustedContent, validateAutoConnectBehavior } from "../mongodbHelpers.js";
+import { freshInsertDocuments } from "./find.test.js";
+import type { Client } from "@modelcontextprotocol/sdk/client";
+
+describeWithMongoDB("aggregate-db tool", (integration) => {
+    afterEach(() => {
+        integration.mcpServer().userConfig.readOnly = false;
+        integration.mcpServer().userConfig.disabledTools = [];
+    });
+
+    validateToolMetadata(integration, "aggregate-db", "Run an aggregation against a MongoDB database", "read", [
+        ...databaseParameters,
+        {
+            name: "pipeline",
+            description: "An array of aggregation stages to execute.",
+            type: "array",
+            required: true,
+        },
+        {
+            name: "responseBytesLimit",
+            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. Note to LLM: If the entire aggregation result is required, use the "export" tool instead of increasing this limit.`,
+            type: "number",
+            required: false,
+        },
+    ]);
+
+    validateThrowsForInvalidArguments(integration, "aggregate-db", [
+        {},
+        { database: "test", collection: "foo" },
+        { database: "test", pipeline: {} },
+        { database: 123, pipeline: [] },
+    ]);
+
+    it("can run aggregation-db on an existing database", async () => {
+        await integration.connectMcpClient();
+        const response = await integration.mcpClient().callTool({
+            name: "aggregate-db",
+            arguments: {
+                database: integration.randomDbName(),
+                pipeline: [
+                    {
+                        $documents: [
+                            { name: "test1", value: 1 },
+                            { name: "test2", value: 2 },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        const content = getResponseContent(response);
+        expect(content).toContain("The aggregation resulted in 2 documents");
+        const docs = getDocsFromUntrustedContent(content);
+        expect(docs[0]).toEqual({ name: "test1", value: 1 });
+        expect(docs[1]).toEqual({ name: "test2", value: 2 });
+    });
+
+    it("can run aggregation-db on the admin database", async () => {
+        await integration.connectMcpClient();
+        const response = await integration.mcpClient().callTool({
+            name: "aggregate-db",
+            arguments: {
+                database: "admin",
+                pipeline: [{ $currentOp: { allUsers: true, idleSessions: true } }, { $limit: 10 }],
+            },
+        });
+
+        const content = getResponseContent(response);
+        expect(content).toMatch(/The aggregation resulted in \d+ documents/);
+    });
+
+    it("can not run $out stages in readOnly mode", async () => {
+        await integration.connectMcpClient();
+        integration.mcpServer().userConfig.readOnly = true;
+        const response = await integration.mcpClient().callTool({
+            name: "aggregate-db",
+            arguments: {
+                database: integration.randomDbName(),
+                pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $out: "outpeople" }],
+            },
+        });
+        const content = getResponseContent(response);
+        expect(content).toEqual(
+            "Error running aggregate-db: In readOnly mode you can not run pipelines with $out or $merge stages."
+        );
+    });
+
+    it("can not run $merge stages in readOnly mode", async () => {
+        await integration.connectMcpClient();
+        integration.mcpServer().userConfig.readOnly = true;
+        const response = await integration.mcpClient().callTool({
+            name: "aggregate-db",
+            arguments: {
+                database: integration.randomDbName(),
+                pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $merge: "outpeople" }],
+            },
+        });
+        const content = getResponseContent(response);
+        expect(content).toEqual(
+            "Error running aggregate-db: In readOnly mode you can not run pipelines with $out or $merge stages."
+        );
+    });
+
+    it("can run $out stages in non-readonly mode", async () => {
+        const mongoClient = integration.mongoClient();
+        await integration.connectMcpClient();
+        const response = await integration.mcpClient().callTool({
+            name: "aggregate-db",
+            arguments: {
+                database: integration.randomDbName(),
+                collection: "people",
+                pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $out: "outpeople" }],
+            },
+        });
+        const content = getResponseContent(response);
+        expect(content).toEqual("The aggregation pipeline executed successfully.");
+
+        const copiedDocs = await mongoClient.db(integration.randomDbName()).collection("outpeople").find().toArray();
+        expect(copiedDocs).toHaveLength(1);
+        expect(copiedDocs.map((doc) => doc.name as string)).toEqual(["Peter"]);
+    });
+
+    it("can run $merge stages in non-readonly mode", async () => {
+        const mongoClient = integration.mongoClient();
+        await integration.connectMcpClient();
+        const response = await integration.mcpClient().callTool({
+            name: "aggregate-db",
+            arguments: {
+                database: integration.randomDbName(),
+                collection: "people",
+                pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $merge: "mergedpeople" }],
+            },
+        });
+        const content = getResponseContent(response);
+        expect(content).toEqual("The aggregation pipeline executed successfully.");
+
+        const mergedDocs = await mongoClient.db(integration.randomDbName()).collection("mergedpeople").find().toArray();
+        expect(mergedDocs).toHaveLength(1);
+        expect(mergedDocs.map((doc) => doc.name as string)).toEqual(["Peter"]);
+    });
+
+    for (const disabledOpType of ["create", "update", "delete"] as const) {
+        it(`can not run $out stages when ${disabledOpType} operation is disabled`, async () => {
+            await integration.connectMcpClient();
+            integration.mcpServer().userConfig.disabledTools = [disabledOpType];
+            const response = await integration.mcpClient().callTool({
+                name: "aggregate-db",
+                arguments: {
+                    database: integration.randomDbName(),
+                    collection: "people",
+                    pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $out: "outpeople" }],
+                },
+            });
+            const content = getResponseContent(response);
+            expect(content).toEqual(
+                "Error running aggregate-db: When 'create', 'update', or 'delete' operations are disabled, you can not run pipelines with $out or $merge stages."
+            );
+        });
+
+        it(`can not run $merge stages when ${disabledOpType} operation is disabled`, async () => {
+            await integration.connectMcpClient();
+            integration.mcpServer().userConfig.disabledTools = [disabledOpType];
+            const response = await integration.mcpClient().callTool({
+                name: "aggregate-db",
+                arguments: {
+                    database: integration.randomDbName(),
+                    collection: "people",
+                    pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $merge: "outpeople" }],
+                },
+            });
+            const content = getResponseContent(response);
+            expect(content).toEqual(
+                "Error running aggregate-db: When 'create', 'update', or 'delete' operations are disabled, you can not run pipelines with $out or $merge stages."
+            );
+        });
+    }
+
+    validateAutoConnectBehavior(integration, "aggregate-db", () => {
+        return {
+            args: {
+                database: integration.randomDbName(),
+                collection: "coll1",
+                pipeline: [{ $match: { name: "Liva" } }],
+            },
+            expectedResponse: "The aggregation resulted in 0 documents",
+        };
+    });
+});
+
+describeWithMongoDB(
+    "aggregate-db tool with configured max documents per query",
+    (integration) => {
+        const initialDocsCount = 100;
+        const initialDocs = Array.from({ length: initialDocsCount }).map((_, idx) => ({
+            name: `Person ${idx}`,
+            age: idx,
+        }));
+
+        const validateDocs = (docs: unknown[], expectedLength: number): void => {
+            expect(docs).toHaveLength(expectedLength);
+
+            const expectedObjects = Array.from({ length: expectedLength }).map((_, idx) => ({
+                name: `Person ${initialDocsCount - 1 - idx}`,
+                age: initialDocsCount - 1 - idx,
+            }));
+
+            expect((docs as { name: string; age: number }[]).map((doc) => ({ name: doc.name, age: doc.age }))).toEqual(
+                expectedObjects
+            );
+        };
+
+        it("should return documents limited to the configured limit without $limit stage", async () => {
+            await integration.connectMcpClient();
+            const response = await integration.mcpClient().callTool({
+                name: "aggregate-db",
+                arguments: {
+                    database: integration.randomDbName(),
+                    pipeline: [{ $documents: initialDocs }, { $sort: { age: -1 } }],
+                },
+            });
+
+            const content = getResponseContent(response);
+            expect(content).toContain("The aggregation resulted in 100 documents");
+            expect(content).toContain(
+                `Returning 20 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery.`
+            );
+            const docs = getDocsFromUntrustedContent(content);
+            validateDocs(docs, 20);
+        });
+
+        it("should return documents limited to the configured limit with $limit stage larger than the configured", async () => {
+            await integration.connectMcpClient();
+            const response = await integration.mcpClient().callTool({
+                name: "aggregate-db",
+                arguments: {
+                    database: integration.randomDbName(),
+                    pipeline: [{ $documents: initialDocs }, { $sort: { age: -1 } }, { $limit: 50 }],
+                },
+            });
+
+            const content = getResponseContent(response);
+            expect(content).toContain("The aggregation resulted in 50 documents");
+            expect(content).toContain(
+                `Returning 20 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery.`
+            );
+            const docs = getDocsFromUntrustedContent(content);
+            validateDocs(docs, 20);
+        });
+
+        it("should return documents limited to the $limit stage when smaller than the configured limit", async () => {
+            await integration.connectMcpClient();
+            const response = await integration.mcpClient().callTool({
+                name: "aggregate-db",
+                arguments: {
+                    database: integration.randomDbName(),
+                    pipeline: [{ $documents: initialDocs }, { $sort: { age: -1 } }, { $limit: 5 }],
+                },
+            });
+
+            const content = getResponseContent(response);
+            expect(content).toContain("The aggregation resulted in 5 documents");
+
+            const docs = getDocsFromUntrustedContent(content);
+            validateDocs(docs, 5);
+        });
+    },
+    {
+        getUserConfig: () => ({ ...defaultTestConfig, maxDocumentsPerQuery: 20 }),
+    }
+);
+
+describeWithMongoDB(
+    "aggregate tool with configured max bytes per query",
+    (integration) => {
+        const initialDocsCount = 1000;
+        const initialDocuments = Array.from({ length: initialDocsCount }).map((_, idx) => ({
+            name: `Person ${idx}`,
+            age: idx,
+        }));
+
+        it("should return only the documents that could fit in maxBytesPerQuery limit", async () => {
+            await integration.connectMcpClient();
+            const response = await integration.mcpClient().callTool({
+                name: "aggregate-db",
+                arguments: {
+                    database: integration.randomDbName(),
+                    pipeline: [{ $documents: initialDocuments }, { $sort: { name: -1 } }],
+                },
+            });
+
+            const content = getResponseContent(response);
+            expect(content).toContain("The aggregation resulted in 1000 documents");
+            expect(content).toContain(
+                `Returning 5 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery, server's configured - maxBytesPerQuery.`
+            );
+        });
+
+        it("should return only the documents that could fit in responseBytesLimit", async () => {
+            await freshInsertDocuments({
+                collection: integration.mongoClient().db(integration.randomDbName()).collection("people"),
+                count: 1000,
+                documentMapper(index) {
+                    return { name: `Person ${index}`, age: index };
+                },
+            });
+            await integration.connectMcpClient();
+            const response = await integration.mcpClient().callTool({
+                name: "aggregate-db",
+                arguments: {
+                    database: integration.randomDbName(),
+                    pipeline: [{ $documents: initialDocuments }, { $sort: { name: -1 } }],
+                    responseBytesLimit: 100,
+                },
+            });
+
+            const content = getResponseContent(response);
+            expect(content).toContain("The aggregation resulted in 1000 documents");
+            expect(content).toContain(
+                `Returning 2 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery, tool's parameter - responseBytesLimit.`
+            );
+        });
+    },
+    {
+        getUserConfig: () => ({ ...defaultTestConfig, maxBytesPerQuery: 200 }),
+    }
+);
+
+describeWithMongoDB(
+    "aggregate tool with disabled max documents and max bytes per query",
+    (integration) => {
+        it("should return all the documents that could fit in responseBytesLimit", async () => {
+            const initialDocsCount = 1000;
+            const initialDocuments = Array.from({ length: initialDocsCount }).map((_, idx) => ({
+                name: `Person ${idx}`,
+                age: idx,
+            }));
+
+            await integration.connectMcpClient();
+            const response = await integration.mcpClient().callTool({
+                name: "aggregate-db",
+                arguments: {
+                    database: integration.randomDbName(),
+                    collection: "people",
+                    pipeline: [{ $documents: initialDocuments }, { $sort: { name: -1 } }],
+                    responseBytesLimit: 1 * 1024 * 1024, // 1MB
+                },
+            });
+
+            const content = getResponseContent(response);
+            expect(content).toContain("The aggregation resulted in 1000 documents");
+        });
+    },
+    {
+        getUserConfig: () => ({ ...defaultTestConfig, maxDocumentsPerQuery: -1, maxBytesPerQuery: -1 }),
+    }
+);
+
+describeWithMongoDB(
+    "aggregate tool with abort signal",
+    (integration) => {
+        const initialDocsCount = 10000;
+        const initialDocuments = Array.from({ length: initialDocsCount }).map((_, idx) => ({
+            _id: idx,
+            description: `Document ${idx}`,
+            longText: `This is a very long text field for document ${idx} `.repeat(100),
+        }));
+
+        const runSlowAggregateDb = async (
+            signal?: AbortSignal
+        ): Promise<{ executionTime: number; result?: Awaited<ReturnType<Client["callTool"]>>; error?: Error }> => {
+            const startTime = performance.now();
+
+            let result: Awaited<ReturnType<Client["callTool"]>> | undefined;
+            let error: Error | undefined;
+            try {
+                result = await integration.mcpClient().callTool(
+                    {
+                        name: "aggregate-db",
+                        arguments: {
+                            database: integration.randomDbName(),
+                            pipeline: [
+                                { $documents: initialDocuments },
+                                // Complex regex matching to slow down the query
+                                {
+                                    $match: {
+                                        longText: { $regex: ".*Document.*very.*long.*text.*", $options: "i" },
+                                    },
+                                },
+                                // Add complex calculations to slow it down further
+                                {
+                                    $addFields: {
+                                        complexCalculation: {
+                                            $sum: {
+                                                $map: {
+                                                    input: { $range: [0, 1000] },
+                                                    as: "num",
+                                                    in: { $multiply: ["$$num", "$_id"] },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                                // Group and unwind to add more processing
+                                {
+                                    $group: {
+                                        _id: "$_id",
+                                        description: { $first: "$description" },
+                                        longText: { $first: "$longText" },
+                                        complexCalculation: { $first: "$complexCalculation" },
+                                    },
+                                },
+                                { $sort: { complexCalculation: -1 } },
+                            ],
+                        },
+                    },
+                    undefined,
+                    { signal }
+                );
+            } catch (err: unknown) {
+                error = err as Error;
+            }
+
+            const executionTime = performance.now() - startTime;
+
+            return {
+                result,
+                error,
+                executionTime,
+            };
+        };
+
+        it("should abort aggregate operation when signal is triggered immediately", async () => {
+            await integration.connectMcpClient();
+            const abortController = new AbortController();
+
+            const aggregatePromise = runSlowAggregateDb(abortController.signal);
+
+            // Abort immediately
+            abortController.abort();
+
+            const { result, error, executionTime } = await aggregatePromise;
+
+            expect(executionTime).toBeLessThan(25); // Ensure it aborted quickly
+            expect(result).toBeUndefined();
+            expectDefined(error);
+            expect(error.message).toContain("This operation was aborted");
+        });
+
+        it("should abort aggregate operation during cursor iteration", async () => {
+            await integration.connectMcpClient();
+            const abortController = new AbortController();
+
+            // Start an aggregation with regex and complex filter that requires scanning many documents
+            const aggregatePromise = runSlowAggregateDb(abortController.signal);
+
+            // Give the cursor a bit of time to start processing, then abort
+            setTimeout(() => abortController.abort(), 25);
+
+            const { result, error, executionTime } = await aggregatePromise;
+
+            // Ensure it aborted quickly, but possibly after some processing
+            expect(executionTime).toBeGreaterThanOrEqual(25);
+            expect(executionTime).toBeLessThan(250);
+            expect(result).toBeUndefined();
+            expectDefined(error);
+            expect(error.message).toContain("This operation was aborted");
+        });
+
+        it("should complete successfully when not aborted", async () => {
+            await integration.connectMcpClient();
+
+            const { result, error, executionTime } = await runSlowAggregateDb();
+
+            // Complex regex matching and calculations on 10000 docs should take some time
+            expect(executionTime).toBeGreaterThan(100);
+            expectDefined(result);
+            expect(error).toBeUndefined();
+            const content = getResponseContent(result);
+            expect(content).toContain("The aggregation resulted in");
+        });
+    },
+    {
+        getUserConfig: () => ({
+            ...defaultTestConfig,
+            maxDocumentsPerQuery: 10000,
+        }),
+    }
+);

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -20,13 +20,14 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
         ...databaseParameters,
         {
             name: "pipeline",
-            description: "An array of aggregation stages to execute.",
+            description:
+                "An array of aggregation stages to execute. Has to start with a database aggregation stage. https://www.mongodb.com/docs/manual/reference/mql/aggregation-stages/#db.aggregate---stages",
             type: "array",
             required: true,
         },
         {
             name: "responseBytesLimit",
-            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. Note to LLM: If the entire aggregation result is required, use the "export" tool instead of increasing this limit.`,
+            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded.`,
             type: "number",
             required: false,
         },
@@ -37,6 +38,7 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
         { database: "test", collection: "foo" },
         { database: "test", pipeline: {} },
         { database: 123, pipeline: [] },
+        { database: "test", pipeline: [{ $match: { name: "Peter" } }] }, // This is invalid because we don't have any documents yet. The first stage has to be a db level aggregate stage
     ]);
 
     it("can run aggregation-db on an existing database", async () => {

--- a/tests/integration/transports/stdio.test.ts
+++ b/tests/integration/transports/stdio.test.ts
@@ -32,7 +32,7 @@ describeWithMongoDB("StdioRunner", (integration) => {
             const response = await client.listTools();
             expect(response).toBeDefined();
             expect(response.tools).toBeDefined();
-            expect(response.tools).toHaveLength(24);
+            expect(response.tools).toHaveLength(25);
 
             const sortedTools = response.tools.sort((a, b) => a.name.localeCompare(b.name));
             expect(sortedTools[0]?.name).toBe("aggregate");


### PR DESCRIPTION
## Proposed changes

Mainly a copy of collection aggregate, using the `aggregateDb` method of the service provider, with irrelevant parts regarding search and vectorSearch removed.

Side change: separated CollOperationArgs, this is now a 4th case where we're on the db level and the DBOperationArgs being actually collection scoped was confusing

### TODO:

- [x] Add accuracy tests
- [x] Update after https://github.com/mongodb-js/mongodb-mcp-server/pull/1067 is merged
