### PR TITLE
chore: Revert "chore: temporarily disable failing autoembeddings test"

### DIFF
--- a/tests/integration/tools/mongodb/read/aggregate.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregate.test.ts
@@ -1054,7 +1054,7 @@ describeWithMongoDB(
             await waitUntilSearchIndexIsQueryable(collection, "auto-embed-index", 120_000);
         });
 
-        it.todo("should be able to query autoEmbed text index", { timeout: 130_000 }, async () => {
+        it("should be able to query autoEmbed text index", { timeout: 130_000 }, async () => {
             const response = await integration.mcpClient().callTool({
                 name: "aggregate",
                 arguments: {


### PR DESCRIPTION
Reverts mongodb-js/mongodb-mcp-server#1063

The bug fix for mongo search community was released last Friday so enabling the test back again.