### PR TITLE
fix: fall back to browser fetch in ApiClient MCP-473

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -852,7 +852,7 @@ export interface ServerOptions<TUserConfig extends UserConfig = UserConfig, TCon
 export class Session extends EventEmitter<SessionEvents> {
     constructor(input: SessionOptions<UserConfig>);
     // (undocumented)
-    readonly apiClient?: ApiClient;
+    readonly apiClient: ApiClient;
     // (undocumented)
     assertSearchSupported(): Promise<void>;
     // (undocumented)
@@ -911,7 +911,7 @@ export type SessionEvents = {
 // @public (undocumented)
 export interface SessionOptions<TUserConfig extends UserConfig = UserConfig> {
     // (undocumented)
-    apiClient?: ApiClient;
+    apiClient: ApiClient;
     // (undocumented)
     atlasLocalClient?: Client;
     // (undocumented)

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -780,7 +780,7 @@ export interface ServerOptions<TUserConfig extends UserConfig = UserConfig, TCon
 export class Session extends EventEmitter<SessionEvents> {
     constructor(input: SessionOptions<UserConfig>);
     // (undocumented)
-    readonly apiClient?: ApiClient;
+    readonly apiClient: ApiClient;
     // (undocumented)
     assertSearchSupported(): Promise<void>;
     // (undocumented)
@@ -836,7 +836,7 @@ export type SessionEvents = {
 // @public (undocumented)
 export interface SessionOptions<TUserConfig extends UserConfig = UserConfig> {
     // (undocumented)
-    apiClient?: ApiClient;
+    apiClient: ApiClient;
     // (undocumented)
     atlasLocalClient?: Client;
     // (undocumented)

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -13,6 +13,16 @@ import { AuthProviderFactory } from "./auth/authProvider.js";
 const ATLAS_API_VERSION = "2025-03-12";
 const DEFAULT_SEND_TIMEOUT_MS = 5_000;
 
+/**
+ * Detects whether we're running on Node.js as opposed to a browser/web
+ * environment. We rely on `process.versions.node` rather than `typeof process`
+ * because bundlers (e.g. Vite) may replace `process` with a literal object
+ * shim in the browser build, which would still be `"object"` at runtime.
+ */
+function isNodeRuntime(): boolean {
+    return typeof process !== "undefined" && process.versions !== undefined && process.versions.node !== undefined;
+}
+
 export interface ApiClientOptions {
     baseUrl: string;
     userAgent?: string;
@@ -49,17 +59,29 @@ export class ApiClient {
         public readonly logger: LoggerBase,
         public readonly authProvider?: AuthProvider
     ) {
-        // createFetch assumes that the first parameter of fetch is always a string
-        // with the URL. However, fetch can also receive a Request object. While
-        // the typechecking complains, createFetch does passthrough the parameters
-        // so it works fine. That said, node-fetch has incompatibilities with the web version
-        // of fetch and can lead to genuine issues so we would like to move away of node-fetch dependency.
-        this.customFetch = createFetch({
-            useEnvironmentVariableProxies: true,
-        }) as unknown as typeof fetch;
+        // In Node we use `createFetch` from devtools-proxy-support to pick up
+        // environment-variable proxy configuration and system CA trust, and we
+        // use node-fetch's Request since its interface is a superset of the
+        // web Request. In the browser those Node-only concerns don't apply and
+        // the implementations aren't available, so we fall back to the native
+        // `fetch`/`Request` globals.
+        if (isNodeRuntime()) {
+            // createFetch assumes that the first parameter of fetch is always a string
+            // with the URL. However, fetch can also receive a Request object. While
+            // the typechecking complains, createFetch does passthrough the parameters
+            // so it works fine. That said, node-fetch has incompatibilities with the web version
+            // of fetch and can lead to genuine issues so we would like to move away of node-fetch dependency.
+            this.customFetch = createFetch({
+                useEnvironmentVariableProxies: true,
+            }) as unknown as typeof fetch;
+        } else {
+            this.customFetch = globalThis.fetch.bind(globalThis);
+        }
         this.options = {
             ...options,
-            userAgent: options.userAgent ?? `AtlasMCP/${packageInfo.version} (${process.platform}; ${process.arch})`,
+            userAgent:
+                options.userAgent ??
+                `AtlasMCP/${packageInfo.version} (${isNodeRuntime() ? `${process.platform}; ${process.arch}` : "browser"})`,
         };
 
         this.authProvider =
@@ -83,7 +105,7 @@ export class ApiClient {
             // NodeFetchRequest has more overloadings than the native Request
             // so it complains here. However, the interfaces are actually compatible
             // so it's not a real problem, just a type checking problem.
-            Request: NodeFetchRequest as unknown as ClientOptions["Request"],
+            Request: (isNodeRuntime() ? NodeFetchRequest : globalThis.Request) as unknown as ClientOptions["Request"],
         });
 
         if (this.authProvider) {

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -29,7 +29,7 @@ export interface SessionOptions<TUserConfig extends UserConfig = UserConfig> {
     keychain: Keychain;
     atlasLocalClient?: Client;
     connectionErrorHandler: ConnectionErrorHandler;
-    apiClient?: ApiClient;
+    apiClient: ApiClient;
 }
 
 export type SessionEvents = {
@@ -44,7 +44,7 @@ export class Session extends EventEmitter<SessionEvents> {
     readonly sessionId: string = new ObjectId().toString();
     readonly exportsManager: ExportsManager;
     readonly connectionManager: ConnectionManager;
-    readonly apiClient?: ApiClient;
+    readonly apiClient: ApiClient;
     readonly atlasLocalClient?: Client;
     readonly keychain: Keychain;
     readonly connectionErrorHandler: ConnectionErrorHandler;

--- a/src/telemetry/constants.ts
+++ b/src/telemetry/constants.ts
@@ -7,8 +7,8 @@ import { type CommonStaticProperties } from "./types.js";
 export const MACHINE_METADATA: CommonStaticProperties = {
     mcp_server_version: packageInfo.version,
     mcp_server_name: packageInfo.mcpServerName,
-    platform: process.platform,
-    arch: process.arch,
-    os_type: process.platform,
-    os_version: process.version,
+    platform: typeof process !== "undefined" ? process.platform : "browser",
+    arch: typeof process !== "undefined" ? process.arch : "unknown",
+    os_type: typeof process !== "undefined" ? process.platform : "unknown",
+    os_version: typeof process !== "undefined" ? process.version : "unknown",
 } as const;

--- a/src/telemetry/constants.ts
+++ b/src/telemetry/constants.ts
@@ -7,8 +7,8 @@ import { type CommonStaticProperties } from "./types.js";
 export const MACHINE_METADATA: CommonStaticProperties = {
     mcp_server_version: packageInfo.version,
     mcp_server_name: packageInfo.mcpServerName,
-    platform: typeof process !== "undefined" ? process.platform : "browser",
-    arch: typeof process !== "undefined" ? process.arch : "unknown",
-    os_type: typeof process !== "undefined" ? process.platform : "unknown",
-    os_version: typeof process !== "undefined" ? process.version : "unknown",
+    platform: (typeof process !== "undefined" && process.platform) || "browser",
+    arch: (typeof process !== "undefined" && process.arch) || "unknown",
+    os_type: (typeof process !== "undefined" && process.platform) || "unknown",
+    os_version: (typeof process !== "undefined" && process.version) || "unknown",
 } as const;

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -166,6 +166,12 @@ export class Telemetry {
             return false;
         }
 
+        // In browser environments, we don't have access to the process object, so we default to true.
+        if (typeof process === "undefined" || !process.env) {
+            return true;
+        }
+
+        // In Node.js environments, we check the DO_NOT_TRACK environment variable.
         const doNotTrack = "DO_NOT_TRACK" in process.env;
         return !doNotTrack;
     }
@@ -220,9 +226,9 @@ export class Telemetry {
      * Does not reschedule — the caller decides what to do next.
      */
     private async sendBatch({ signal }: { signal?: AbortSignal } = {}): Promise<SendResult> {
-        if (!this.session.apiClient || this.eventCache.size === 0) return { status: "empty" };
-
-        const apiClient = this.session.apiClient;
+        if (this.eventCache.size === 0) {
+            return { status: "empty" };
+        }
 
         const result = await this.eventCache.processOldestBatch(BATCH_SIZE, async (events) => {
             this.session.logger.debug({
@@ -231,7 +237,7 @@ export class Telemetry {
                 message: `Attempting to send ${events.length} events`,
             });
 
-            const sendResult = await this.sendEvents(apiClient, events, signal);
+            const sendResult = await this.sendEvents(this.session.apiClient, events, signal);
 
             if (sendResult.status !== "success") {
                 if (sendResult.status !== "rate-limited") {

--- a/src/transports/base.ts
+++ b/src/transports/base.ts
@@ -19,7 +19,8 @@ import { Elicitation } from "../elicitation.js";
 import type { AtlasLocalClientFactoryFn } from "../common/atlasLocal.js";
 import { defaultCreateAtlasLocalClient } from "../common/atlasLocal.js";
 import { applyConfigOverrides } from "../common/config/configOverrides.js";
-import { ApiClient, type ApiClientFactoryFn } from "../common/atlas/apiClient.js";
+import type { ApiClientOptions, ApiClientFactoryFn } from "../common/atlas/apiClient.js";
+import { ApiClient } from "../common/atlas/apiClient.js";
 import { defaultCreateApiClient } from "../common/atlas/apiClient.js";
 import type { UIRegistry } from "../ui/registry/index.js";
 import { createDefaultMetrics, PrometheusMetrics, type DefaultMetrics } from "../common/metrics/index.js";
@@ -307,19 +308,16 @@ export abstract class TransportRunnerBase<
             sessionOptions?.connectionManager ??
             (await this.createConnectionManager({ logger: logger, deviceId: this.deviceId, userConfig }));
 
-        const apiClient =
-            userConfig.apiClientId && userConfig.apiClientSecret
-                ? new ApiClient(
-                      {
-                          baseUrl: userConfig.apiBaseUrl,
-                          credentials: {
-                              clientId: userConfig.apiClientId,
-                              clientSecret: userConfig.apiClientSecret,
-                          },
-                      },
-                      logger
-                  )
-                : undefined;
+        const apiClientOptions: ApiClientOptions = {
+            baseUrl: userConfig.apiBaseUrl,
+        };
+        if (userConfig.apiClientId && userConfig.apiClientSecret) {
+            apiClientOptions.credentials = {
+                clientId: userConfig.apiClientId,
+                clientSecret: userConfig.apiClientSecret,
+            };
+        }
+        const apiClient = new ApiClient(apiClientOptions, logger);
 
         const session = new Session({
             userConfig,

--- a/src/transports/base.ts
+++ b/src/transports/base.ts
@@ -308,15 +308,17 @@ export abstract class TransportRunnerBase<
             sessionOptions?.connectionManager ??
             (await this.createConnectionManager({ logger: logger, deviceId: this.deviceId, userConfig }));
 
+        const { apiClientId, apiClientSecret } = userConfig;
         const apiClientOptions: ApiClientOptions = {
             baseUrl: userConfig.apiBaseUrl,
+            credentials:
+                apiClientId && apiClientSecret
+                    ? {
+                          clientId: apiClientId,
+                          clientSecret: apiClientSecret,
+                      }
+                    : undefined,
         };
-        if (userConfig.apiClientId && userConfig.apiClientSecret) {
-            apiClientOptions.credentials = {
-                clientId: userConfig.apiClientId,
-                clientSecret: userConfig.apiClientSecret,
-            };
-        }
         const apiClient = new ApiClient(apiClientOptions, logger);
 
         const session = new Session({

--- a/tests/browser/tests/telemetry.test.ts
+++ b/tests/browser/tests/telemetry.test.ts
@@ -1,0 +1,101 @@
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    ApiClient,
+    CompositeLogger,
+    Keychain,
+    Telemetry,
+    type DeviceId,
+    type Session,
+    UserConfigSchema,
+} from "mongodb-mcp-server/web";
+
+/**
+ * Browser regression test: the MCP server ships a `mongodb-mcp-server/web`
+ * entrypoint that must be usable from a browser bundle. Historically the
+ * `ApiClient` constructor and the telemetry auth provider both called
+ * `createFetch` from `@mongodb-js/devtools-proxy-support` — a node-fetch /
+ * Node-only helper that throws in the browser polyfill. This test verifies
+ * that:
+ *
+ *   1. `ApiClient` can be constructed in the browser without invoking
+ *      `createFetch` (i.e. it must detect the environment and fall back to
+ *      `globalThis.fetch`).
+ *   2. A `Telemetry` instance can be created, initialized, and used to emit +
+ *      flush events end-to-end via `globalThis.fetch`, without any
+ *      node-fetch related exceptions.
+ */
+describe("Telemetry in browser environment", () => {
+    const API_BASE = "https://api.test.com/";
+
+    let fetchSpy: MockInstance<typeof fetch>;
+    const mockDeviceId = {
+        get: vi.fn().mockResolvedValue("test-device-id"),
+    } as unknown as DeviceId;
+
+    function createMockSession(apiClient: ApiClient): Session {
+        return {
+            apiClient,
+            sessionId: "browser-session-id",
+            mcpClient: { name: "browser-test-client", version: "1.0.0" },
+            logger: new CompositeLogger(),
+            keychain: new Keychain(),
+        } as unknown as Session;
+    }
+
+    beforeEach(() => {
+        fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    });
+
+    afterEach(() => {
+        fetchSpy.mockRestore();
+        vi.clearAllMocks();
+    });
+
+    it("can construct an ApiClient without throwing due to node-fetch / createFetch", () => {
+        expect(
+            () => new ApiClient({ baseUrl: API_BASE, userAgent: "browser-test-agent" }, new CompositeLogger())
+        ).not.toThrow();
+    });
+
+    it("initializes Telemetry and sends events via the browser fetch without throwing", async () => {
+        const apiClient = new ApiClient({ baseUrl: API_BASE, userAgent: "browser-test-agent" }, new CompositeLogger());
+        expect(apiClient.isAuthConfigured()).toBe(false);
+
+        const telemetry = Telemetry.create(
+            createMockSession(apiClient),
+            UserConfigSchema.parse({ telemetry: "enabled" }),
+            mockDeviceId
+        );
+
+        await expect(telemetry.setupPromise).resolves.toBeDefined();
+
+        telemetry.emitEvents([
+            {
+                timestamp: new Date().toISOString(),
+                source: "mdbmcp",
+                properties: {
+                    component: "browser-test",
+                    duration_ms: 0,
+                    result: "success",
+                    category: "test",
+                    command: "browser-command",
+                },
+            },
+        ]);
+
+        // `close()` performs a best-effort final flush of the event cache.
+        // This is the failure path we care about: in a regressed build this
+        // would throw synchronously inside ApiClient construction, or reject
+        // here because node-fetch's Request is not available in the browser.
+        await expect(telemetry.close()).resolves.toBeUndefined();
+
+        const telemetryCall = fetchSpy.mock.calls.find(([input]) => {
+            const href = input instanceof URL ? input.href : typeof input === "string" ? input : input.url;
+            return href === new URL("api/private/unauth/telemetry/events", API_BASE).href;
+        });
+
+        expect(telemetryCall, "expected a POST to the unauth telemetry endpoint").toBeDefined();
+        expect(telemetryCall![1]?.method).toBe("POST");
+    });
+});

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -11,26 +11,24 @@ import {
 } from "../../src/telemetry/telemetry.js";
 import type { BaseEvent, CommonProperties, TelemetryEvent, TelemetryResult } from "../../src/telemetry/types.js";
 import { EventCache } from "../../src/telemetry/eventCache.js";
-import { afterEach, beforeAll, beforeEach, describe, it, vi, expect } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, it, vi, expect } from "vitest";
 import { NullLogger } from "../../src/common/logging/nullLogger.js";
-import type { MockedFunction } from "vitest";
+import type { MockedFunction, MockInstance } from "vitest";
 import type { DeviceId } from "../../src/helpers/deviceId.js";
 import { defaultTestConfig, expectDefined } from "../integration/helpers.js";
 import { Keychain } from "../../src/common/keychain.js";
 import { type UserConfig } from "../../src/common/config/userConfig.js";
 
-// Mock the ApiClient to avoid real API calls
-vi.mock("../../src/common/atlas/apiClient.js");
-const MockApiClient = vi.mocked(ApiClient);
-
-// Mock EventCache to control and verify caching behavior
-vi.mock("../../src/telemetry/eventCache.js");
-const MockEventCache = vi.mocked(EventCache);
-
 // Mock container detection to avoid file I/O in tests
 vi.mock("../../src/helpers/container.js", () => ({
     detectContainerEnv: vi.fn().mockResolvedValue(false),
 }));
+
+// Restore any spies installed by individual describe blocks so tests in
+// different blocks don't interfere with each other.
+afterAll(() => {
+    vi.restoreAllMocks();
+});
 
 describe("nextBackoffMs", () => {
     it("should double the current backoff", () => {
@@ -127,43 +125,44 @@ describe("Telemetry", () => {
         config = { ...defaultTestConfig, telemetry: "enabled" };
         vi.clearAllMocks();
 
-        // Setup mocked API client
-        mockApiClient = vi.mocked(
-            new MockApiClient({ baseUrl: "" }, new NullLogger())
-        ) as unknown as typeof mockApiClient;
-        mockApiClient.sendEvents = vi.fn().mockResolvedValue(undefined);
-        mockApiClient.validateAuthConfig = vi.fn().mockReturnValue(Promise.resolve());
-        mockApiClient.isAuthConfigured = vi.fn().mockReturnValue(true);
+        mockApiClient = {
+            sendEvents: vi.fn().mockResolvedValue(undefined),
+            validateAuthConfig: vi.fn().mockReturnValue(Promise.resolve()),
+            isAuthConfigured: vi.fn().mockReturnValue(true),
+        };
 
-        // Setup a stateful mocked EventCache backed by _cachedEvents
-        mockEventCache = new MockEventCache() as unknown as typeof mockEventCache;
-        Object.defineProperty(mockEventCache, "size", { get: () => _cachedEvents.length, configurable: true });
-        mockEventCache.getEvents = vi.fn().mockImplementation(() => _cachedEvents.map((event, id) => ({ id, event })));
-        mockEventCache.removeEvents = vi.fn().mockImplementation((ids: number[]) => {
-            _cachedEvents = _cachedEvents.filter((_, i) => !ids.includes(i));
-        });
-        mockEventCache.appendEvents = vi.fn().mockImplementation((events: BaseEvent[]) => {
-            _cachedEvents.push(...events);
-        });
-        mockEventCache.processOldestBatch = vi
-            .fn()
-            .mockImplementation(
-                async <T>(
-                    batchSize: number,
-                    processor: (events: BaseEvent[]) => Promise<{ removeProcessed: boolean; result: T }>
-                ): Promise<T | undefined> => {
-                    const allEvents = mockEventCache.getEvents();
-                    const batch = allEvents.slice(0, batchSize);
-                    if (batch.length === 0) return undefined;
+        // Stateful plain-object mock for EventCache backed by _cachedEvents.
+        mockEventCache = {
+            get size(): number {
+                return _cachedEvents.length;
+            },
+            getEvents: vi.fn().mockImplementation(() => _cachedEvents.map((event, id) => ({ id, event }))),
+            removeEvents: vi.fn().mockImplementation((ids: number[]) => {
+                _cachedEvents = _cachedEvents.filter((_, i) => !ids.includes(i));
+            }),
+            appendEvents: vi.fn().mockImplementation((events: BaseEvent[]) => {
+                _cachedEvents.push(...events);
+            }),
+            processOldestBatch: vi
+                .fn()
+                .mockImplementation(
+                    async <T>(
+                        batchSize: number,
+                        processor: (events: BaseEvent[]) => Promise<{ removeProcessed: boolean; result: T }>
+                    ): Promise<T | undefined> => {
+                        const allEvents = mockEventCache.getEvents();
+                        const batch = allEvents.slice(0, batchSize);
+                        if (batch.length === 0) return undefined;
 
-                    const { removeProcessed, result } = await processor(batch.map((e) => e.event));
-                    if (removeProcessed) {
-                        mockEventCache.removeEvents(batch.map((e) => e.id));
+                        const { removeProcessed, result } = await processor(batch.map((e) => e.event));
+                        if (removeProcessed) {
+                            mockEventCache.removeEvents(batch.map((e) => e.id));
+                        }
+                        return result;
                     }
-                    return result;
-                }
-            );
-        MockEventCache.getInstance = vi.fn().mockReturnValue(mockEventCache as unknown as EventCache);
+                ),
+        } as unknown as typeof mockEventCache;
+        vi.spyOn(EventCache, "getInstance").mockReturnValue(mockEventCache as unknown as EventCache);
 
         mockDeviceId = {
             get: vi.fn().mockResolvedValue("test-device-id"),
@@ -579,15 +578,8 @@ describe("Telemetry", () => {
      * from being sent twice when sendBatch is triggered concurrently.
      */
     describe("when sendBatch is triggered concurrently", () => {
-        let RealEventCache: typeof EventCache;
-
-        beforeAll(async () => {
-            const mod = await vi.importActual<{ EventCache: typeof EventCache }>("../../src/telemetry/eventCache.js");
-            RealEventCache = mod.EventCache;
-        });
-
         it("should not send the same cached event twice when two batches overlap", async () => {
-            const eventCache = new RealEventCache();
+            const eventCache = new EventCache();
             const CACHED_MARKER = "cached-race-test";
 
             eventCache.appendEvents([createTestEvent({ command: CACHED_MARKER, component: "cached" })]);
@@ -611,5 +603,122 @@ describe("Telemetry", () => {
             }
             expect(cachedEventSendCount, "Cached event should be sent exactly once").toBe(1);
         });
+    });
+});
+
+/**
+ * Regression tests for telemetry dispatch when Atlas credentials are / are not
+ * configured. Telemetry must be emitted in both cases:
+ *   - with credentials    -> POST to `api/private/v1.0/telemetry/events` (auth)
+ *   - without credentials -> POST to `api/private/unauth/telemetry/events`
+ */
+describe("Telemetry credentials handling", () => {
+    const API_BASE = "https://api.test.com";
+    const USER_AGENT = "test-user-agent";
+
+    let fetchSpy: MockInstance<typeof fetch>;
+
+    const mockDeviceId = {
+        get: vi.fn().mockResolvedValue("test-device-id"),
+    } as unknown as DeviceId;
+
+    function createMockSession(apiClient: ApiClient): Session {
+        return {
+            apiClient,
+            sessionId: "test-session-id",
+            mcpClient: { name: "test-agent", version: "1.0.0" },
+            logger: new NullLogger(),
+            keychain: new Keychain(),
+        } as unknown as Session;
+    }
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        fetchSpy.mockRestore();
+        vi.clearAllMocks();
+    });
+
+    it.each([
+        {
+            label: "with atlas credentials",
+            credentials: { clientId: "cid", clientSecret: "csec" },
+            expectedPath: "/api/private/v1.0/telemetry/events",
+            expectAuthHeader: true,
+        },
+        {
+            label: "without atlas credentials",
+            credentials: {},
+            expectedPath: "/api/private/unauth/telemetry/events",
+            expectAuthHeader: false,
+        },
+    ])("sends telemetry events $label", async ({ credentials, expectedPath, expectAuthHeader }) => {
+        const apiClient = new ApiClient(
+            {
+                baseUrl: API_BASE,
+                credentials,
+                userAgent: USER_AGENT,
+            },
+            new NullLogger()
+        );
+
+        // When credentials are present, short-circuit the OAuth token fetch
+        // so the test stays focused on the telemetry dispatch rather than the
+        // auth flow (which is covered elsewhere).
+        if (credentials.clientId) {
+            expect(apiClient.isAuthConfigured()).toBe(true);
+            apiClient.authProvider!.getAuthHeaders = vi.fn().mockResolvedValue({ Authorization: "Bearer mockToken" });
+        } else {
+            expect(apiClient.isAuthConfigured()).toBe(false);
+        }
+
+        const config: UserConfig = { ...defaultTestConfig, telemetry: "enabled" };
+        const telemetry = Telemetry.create(createMockSession(apiClient), config, mockDeviceId, {
+            eventCache: new EventCache(),
+        });
+        await telemetry.setupPromise;
+
+        const emitCompleted = new Promise<void>((resolve) => {
+            telemetry.events.once("events-emitted", resolve);
+            telemetry.events.once("events-send-failed", resolve);
+            telemetry.events.once("events-skipped", resolve);
+        });
+        telemetry.emitEvents([
+            {
+                timestamp: new Date().toISOString(),
+                source: "mdbmcp",
+                properties: {
+                    component: "test-component",
+                    duration_ms: 0,
+                    result: "success" as TelemetryResult,
+                    category: "test",
+                    command: "test-command",
+                },
+            },
+        ]);
+        await vi.advanceTimersByTimeAsync(SEND_INTERVAL_MS);
+        await emitCompleted;
+
+        const matchingCall = fetchSpy.mock.calls.find(([input]) => {
+            const href = input instanceof URL ? input.href : typeof input === "string" ? input : input.url;
+            return href === new URL(expectedPath, API_BASE).href;
+        });
+
+        expect(matchingCall, `expected a POST to ${expectedPath}`).toBeDefined();
+
+        const [, init] = matchingCall!;
+        expect(init?.method).toBe("POST");
+        const headers = init?.headers as Record<string, string>;
+        expect(headers["Content-Type"]).toBe("application/json");
+        expect(headers["User-Agent"]).toBe(USER_AGENT);
+        if (expectAuthHeader) {
+            expect(headers.Authorization).toBe("Bearer mockToken");
+        } else {
+            expect(headers.Authorization).toBeUndefined();
+        }
     });
 });


### PR DESCRIPTION
## Proposed changes

This is an alternative approach to https://github.com/mongodb-js/mongodb-mcp-server/pull/1068. It modifies ApiClient to add a runtime check and only use the devtools-proxy-support fetch when running in a node environment.