### PR TITLE
chore: allow extending and injecting MCP HTTP server through StreamableHttp transport CLOUDP-395173

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -27,7 +27,7 @@ import { NodeDriverServiceProvider } from '@mongosh/service-provider-node-driver
 import type { operations } from './openapi.js';
 import { Registry } from 'prom-client';
 import { Secret } from 'mongodb-redact';
-import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { z } from 'zod';
@@ -400,6 +400,9 @@ export class ConsoleLogger extends LoggerBase {
 }
 
 // @public
+export const createDefaultMcpHttpServer: <TUserConfig extends UserConfig = UserConfig, TContext = unknown>(args: MCPHttpServerConstructorArgs<TUserConfig, TContext>) => MCPHttpServer<TUserConfig, TContext>;
+
+// @public
 export function createDefaultMetrics(): {
     readonly toolExecutionDuration: Histogram<"status" | "category" | "tool_name" | "operation_type" | "error_type">;
     readonly sessionCreated: Counter<string>;
@@ -414,6 +417,9 @@ export function createDefaultSessionStore<TTransport extends CloseableTransport 
 
 // @public @deprecated (undocumented)
 export const createMCPConnectionManager: ConnectionManagerFactoryFn;
+
+// @public
+export type CreateMcpHttpServerFn<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = (args: MCPHttpServerConstructorArgs<TUserConfig, TContext>) => MCPHttpServer<TUserConfig, TContext>;
 
 // @public
 export type CreateMonitoringServerFn<TMetrics extends DefaultMetrics = DefaultMetrics> = (args: MonitoringServerConstructorArgs<TMetrics>) => MonitoringServer<TMetrics> | undefined;
@@ -667,6 +673,36 @@ export interface LogPayload {
     noRedaction?: boolean | LoggerType | LoggerType[];
 }
 
+// Warning: (ae-forgotten-export) The symbol "ExpressBasedHttpServer" needs to be exported by the entry point lib.d.ts
+//
+// @public (undocumented)
+export class MCPHttpServer<TUserConfig extends UserConfig = UserConfig, TContext = unknown> extends ExpressBasedHttpServer {
+    constructor(input: MCPHttpServerConstructorArgs<TUserConfig, TContext>);
+    // (undocumented)
+    protected setupMiddlewares(): void;
+    // (undocumented)
+    protected setupRoutes(): Promise<void>;
+    // (undocumented)
+    stop(): Promise<void>;
+    // (undocumented)
+    protected readonly userConfig: TUserConfig;
+}
+
+// @public (undocumented)
+export type MCPHttpServerConstructorArgs<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = {
+    userConfig: TUserConfig;
+    createServerForRequest: (createParams: {
+        request: TransportRequestContext;
+        serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
+        sessionOptions?: CustomizableSessionOptions<TUserConfig>;
+    }) => Promise<Server<TUserConfig, TContext>>;
+    logger: LoggerBase;
+    serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
+    sessionOptions?: CustomizableSessionOptions<TUserConfig>;
+    metrics: Metrics<DefaultMetrics>;
+    sessionStore: ISessionStore<StreamableHTTPServerTransport>;
+};
+
 // @public (undocumented)
 export type MetricDefinitions = {
     [key: string]: Histogram | Counter | Gauge;
@@ -685,8 +721,6 @@ export class MongoDBError<ErrorCode extends ErrorCodes = ErrorCodes> extends Err
     code: ErrorCode;
 }
 
-// Warning: (ae-forgotten-export) The symbol "ExpressBasedHttpServer" needs to be exported by the entry point lib.d.ts
-//
 // @public (undocumented)
 export class MonitoringServer<TMetrics extends DefaultMetrics = DefaultMetrics> extends ExpressBasedHttpServer {
     constructor(input: {
@@ -979,7 +1013,7 @@ export class StdioRunner<TUserConfig extends UserConfig = UserConfig, TContext =
 
 // @public (undocumented)
 export class StreamableHttpRunner<TUserConfig extends UserConfig = UserConfig, TContext = unknown, TMetrics extends DefaultMetrics = DefaultMetrics> extends TransportRunnerBase<TUserConfig, TContext, TMetrics> {
-    constructor(config: StreamableHttpTransportRunnerConfig<TUserConfig, TMetrics>);
+    constructor(config: StreamableHttpTransportRunnerConfig<TUserConfig, TMetrics, TContext>);
     // (undocumented)
     closeTransport(): Promise<void>;
     protected createServerForRequest(input: {
@@ -994,9 +1028,10 @@ export class StreamableHttpRunner<TUserConfig extends UserConfig = UserConfig, T
 }
 
 // @public
-export type StreamableHttpTransportRunnerConfig<TUserConfig extends UserConfig = UserConfig, TMetrics extends DefaultMetrics = DefaultMetrics> = TransportRunnerConfig<TUserConfig, TMetrics> & {
+export type StreamableHttpTransportRunnerConfig<TUserConfig extends UserConfig = UserConfig, TMetrics extends DefaultMetrics = DefaultMetrics, TContext = unknown> = TransportRunnerConfig<TUserConfig, TMetrics> & {
     createMonitoringServer?: CreateMonitoringServerFn<TMetrics>;
     createSessionStore?: CreateSessionStoreFn<StreamableHTTPServerTransport, TMetrics>;
+    createMcpHttpServer?: CreateMcpHttpServerFn<TUserConfig, TContext>;
 };
 
 // @public (undocumented)

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -42,7 +42,7 @@ export {
     createDefaultMcpHttpServer,
     type MCPHttpServerConstructorArgs,
     type CreateMcpHttpServerFn,
-    type MonitoringServer,
+    MonitoringServer,
     createDefaultMonitoringServer,
     type StreamableHttpTransportRunnerConfig,
     type CreateMonitoringServerFn,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,6 +38,10 @@ export {
 } from "./common/logging/index.js";
 export {
     StreamableHttpRunner,
+    MCPHttpServer,
+    createDefaultMcpHttpServer,
+    type MCPHttpServerConstructorArgs,
+    type CreateMcpHttpServerFn,
     type MonitoringServer,
     createDefaultMonitoringServer,
     type StreamableHttpTransportRunnerConfig,

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -23,6 +23,20 @@ import {
     JSON_RPC_ERROR_CODE_PROCESSING_REQUEST_FAILED,
 } from "./jsonRpcErrorCodes.js";
 
+export type MCPHttpServerConstructorArgs<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = {
+    userConfig: TUserConfig;
+    createServerForRequest: (createParams: {
+        request: TransportRequestContext;
+        serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
+        sessionOptions?: CustomizableSessionOptions<TUserConfig>;
+    }) => Promise<Server<TUserConfig, TContext>>;
+    logger: LoggerBase;
+    serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
+    sessionOptions?: CustomizableSessionOptions<TUserConfig>;
+    metrics: Metrics<DefaultMetrics>;
+    sessionStore: ISessionStore<StreamableHTTPServerTransport>;
+};
+
 export class MCPHttpServer<
     TUserConfig extends UserConfig = UserConfig,
     TContext = unknown,
@@ -30,10 +44,9 @@ export class MCPHttpServer<
     private readonly sessionStore: ISessionStore<StreamableHTTPServerTransport>;
     private readonly serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
     private readonly sessionOptions?: CustomizableSessionOptions<TUserConfig>;
-    private readonly userConfig: UserConfig;
+    protected readonly userConfig: UserConfig;
     private readonly metrics: Metrics<DefaultMetrics>;
     private readonly pendingInitializations = new Map<string, Promise<void>>();
-    private readonly preRouteMiddleware: express.RequestHandler[];
 
     private createServerForRequest: (createParams: {
         request: TransportRequestContext;
@@ -49,21 +62,7 @@ export class MCPHttpServer<
         logger,
         metrics,
         sessionStore,
-        preRouteMiddleware,
-    }: {
-        userConfig: TUserConfig;
-        createServerForRequest: (createParams: {
-            request: TransportRequestContext;
-            serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
-            sessionOptions?: CustomizableSessionOptions<TUserConfig>;
-        }) => Promise<Server<TUserConfig, TContext>>;
-        logger: LoggerBase;
-        serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
-        sessionOptions?: CustomizableSessionOptions<TUserConfig>;
-        metrics: Metrics<DefaultMetrics>;
-        sessionStore: ISessionStore<StreamableHTTPServerTransport>;
-        preRouteMiddleware?: express.RequestHandler[];
-    }) {
+    }: MCPHttpServerConstructorArgs<TUserConfig, TContext>) {
         super({
             port: userConfig.httpPort,
             hostname: userConfig.httpHost,
@@ -76,7 +75,6 @@ export class MCPHttpServer<
         this.userConfig = userConfig;
         this.metrics = metrics;
         this.sessionStore = sessionStore;
-        this.preRouteMiddleware = preRouteMiddleware ?? [];
     }
 
     public async stop(): Promise<void> {
@@ -305,8 +303,7 @@ export class MCPHttpServer<
         return sessionId;
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    protected override async setupRoutes(): Promise<void> {
+    protected setupMiddlewares(): void {
         this.app.use(express.json({ limit: this.userConfig.httpBodyLimit }));
         this.app.use((req, res, next) => {
             for (const [key, value] of Object.entries(this.userConfig.httpHeaders)) {
@@ -319,12 +316,11 @@ export class MCPHttpServer<
 
             next();
         });
+    }
 
-        // Apply any pre-route middleware (e.g., session validation from downstream services)
-        for (const middleware of this.preRouteMiddleware) {
-            this.app.use(middleware);
-        }
-
+    // eslint-disable-next-line @typescript-eslint/require-await
+    protected override async setupRoutes(): Promise<void> {
+        this.setupMiddlewares();
         const handleSessionRequest = async (req: express.Request, res: express.Response): Promise<void> => {
             const sessionId = req.headers["mcp-session-id"];
             if (!sessionId) {
@@ -439,3 +435,18 @@ export class MCPHttpServer<
         };
     }
 }
+
+/**
+ * A function to create a custom MCPHttpServer instance.
+ * When provided, the runner will use this function instead of the default MCPHttpServer constructor.
+ */
+export type CreateMcpHttpServerFn<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = (
+    args: MCPHttpServerConstructorArgs<TUserConfig, TContext>
+) => MCPHttpServer<TUserConfig, TContext>;
+
+/**
+ * Creates a default MCPHttpServer instance from the provided constructor arguments.
+ */
+export const createDefaultMcpHttpServer = <TUserConfig extends UserConfig = UserConfig, TContext = unknown>(
+    args: MCPHttpServerConstructorArgs<TUserConfig, TContext>
+): MCPHttpServer<TUserConfig, TContext> => new MCPHttpServer<TUserConfig, TContext>(args);

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -44,7 +44,7 @@ export class MCPHttpServer<
     private readonly sessionStore: ISessionStore<StreamableHTTPServerTransport>;
     private readonly serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
     private readonly sessionOptions?: CustomizableSessionOptions<TUserConfig>;
-    protected readonly userConfig: UserConfig;
+    protected readonly userConfig: TUserConfig;
     private readonly metrics: Metrics<DefaultMetrics>;
     private readonly pendingInitializations = new Map<string, Promise<void>>();
 

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -33,6 +33,7 @@ export class MCPHttpServer<
     private readonly userConfig: UserConfig;
     private readonly metrics: Metrics<DefaultMetrics>;
     private readonly pendingInitializations = new Map<string, Promise<void>>();
+    private readonly preRouteMiddleware: express.RequestHandler[];
 
     private createServerForRequest: (createParams: {
         request: TransportRequestContext;
@@ -48,6 +49,7 @@ export class MCPHttpServer<
         logger,
         metrics,
         sessionStore,
+        preRouteMiddleware,
     }: {
         userConfig: TUserConfig;
         createServerForRequest: (createParams: {
@@ -60,6 +62,7 @@ export class MCPHttpServer<
         sessionOptions?: CustomizableSessionOptions<TUserConfig>;
         metrics: Metrics<DefaultMetrics>;
         sessionStore: ISessionStore<StreamableHTTPServerTransport>;
+        preRouteMiddleware?: express.RequestHandler[];
     }) {
         super({
             port: userConfig.httpPort,
@@ -73,6 +76,7 @@ export class MCPHttpServer<
         this.userConfig = userConfig;
         this.metrics = metrics;
         this.sessionStore = sessionStore;
+        this.preRouteMiddleware = preRouteMiddleware ?? [];
     }
 
     public async stop(): Promise<void> {
@@ -315,6 +319,11 @@ export class MCPHttpServer<
 
             next();
         });
+
+        // Apply any pre-route middleware (e.g., session validation from downstream services)
+        for (const middleware of this.preRouteMiddleware) {
+            this.app.use(middleware);
+        }
 
         const handleSessionRequest = async (req: express.Request, res: express.Response): Promise<void> => {
             const sessionId = req.headers["mcp-session-id"];

--- a/src/transports/streamableHttp.ts
+++ b/src/transports/streamableHttp.ts
@@ -1,4 +1,5 @@
 import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type express from "express";
 import type { LoggerBase } from "../common/logging/index.js";
 import { CompositeLogger, LogId } from "../common/logging/index.js";
 import { type ISessionStore, type CreateSessionStoreFn, createDefaultSessionStore } from "../common/sessionStore.js";
@@ -105,11 +106,14 @@ export class StreamableHttpRunner<
     async start({
         serverOptions,
         sessionOptions,
+        preRouteMiddleware,
     }: {
         /** Server options to use when creating the server. */
         serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
         /** Session options to use when creating the session. */
         sessionOptions?: CustomizableSessionOptions<TUserConfig>;
+        /** Optional Express middleware to run after body parsing but before route handlers. */
+        preRouteMiddleware?: express.RequestHandler[];
     } = {}): Promise<void> {
         this.validateConfig();
 
@@ -120,6 +124,7 @@ export class StreamableHttpRunner<
             logger: this.logger,
             metrics: this.metrics,
             sessionStore: this.sessionStore,
+            preRouteMiddleware,
         });
         await this.mcpServer.start();
 

--- a/src/transports/streamableHttp.ts
+++ b/src/transports/streamableHttp.ts
@@ -1,5 +1,4 @@
 import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import type express from "express";
 import type { LoggerBase } from "../common/logging/index.js";
 import { CompositeLogger, LogId } from "../common/logging/index.js";
 import { type ISessionStore, type CreateSessionStoreFn, createDefaultSessionStore } from "../common/sessionStore.js";
@@ -13,11 +12,16 @@ import type { CustomizableServerOptions, Server, UserConfig } from "../lib.js";
 import { applyConfigOverrides } from "../common/config/configOverrides.js";
 import type { DefaultMetrics, Metrics } from "../common/metrics/index.js";
 import type { MonitoringServerFeature } from "../common/schemas.js";
-import { MCPHttpServer } from "./mcpHttpServer.js";
+import {
+    MCPHttpServer,
+    type CreateMcpHttpServerFn,
+    createDefaultMcpHttpServer,
+    type MCPHttpServerConstructorArgs,
+} from "./mcpHttpServer.js";
 import { MonitoringServer, type CreateMonitoringServerFn, createDefaultMonitoringServer } from "./monitoringServer.js";
 
-export { createDefaultMonitoringServer, MonitoringServer };
-export type { CreateMonitoringServerFn, MonitoringServerFeature, MCPHttpServer };
+export { createDefaultMonitoringServer, MonitoringServer, createDefaultMcpHttpServer, MCPHttpServer };
+export type { CreateMonitoringServerFn, MonitoringServerFeature, CreateMcpHttpServerFn, MCPHttpServerConstructorArgs };
 
 /**
  * Configuration options for extracting monitoring server settings from UserConfig.
@@ -40,6 +44,7 @@ export type MonitoringServerConfig = {
 export type StreamableHttpTransportRunnerConfig<
     TUserConfig extends UserConfig = UserConfig,
     TMetrics extends DefaultMetrics = DefaultMetrics,
+    TContext = unknown,
 > = TransportRunnerConfig<TUserConfig, TMetrics> & {
     /**
      * When provided, the runner will use this function to create the monitoring server
@@ -57,6 +62,14 @@ export type StreamableHttpTransportRunnerConfig<
      * arguments that would normally be used.
      */
     createSessionStore?: CreateSessionStoreFn<StreamableHTTPServerTransport, TMetrics>;
+
+    /**
+     * When provided, the runner will use this function to create the MCP HTTP server
+     * instead of using the default MCPHttpServer constructor. This allows for
+     * customizing the HTTP server (e.g., adding pre-route middleware) while still
+     * receiving the constructor arguments that would normally be used.
+     */
+    createMcpHttpServer?: CreateMcpHttpServerFn<TUserConfig, TContext>;
 };
 
 export {
@@ -76,9 +89,11 @@ export class StreamableHttpRunner<
     private mcpServer: MCPHttpServer<TUserConfig, TContext> | undefined;
     private readonly monitoringServer: MonitoringServer<TMetrics> | undefined;
     private readonly sessionStore: ISessionStore<StreamableHTTPServerTransport>;
+    private readonly createMcpHttpServer: CreateMcpHttpServerFn<TUserConfig, TContext>;
 
-    constructor(config: StreamableHttpTransportRunnerConfig<TUserConfig, TMetrics>) {
+    constructor(config: StreamableHttpTransportRunnerConfig<TUserConfig, TMetrics, TContext>) {
         super(config);
+        this.createMcpHttpServer = config.createMcpHttpServer ?? createDefaultMcpHttpServer;
 
         this.sessionStore = (config.createSessionStore ?? createDefaultSessionStore<StreamableHTTPServerTransport>)({
             options: {
@@ -106,25 +121,21 @@ export class StreamableHttpRunner<
     async start({
         serverOptions,
         sessionOptions,
-        preRouteMiddleware,
     }: {
         /** Server options to use when creating the server. */
         serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
         /** Session options to use when creating the session. */
         sessionOptions?: CustomizableSessionOptions<TUserConfig>;
-        /** Optional Express middleware to run after body parsing but before route handlers. */
-        preRouteMiddleware?: express.RequestHandler[];
     } = {}): Promise<void> {
         this.validateConfig();
 
-        this.mcpServer = new MCPHttpServer<TUserConfig, TContext>({
+        this.mcpServer = this.createMcpHttpServer({
             userConfig: this.userConfig,
             createServerForRequest: ({ request }): Promise<Server<TUserConfig, TContext>> =>
                 this.createServerForRequest({ request, serverOptions, sessionOptions }),
             logger: this.logger,
             metrics: this.metrics,
             sessionStore: this.sessionStore,
-            preRouteMiddleware,
         });
         await this.mcpServer.start();
 

--- a/tests/integration/transports/streamableHttp.test.ts
+++ b/tests/integration/transports/streamableHttp.test.ts
@@ -788,6 +788,92 @@ describe("StreamableHttpRunner", () => {
         }
     });
 
+    describe("preRouteMiddleware", () => {
+        it("should execute middleware before route handlers", async () => {
+            const middlewareCalls: string[] = [];
+
+            runner = new StreamableHttpRunner({ userConfig: config });
+            await runner.start({
+                preRouteMiddleware: [
+                    (_req, _res, next) => {
+                        middlewareCalls.push("middleware-executed");
+                        next();
+                    },
+                ],
+            });
+
+            const client = await connectClient({});
+            const response = await client.listTools();
+            expect(response).toBeDefined();
+            expect(response.tools).toBeDefined();
+            // Middleware should have been called for the initialize and listTools requests
+            expect(middlewareCalls.length).toBeGreaterThanOrEqual(1);
+        });
+
+        it("should allow middleware to reject requests", async () => {
+            runner = new StreamableHttpRunner({ userConfig: config });
+            await runner.start({
+                preRouteMiddleware: [
+                    (_req, res, _next) => {
+                        // Block all requests
+                        res.status(403).json({ error: "blocked by middleware" });
+                    },
+                ],
+            });
+
+            const response = await fetch(`${runner["mcpServer"]!.serverAddress}/mcp`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json", accept: "application/json, text/event-stream" },
+                body: JSON.stringify({
+                    jsonrpc: "2.0",
+                    method: "initialize",
+                    id: 1,
+                    params: {
+                        protocolVersion: "2024-11-05",
+                        capabilities: {},
+                        clientInfo: { name: "test", version: "0.0.0" },
+                    },
+                }),
+            });
+
+            expect(response.status).toBe(403);
+            const data = (await response.json()) as { error?: string };
+            expect(data.error).toBe("blocked by middleware");
+        });
+
+        it("should run middleware in the order provided", async () => {
+            const order: number[] = [];
+
+            runner = new StreamableHttpRunner({ userConfig: config });
+            await runner.start({
+                preRouteMiddleware: [
+                    (_req, _res, next) => {
+                        order.push(1);
+                        next();
+                    },
+                    (_req, _res, next) => {
+                        order.push(2);
+                        next();
+                    },
+                ],
+            });
+
+            await connectClient({});
+            expect(order[0]).toBe(1);
+            expect(order[1]).toBe(2);
+        });
+
+        it("should work without preRouteMiddleware (default behavior)", async () => {
+            runner = new StreamableHttpRunner({ userConfig: config });
+            await runner.start();
+
+            const client = await connectClient({});
+            const response = await client.listTools();
+            expect(response).toBeDefined();
+            expect(response.tools.length).toBeGreaterThan(0);
+        });
+    });
+
     describe("monitoring server", () => {
         describe("using legacy healthCheck config (backwards compat)", () => {
             beforeEach(() => {

--- a/tests/integration/transports/streamableHttp.test.ts
+++ b/tests/integration/transports/streamableHttp.test.ts
@@ -1,4 +1,5 @@
-import { StreamableHttpRunner } from "../../../src/transports/streamableHttp.js";
+import type express from "express";
+import { StreamableHttpRunner, MCPHttpServer } from "../../../src/transports/streamableHttp.js";
 import {
     createDefaultSessionStore,
     type ISessionStore,
@@ -788,38 +789,50 @@ describe("StreamableHttpRunner", () => {
         }
     });
 
-    describe("preRouteMiddleware", () => {
-        it("should execute middleware before route handlers", async () => {
+    describe("createMcpHttpServer factory", () => {
+        it("should use custom MCPHttpServer subclass via factory", async () => {
             const middlewareCalls: string[] = [];
 
-            runner = new StreamableHttpRunner({ userConfig: config });
-            await runner.start({
-                preRouteMiddleware: [
-                    (_req, _res, next) => {
-                        middlewareCalls.push("middleware-executed");
-                        next();
-                    },
-                ],
+            runner = new StreamableHttpRunner({
+                userConfig: config,
+                createMcpHttpServer(args): MCPHttpServer {
+                    return new (class extends MCPHttpServer {
+                        protected override setupMiddlewares(): void {
+                            this.app.use(
+                                (_req: express.Request, _res: express.Response, next: express.NextFunction) => {
+                                    middlewareCalls.push("middleware-executed");
+                                    next();
+                                }
+                            );
+                            super.setupMiddlewares();
+                        }
+                    })(args);
+                },
             });
+            await runner.start();
 
             const client = await connectClient({});
             const response = await client.listTools();
             expect(response).toBeDefined();
             expect(response.tools).toBeDefined();
-            // Middleware should have been called for the initialize and listTools requests
             expect(middlewareCalls.length).toBeGreaterThanOrEqual(1);
         });
 
-        it("should allow middleware to reject requests", async () => {
-            runner = new StreamableHttpRunner({ userConfig: config });
-            await runner.start({
-                preRouteMiddleware: [
-                    (_req, res, _next) => {
-                        // Block all requests
-                        res.status(403).json({ error: "blocked by middleware" });
-                    },
-                ],
+        it("should allow factory to create a server that rejects requests", async () => {
+            runner = new StreamableHttpRunner({
+                userConfig: config,
+                createMcpHttpServer(args): MCPHttpServer {
+                    return new (class extends MCPHttpServer {
+                        protected override setupMiddlewares(): void {
+                            this.app.use((_req: express.Request, res: express.Response) => {
+                                res.status(403).json({ error: "blocked by middleware" });
+                            });
+                            super.setupMiddlewares();
+                        }
+                    })(args);
+                },
             });
+            await runner.start();
 
             const response = await fetch(`${runner["mcpServer"]!.serverAddress}/mcp`, {
                 method: "POST",
@@ -841,29 +854,7 @@ describe("StreamableHttpRunner", () => {
             expect(data.error).toBe("blocked by middleware");
         });
 
-        it("should run middleware in the order provided", async () => {
-            const order: number[] = [];
-
-            runner = new StreamableHttpRunner({ userConfig: config });
-            await runner.start({
-                preRouteMiddleware: [
-                    (_req, _res, next) => {
-                        order.push(1);
-                        next();
-                    },
-                    (_req, _res, next) => {
-                        order.push(2);
-                        next();
-                    },
-                ],
-            });
-
-            await connectClient({});
-            expect(order[0]).toBe(1);
-            expect(order[1]).toBe(2);
-        });
-
-        it("should work without preRouteMiddleware (default behavior)", async () => {
+        it("should work without custom factory (default behavior)", async () => {
             runner = new StreamableHttpRunner({ userConfig: config });
             await runner.start();
 


### PR DESCRIPTION
## Proposed changes
This PR builds on https://github.com/10gen/mms/pull/163767 and enables https://github.com/10gen/mms/pull/163773.

The idea is for Atlas MCP service to ensure protocol correctness by checking whether MMS proxy had to generate a session id also for non-initialize request and reject any such request.

To enable this, we will now allow injecting MCP HTTP server through StreamableHTTP interface giving the interface consumers the ability to override chosen methods in MCPHttpServer class to inject or extend custom functionality.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
