### PR TITLE
chore: re-export StreamableHTTPServerTransport

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -27,7 +27,7 @@ import { NodeDriverServiceProvider } from '@mongosh/service-provider-node-driver
 import type { operations } from './openapi.js';
 import { Registry } from 'prom-client';
 import { Secret } from 'mongodb-redact';
-import type { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { z } from 'zod';
@@ -992,6 +992,8 @@ export class StreamableHttpRunner<TUserConfig extends UserConfig = UserConfig, T
         sessionOptions?: CustomizableSessionOptions<TUserConfig>;
     }): Promise<void>;
 }
+
+export { StreamableHTTPServerTransport }
 
 // @public
 export type StreamableHttpTransportRunnerConfig<TUserConfig extends UserConfig = UserConfig, TMetrics extends DefaultMetrics = DefaultMetrics> = TransportRunnerConfig<TUserConfig, TMetrics> & {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -45,6 +45,7 @@ export {
     type MonitoringServerConstructorArgs,
     type MonitoringServerConfig,
 } from "./transports/streamableHttp.js";
+export { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 export { StdioRunner } from "./transports/stdio.js";
 export {
     TransportRunnerBase,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -49,7 +49,7 @@ export {
     type MonitoringServerConstructorArgs,
     type MonitoringServerConfig,
 } from "./transports/streamableHttp.js";
-export { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+export type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 export { StdioRunner } from "./transports/stdio.js";
 export {
     TransportRunnerBase,


### PR DESCRIPTION
This is useful when creating a custom session store.