### PR TITLE
feat: added terraform script to deploy MCP server on Agentcore runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,39 @@ yalc.lock
 # Ignoring AI Tools directories
 .claude/
 .kiro/
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ coverage
 # Development tool files
 .yalc
 yalc.lock
+
+# Ignoring AI Tools directories
+.claude/
+.kiro/

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -1,0 +1,503 @@
+# MongoDB MCP Server — Terraform Deployment for AWS Bedrock AgentCore
+
+This directory contains a fully self-contained Terraform module that:
+
+1. Creates an ECR repository and builds + pushes the `linux/arm64` Docker image.
+2. Provisions the IAM execution role, Cognito user pool, and app client.
+3. Deploys the MongoDB MCP Server as an AWS Bedrock AgentCore MCP runtime.
+4. Provides a Python helper script to generate OAuth2 tokens for testing.
+
+---
+
+## Table of contents
+
+- [Architecture overview](#architecture-overview)
+- [Prerequisites](#prerequisites)
+- [File structure](#file-structure)
+- [Variables reference](#variables-reference)
+- [Deployment walkthrough](#deployment-walkthrough)
+  - [1 — Clone and configure](#1--clone-and-configure)
+  - [2 — Initialize Terraform](#2--initialize-terraform)
+  - [3 — Plan and apply](#3--plan-and-apply)
+  - [4 — Inspect outputs](#4--inspect-outputs)
+- [Generating OAuth tokens](#generating-oauth-tokens)
+  - [First login (temporary → permanent password)](#first-login-temporary--permanent-password)
+  - [Subsequent logins](#subsequent-logins)
+  - [Output formats](#output-formats)
+  - [Smoke-testing against the live runtime](#smoke-testing-against-the-live-runtime)
+- [Invoking the AgentCore runtime](#invoking-the-agentcore-runtime)
+- [Updating the deployment](#updating-the-deployment)
+  - [Rebuilding and pushing a new image](#rebuilding-and-pushing-a-new-image)
+  - [Rotating MongoDB credentials](#rotating-mongodb-credentials)
+- [Destroying the stack](#destroying-the-stack)
+- [Troubleshooting](#troubleshooting)
+- [Security notes for production](#security-notes-for-production)
+
+---
+
+## Architecture overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                      Your AWS Account                   │
+│                                                         │
+│  ┌─────────┐   push    ┌──────────────────────────────┐ │
+│  │  Docker │ ────────► │  Amazon ECR                  │ │
+│  │  Build  │           │  mongodb-mcp-server:latest   │ │
+│  └─────────┘           └──────────────┬───────────────┘ │
+│                                       │ pull             │
+│  ┌──────────────────┐                 ▼                  │
+│  │  Amazon Cognito  │   OIDC   ┌─────────────────────┐  │
+│  │  User Pool       │ ◄──────► │  Bedrock AgentCore  │  │
+│  │  (OAuth2/OIDC)   │          │  MCP Runtime        │  │
+│  └──────────────────┘          │  (port 8000 / HTTP) │  │
+│                                └─────────────────────┘  │
+│                                        ▲                 │
+│                               IAM Execution Role         │
+└─────────────────────────────────────────────────────────┘
+```
+
+| Component | Terraform file | AWS resource |
+|---|---|---|
+| Container registry | `ecr.tf` | `aws_ecr_repository` |
+| Docker build + push | `ecr.tf` | `null_resource` (local-exec) |
+| Execution role | `iam.tf` | `aws_iam_role` + policies |
+| Authentication | `cognito.tf` | `aws_cognito_user_pool` + domain + client |
+| Test user | `cognito.tf` | `aws_cognito_user` |
+| MCP runtime | `agentcore.tf` | AWS CLI via `null_resource` |
+
+---
+
+## Prerequisites
+
+| Tool | Minimum version | Notes |
+|---|---|---|
+| Terraform | 1.6.0 | `terraform version` |
+| AWS CLI | v2 | `aws --version` |
+| Docker | 24+ with Buildx | `docker buildx version` |
+| Python | 3.9+ | Only for `get_token.py` |
+| boto3 | any | `pip install boto3` |
+
+**AWS permissions required** (for the identity running `terraform apply`):
+
+- `ecr:*` on the target repository
+- `iam:CreateRole`, `iam:AttachRolePolicy`, `iam:PutRolePolicy`
+- `cognito-idp:*`
+- `bedrock-agentcore:CreateAgentRuntime`, `bedrock-agentcore:UpdateAgentRuntime`, `bedrock-agentcore:ListAgentRuntimes`
+
+Ensure your AWS CLI is configured:
+
+```bash
+aws configure
+# or
+export AWS_PROFILE=my-profile
+export AWS_REGION=us-east-1
+```
+
+---
+
+## File structure
+
+```
+deploy/aws/terraform/
+├── main.tf            # Provider config, caller identity, shared locals
+├── variables.tf       # All input variables with defaults and descriptions
+├── ecr.tf             # ECR repository + Docker build/push null_resource
+├── iam.tf             # AgentCore execution role + ECR/CloudWatch policies
+├── cognito.tf         # Cognito user pool, domain, app client, test user
+├── agentcore.tf       # AgentCore MCP runtime (AWS CLI provisioner)
+├── outputs.tf         # All useful post-deployment values
+└── scripts/
+    └── get_token.py   # Python helper to obtain Cognito OAuth2 tokens
+```
+
+---
+
+## Variables reference
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `aws_region` | No | `us-east-1` | AWS region for all resources |
+| `ecr_repository_name` | No | `mongodb-mcp-server` | Name of the ECR repository |
+| `image_tag` | No | `latest` | Docker image tag |
+| `agentcore_runtime_name` | No | `mongodb-mcp-server` | AgentCore runtime name |
+| `cognito_user_pool_name` | No | `mongodb-mcp-server-pool` | Cognito user pool name |
+| `cognito_test_username` | No | `mcp-test-user` | Test user's Cognito username |
+| `cognito_test_user_email` | **Yes** | — | Test user's email address |
+| `cognito_test_user_password` | **Yes** | — | Temporary password (first login only) |
+| `mdb_connection_string` | No | `""` | MongoDB connection string (`mongodb://` format) |
+| `mdb_api_client_id` | No | `""` | MongoDB Atlas API client ID |
+| `mdb_api_client_secret` | No | `""` | MongoDB Atlas API client secret |
+| `dockerfile_context_path` | No | `..` | Path to the directory containing `Dockerfile` |
+| `tags` | No | `{Project, ManagedBy}` | Tags applied to all AWS resources |
+
+> **Note on `mdb_connection_string`:** AgentCore does not support `mongodb+srv://` URIs
+> (no DNS SRV resolution in the managed runtime network). Use the standard `mongodb://` format
+> with a direct host and port, or a load-balanced endpoint.
+
+---
+
+## Deployment walkthrough
+
+### 1 — Clone and configure
+
+```bash
+cd deploy/aws/terraform
+```
+
+Create a `terraform.tfvars` file (never commit this — add it to `.gitignore`):
+
+```hcl
+# terraform.tfvars
+aws_region              = "us-east-1"
+cognito_test_user_email    = "you@example.com"
+cognito_test_user_password = "TempP@ss1234!"   # must satisfy Cognito policy (12+ chars, upper, lower, number, symbol)
+mdb_connection_string      = "mongodb://user:pass@your-cluster-host:27017/dbname"
+```
+
+Optional — add Atlas API credentials only if you enable Atlas tools:
+
+```hcl
+mdb_api_client_id     = "your-atlas-client-id"
+mdb_api_client_secret = "your-atlas-client-secret"
+```
+
+Alternatively, export sensitive values as environment variables so they never touch disk:
+
+```bash
+export TF_VAR_mdb_connection_string="mongodb://user:pass@host:27017/db"
+export TF_VAR_cognito_test_user_password="TempP@ss1234!"
+export TF_VAR_cognito_test_user_email="you@example.com"
+```
+
+### 2 — Initialize Terraform
+
+```bash
+terraform init
+```
+
+This downloads the `hashicorp/aws` and `hashicorp/null` providers. Expected output:
+
+```
+Terraform has been successfully initialized!
+```
+
+### 3 — Plan and apply
+
+Preview what will be created (no changes made):
+
+```bash
+terraform plan -var-file=terraform.tfvars
+```
+
+Apply all changes. Terraform will:
+1. Create the ECR repository.
+2. Build the Docker image for `linux/arm64` and push it to ECR.
+3. Create IAM roles and policies.
+4. Create the Cognito user pool, domain, app client, and test user.
+5. Create the Bedrock AgentCore MCP runtime via the AWS CLI.
+
+```bash
+terraform apply -var-file=terraform.tfvars
+```
+
+Type `yes` when prompted. The first apply takes approximately **5–10 minutes** — most of that time is the Docker `buildx` cross-compilation step.
+
+### 4 — Inspect outputs
+
+```bash
+terraform output
+```
+
+Example output:
+
+```
+agentcore_execution_role_arn = "arn:aws:iam::123456789012:role/mongodb-mcp-server-execution-role"
+agentcore_runtime_arn        = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/mongodb-mcp-server"
+agentcore_runtime_id         = "mongodb-mcp-server"
+cognito_token_endpoint       = "https://mongodb-mcp-server-pool-123456789012.auth.us-east-1.amazoncognito.com/oauth2/token"
+cognito_user_pool_client_id  = "4abc123def456ghi789"
+cognito_user_pool_id         = "us-east-1_AbCdEfGhI"
+ecr_image_uri                = "123456789012.dkr.ecr.us-east-1.amazonaws.com/mongodb-mcp-server:latest"
+get_token_command            = <<EOT
+  python3 scripts/get_token.py \
+    --region us-east-1 \
+    --user-pool-id us-east-1_AbCdEfGhI \
+    --client-id 4abc123def456ghi789 \
+    --username mcp-test-user \
+    --password <PASSWORD>
+EOT
+```
+
+---
+
+## Generating OAuth tokens
+
+Cognito tokens are required to call the AgentCore runtime API. The `get_token.py` script handles authentication, including the mandatory password-change challenge that Cognito triggers on first sign-in.
+
+### First login (temporary → permanent password)
+
+When a Cognito user is created via Terraform, AWS sets their status to `FORCE_CHANGE_PASSWORD`. On the very first sign-in you must supply a new permanent password:
+
+```bash
+python3 scripts/get_token.py \
+  --region us-east-1 \
+  --user-pool-id $(terraform output -raw cognito_user_pool_id) \
+  --client-id $(terraform output -raw cognito_user_pool_client_id) \
+  --username mcp-test-user \
+  --password "TempP@ss1234!" \
+  --new-password "MyPermanentP@ss99!" \
+  --verbose
+```
+
+`--verbose` prints decoded token claims (subject, email, expiry) to stderr alongside the JSON output.
+
+### Subsequent logins
+
+Once the permanent password is set, omit `--new-password`:
+
+```bash
+python3 scripts/get_token.py \
+  --region us-east-1 \
+  --user-pool-id $(terraform output -raw cognito_user_pool_id) \
+  --client-id $(terraform output -raw cognito_user_pool_client_id) \
+  --username mcp-test-user \
+  --password "MyPermanentP@ss99!"
+```
+
+You can also supply credentials via environment variables:
+
+```bash
+export AWS_REGION=us-east-1
+export COGNITO_USER_POOL_ID=$(terraform output -raw cognito_user_pool_id)
+export COGNITO_CLIENT_ID=$(terraform output -raw cognito_user_pool_client_id)
+export COGNITO_USERNAME=mcp-test-user
+export COGNITO_PASSWORD="MyPermanentP@ss99!"
+
+python3 scripts/get_token.py
+```
+
+### Output formats
+
+| Flag | Output |
+|---|---|
+| `--output json` (default) | Full JSON with `access_token`, `id_token`, `refresh_token`, `expires_in`, `token_type` |
+| `--output id_token` | Just the raw ID token string (for piping into `curl`) |
+| `--output access_token` | Just the raw access token string |
+
+### Smoke-testing against the live runtime
+
+Pass `--runtime-arn` to automatically call `tools/list` on the deployed AgentCore runtime using the freshly obtained ID token:
+
+```bash
+python3 scripts/get_token.py \
+  --username mcp-test-user \
+  --password "MyPermanentP@ss99!" \
+  --runtime-arn $(terraform output -raw agentcore_runtime_arn) \
+  --output id_token
+```
+
+---
+
+## Invoking the AgentCore runtime
+
+Once you have a token, call the runtime directly using `curl`:
+
+```bash
+RUNTIME_ARN=$(terraform output -raw agentcore_runtime_arn)
+REGION=$(terraform output -raw cognito_token_endpoint | cut -d. -f3)  # extracts region
+ENCODED_ARN=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$RUNTIME_ARN")
+
+TOKEN=$(python3 scripts/get_token.py \
+  --username mcp-test-user \
+  --password "MyPermanentP@ss99!" \
+  --output id_token)
+
+# List available MCP tools
+curl -s -X POST \
+  "https://bedrock-agentcore.${REGION}.amazonaws.com/runtimes/${ENCODED_ARN}/invocations?qualifier=DEFAULT" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}' | jq .
+```
+
+---
+
+## Updating the deployment
+
+### Rebuilding and pushing a new image
+
+Bump the image tag in `terraform.tfvars` (or leave it as `latest`). Terraform detects the `Dockerfile` MD5 change and triggers a rebuild automatically:
+
+```bash
+terraform apply -var-file=terraform.tfvars -var="image_tag=v1.2.0"
+```
+
+### Rotating MongoDB credentials
+
+Update the relevant variable, then re-apply. Only the AgentCore runtime's environment variables are updated — no downtime to ECR or Cognito:
+
+```bash
+terraform apply \
+  -var-file=terraform.tfvars \
+  -var='mdb_connection_string=mongodb://newuser:newpass@host:27017/db'
+```
+
+---
+
+## Destroying the stack
+
+```bash
+terraform destroy -var-file=terraform.tfvars
+```
+
+> **Note:** The Cognito user pool domain must be deleted before the user pool itself.
+> Terraform handles this automatically via `depends_on`, but if a partial destroy fails,
+> delete the domain manually in the AWS console first, then re-run `terraform destroy`.
+
+---
+
+## Troubleshooting
+
+### Docker build fails: `exec format error` or `no matching manifest`
+
+The AgentCore runtime requires `linux/arm64` images. Ensure Docker Buildx is configured with a multi-platform builder:
+
+```bash
+docker buildx create --name multi --use
+docker buildx inspect --bootstrap
+```
+
+Then re-run `terraform apply`.
+
+---
+
+### ECR authentication fails: `no basic auth credentials`
+
+The AWS CLI identity used by Terraform must have `ecr:GetAuthorizationToken` permission. Verify:
+
+```bash
+aws ecr get-login-password --region us-east-1 | \
+  docker login --username AWS --password-stdin \
+  $(terraform output -raw ecr_repository_url | cut -d/ -f1)
+```
+
+---
+
+### `terraform apply` hangs at the Docker build step
+
+Cross-compilation for `arm64` on an `x86_64` host requires QEMU emulation and can be slow (10–20 minutes for a cold build). To confirm progress:
+
+```bash
+docker buildx build --platform linux/arm64 --progress=plain ..
+```
+
+---
+
+### AgentCore runtime creation fails: `ResourceNotFoundException`
+
+Bedrock AgentCore is not available in all regions. Verify availability:
+
+```bash
+aws bedrock-agentcore list-agent-runtimes --region us-east-1
+```
+
+Supported regions as of early 2025: `us-east-1`, `us-west-2`, `eu-west-1`. Check the [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/agentcore.html) for the current list.
+
+---
+
+### AgentCore runtime creation fails: `AccessDeniedException`
+
+The IAM identity running Terraform must have `bedrock-agentcore:CreateAgentRuntime`. If using an IAM role or SSO session, ensure the session has not expired:
+
+```bash
+aws sts get-caller-identity
+```
+
+---
+
+### Cognito: `NotAuthorizedException: Incorrect username or password`
+
+- The test user's status may still be `FORCE_CHANGE_PASSWORD`. Re-run `get_token.py` with `--new-password` to complete the challenge.
+- Check user status in the AWS console: **Cognito → User pools → Users**.
+
+---
+
+### Cognito: `NEW_PASSWORD_REQUIRED` error in `get_token.py`
+
+You have not yet set a permanent password. Add `--new-password`:
+
+```bash
+python3 scripts/get_token.py \
+  --username mcp-test-user \
+  --password "TempP@ss1234!" \
+  --new-password "MyPermanentP@ss99!"
+```
+
+The new password must satisfy the Cognito policy (12+ characters, uppercase, lowercase, number, symbol).
+
+---
+
+### Cognito domain conflict: `Domain already exists`
+
+The Cognito domain name (`<pool-name>-<account-id>`) must be globally unique within Cognito. If a previous deploy left a stale domain:
+
+```bash
+aws cognito-idp delete-user-pool-domain \
+  --domain <your-domain-prefix> \
+  --user-pool-id <pool-id> \
+  --region us-east-1
+```
+
+Then re-run `terraform apply`.
+
+---
+
+### `terraform output` returns `"pending"` for `agentcore_runtime_arn`
+
+The `data.external` lookup runs immediately after `null_resource.agentcore_runtime`. If the AgentCore runtime is still initializing, the ARN may not yet be visible via `list-agent-runtimes`. Wait 30 seconds and run:
+
+```bash
+terraform refresh -var-file=terraform.tfvars
+terraform output agentcore_runtime_arn
+```
+
+---
+
+### MCP server is unreachable / returns 5xx
+
+Check the runtime logs in CloudWatch:
+
+```bash
+aws logs describe-log-groups \
+  --region us-east-1 \
+  --log-group-name-prefix "/aws/bedrock-agentcore"
+
+aws logs tail /aws/bedrock-agentcore/mongodb-mcp-server --follow
+```
+
+Common causes:
+- Invalid `MDB_MCP_CONNECTION_STRING` — the server will fail to connect to MongoDB on startup.
+- `mongodb+srv://` URI used — not supported; use `mongodb://` with a direct host.
+- Container OOM — increase memory in the AgentCore runtime configuration if needed.
+
+---
+
+### `boto3` not found when running `get_token.py`
+
+```bash
+pip install boto3
+# or, in a virtual environment:
+python3 -m venv .venv && source .venv/bin/activate && pip install boto3
+```
+
+---
+
+## Security notes for production
+
+- **Secrets in state:** `mdb_connection_string`, `mdb_api_client_secret`, and `cognito_test_user_password` are marked `sensitive = true` but are still stored in the Terraform state file. Use a remote backend with encryption (e.g. S3 + KMS) and restrict access to state.
+- **Test user:** The `aws_cognito_user` resource is intended for developer testing only. Remove it (and `cognito_test_username` / `cognito_test_user_password`) before deploying to production.
+- **MFA:** Cognito MFA is disabled by default. Enable it for production user pools by setting `mfa_configuration = "ON"` in `cognito.tf`.
+- **Token lifetime:** Access and ID tokens are valid for 60 minutes. Reduce this for production workloads.
+- **Advanced Security:** `advanced_security_mode = "ENFORCED"` is already enabled, providing anomaly detection. Review CloudWatch Cognito logs for suspicious activity.
+- **Network mode:** The AgentCore runtime is deployed in `PUBLIC` network mode. For private deployments, change `networkMode` to `VPC` and supply a VPC configuration.

--- a/deploy/aws/terraform/README.md
+++ b/deploy/aws/terraform/README.md
@@ -57,26 +57,26 @@ This directory contains a fully self-contained Terraform module that:
 └─────────────────────────────────────────────────────────┘
 ```
 
-| Component | Terraform file | AWS resource |
-|---|---|---|
-| Container registry | `ecr.tf` | `aws_ecr_repository` |
-| Docker build + push | `ecr.tf` | `null_resource` (local-exec) |
-| Execution role | `iam.tf` | `aws_iam_role` + policies |
-| Authentication | `cognito.tf` | `aws_cognito_user_pool` + domain + client |
-| Test user | `cognito.tf` | `aws_cognito_user` |
-| MCP runtime | `agentcore.tf` | AWS CLI via `null_resource` |
+| Component           | Terraform file | AWS resource                              |
+| ------------------- | -------------- | ----------------------------------------- |
+| Container registry  | `ecr.tf`       | `aws_ecr_repository`                      |
+| Docker build + push | `ecr.tf`       | `null_resource` (local-exec)              |
+| Execution role      | `iam.tf`       | `aws_iam_role` + policies                 |
+| Authentication      | `cognito.tf`   | `aws_cognito_user_pool` + domain + client |
+| Test user           | `cognito.tf`   | `aws_cognito_user`                        |
+| MCP runtime         | `agentcore.tf` | AWS CLI via `null_resource`               |
 
 ---
 
 ## Prerequisites
 
-| Tool | Minimum version | Notes |
-|---|---|---|
-| Terraform | 1.6.0 | `terraform version` |
-| AWS CLI | v2 | `aws --version` |
-| Docker | 24+ with Buildx | `docker buildx version` |
-| Python | 3.9+ | Only for `get_token.py` |
-| boto3 | any | `pip install boto3` |
+| Tool      | Minimum version | Notes                   |
+| --------- | --------------- | ----------------------- |
+| Terraform | 1.6.0           | `terraform version`     |
+| AWS CLI   | v2              | `aws --version`         |
+| Docker    | 24+ with Buildx | `docker buildx version` |
+| Python    | 3.9+            | Only for `get_token.py` |
+| boto3     | any             | `pip install boto3`     |
 
 **AWS permissions required** (for the identity running `terraform apply`):
 
@@ -115,21 +115,21 @@ deploy/aws/terraform/
 
 ## Variables reference
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `aws_region` | No | `us-east-1` | AWS region for all resources |
-| `ecr_repository_name` | No | `mongodb-mcp-server` | Name of the ECR repository |
-| `image_tag` | No | `latest` | Docker image tag |
-| `agentcore_runtime_name` | No | `mongodb-mcp-server` | AgentCore runtime name |
-| `cognito_user_pool_name` | No | `mongodb-mcp-server-pool` | Cognito user pool name |
-| `cognito_test_username` | No | `mcp-test-user` | Test user's Cognito username |
-| `cognito_test_user_email` | **Yes** | — | Test user's email address |
-| `cognito_test_user_password` | **Yes** | — | Temporary password (first login only) |
-| `mdb_connection_string` | No | `""` | MongoDB connection string (`mongodb://` format) |
-| `mdb_api_client_id` | No | `""` | MongoDB Atlas API client ID |
-| `mdb_api_client_secret` | No | `""` | MongoDB Atlas API client secret |
-| `dockerfile_context_path` | No | `..` | Path to the directory containing `Dockerfile` |
-| `tags` | No | `{Project, ManagedBy}` | Tags applied to all AWS resources |
+| Variable                     | Required | Default                   | Description                                     |
+| ---------------------------- | -------- | ------------------------- | ----------------------------------------------- |
+| `aws_region`                 | No       | `us-east-1`               | AWS region for all resources                    |
+| `ecr_repository_name`        | No       | `mongodb-mcp-server`      | Name of the ECR repository                      |
+| `image_tag`                  | No       | `latest`                  | Docker image tag                                |
+| `agentcore_runtime_name`     | No       | `mongodb-mcp-server`      | AgentCore runtime name                          |
+| `cognito_user_pool_name`     | No       | `mongodb-mcp-server-pool` | Cognito user pool name                          |
+| `cognito_test_username`      | No       | `mcp-test-user`           | Test user's Cognito username                    |
+| `cognito_test_user_email`    | **Yes**  | —                         | Test user's email address                       |
+| `cognito_test_user_password` | **Yes**  | —                         | Temporary password (first login only)           |
+| `mdb_connection_string`      | No       | `""`                      | MongoDB connection string (`mongodb://` format) |
+| `mdb_api_client_id`          | No       | `""`                      | MongoDB Atlas API client ID                     |
+| `mdb_api_client_secret`      | No       | `""`                      | MongoDB Atlas API client secret                 |
+| `dockerfile_context_path`    | No       | `..`                      | Path to the directory containing `Dockerfile`   |
+| `tags`                       | No       | `{Project, ManagedBy}`    | Tags applied to all AWS resources               |
 
 > **Note on `mdb_connection_string`:** AgentCore does not support `mongodb+srv://` URIs
 > (no DNS SRV resolution in the managed runtime network). Use the standard `mongodb://` format
@@ -191,6 +191,7 @@ terraform plan -var-file=terraform.tfvars
 ```
 
 Apply all changes. Terraform will:
+
 1. Create the ECR repository.
 2. Build the Docker image for `linux/arm64` and push it to ECR.
 3. Create IAM roles and policies.
@@ -279,11 +280,11 @@ python3 scripts/get_token.py
 
 ### Output formats
 
-| Flag | Output |
-|---|---|
+| Flag                      | Output                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------- |
 | `--output json` (default) | Full JSON with `access_token`, `id_token`, `refresh_token`, `expires_in`, `token_type` |
-| `--output id_token` | Just the raw ID token string (for piping into `curl`) |
-| `--output access_token` | Just the raw access token string |
+| `--output id_token`       | Just the raw ID token string (for piping into `curl`)                                  |
+| `--output access_token`   | Just the raw access token string                                                       |
 
 ### Smoke-testing against the live runtime
 
@@ -477,6 +478,7 @@ aws logs tail /aws/bedrock-agentcore/mongodb-mcp-server --follow
 ```
 
 Common causes:
+
 - Invalid `MDB_MCP_CONNECTION_STRING` — the server will fail to connect to MongoDB on startup.
 - `mongodb+srv://` URI used — not supported; use `mongodb://` with a direct host.
 - Container OOM — increase memory in the AgentCore runtime configuration if needed.

--- a/deploy/aws/terraform/agentcore.tf
+++ b/deploy/aws/terraform/agentcore.tf
@@ -1,0 +1,63 @@
+# ---------------------------------------------------------------------------
+# Bedrock AgentCore – MCP Runtime (aws native resource)
+# ---------------------------------------------------------------------------
+
+locals {
+  # Environment variables forwarded to the MCP server container
+  mcp_env_raw = {
+    # MDB_MCP_LOGGERS                     = "stderr,mcp"
+    # MDB_MCP_DISABLED_TOOLS              = "atlas-local"
+    # MDB_MCP_EXTERNALLY_MANAGED_SESSIONS = "true"
+    # MDB_MCP_HTTP_RESPONSE_TYPE          = "json"
+    # MDB_MCP_TRANSPORT                   = "http"
+    # MDB_MCP_HTTP_HOST                   = "0.0.0.0"
+    # MDB_MCP_HTTP_PORT                   = "8000"
+    MDB_MCP_CONNECTION_STRING           = var.mdb_connection_string
+    MDB_MCP_API_CLIENT_ID               = var.mdb_api_client_id
+    MDB_MCP_API_CLIENT_SECRET           = var.mdb_api_client_secret
+  }
+
+  # Strip empty-value entries (e.g. optional Atlas creds not provided)
+  mcp_env = { for k, v in local.mcp_env_raw : k => v if v != "" }
+
+  # cognito_domain_url = "https://${aws_cognito_user_pool_domain.mcp.domain}.auth.${local.region}.amazoncognito.com"
+  # token_endpoint     = "${local.cognito_domain_url}/oauth2/token"
+  # jwks_uri           = "https://cognito-idp.${local.region}.amazonaws.com/${aws_cognito_user_pool.mcp.id}/.well-known/jwks.json"
+  oidc_discovery_url = "https://cognito-idp.${local.region}.amazonaws.com/${aws_cognito_user_pool.mcp.id}/.well-known/openid-configuration"
+}
+
+# ---------------------------------------------------------------------------
+# AgentCore MCP runtime – native aws resource
+# ---------------------------------------------------------------------------
+
+resource "aws_bedrockagentcore_agent_runtime" "mcp" {
+  agent_runtime_name = var.agentcore_runtime_name
+  role_arn           = aws_iam_role.agentcore_execution.arn
+
+  agent_runtime_artifact {
+    container_configuration {
+      container_uri = local.ecr_image_uri
+    }
+  }
+
+  network_configuration {
+    network_mode = "PUBLIC"
+  }
+
+  authorizer_configuration {
+    custom_jwt_authorizer {
+      discovery_url   = local.oidc_discovery_url
+      allowed_clients = [aws_cognito_user_pool_client.mcp.id]
+    }
+  }
+
+  environment_variables = local.mcp_env
+
+  depends_on = [
+    null_resource.docker_build_push,
+    aws_iam_role_policy_attachment.agentcore_ecr,
+    aws_iam_role_policy_attachment.agentcore_logs,
+    aws_cognito_user_pool_client.mcp,
+    aws_cognito_user_pool_domain.mcp,
+  ]
+}

--- a/deploy/aws/terraform/agentcore.tf
+++ b/deploy/aws/terraform/agentcore.tf
@@ -27,6 +27,15 @@ locals {
 }
 
 # ---------------------------------------------------------------------------
+# CloudWatch log group for AgentCore invocation logs
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "agentcore_invocations" {
+  name              = "/aws/bedrock-agentcore/runtimes/${var.agentcore_runtime_name}"
+  retention_in_days = 30
+}
+
+# ---------------------------------------------------------------------------
 # AgentCore MCP runtime – native aws resource
 # ---------------------------------------------------------------------------
 
@@ -51,13 +60,22 @@ resource "aws_bedrockagentcore_agent_runtime" "mcp" {
     }
   }
 
+  protocol_configuration {
+    server_protocol = "MCP"
+  }
+
   environment_variables = local.mcp_env
 
   depends_on = [
     null_resource.docker_build_push,
     aws_iam_role_policy_attachment.agentcore_ecr,
     aws_iam_role_policy_attachment.agentcore_logs,
+    aws_iam_role_policy_attachment.agentcore_xray,
+    aws_iam_role_policy_attachment.agentcore_metrics,
+    aws_iam_role_policy_attachment.agentcore_workload_identity,
+    aws_iam_role_policy_attachment.agentcore_bedrock,
     aws_cognito_user_pool_client.mcp,
     aws_cognito_user_pool_domain.mcp,
+    aws_cloudwatch_log_group.agentcore_invocations,
   ]
 }

--- a/deploy/aws/terraform/cognito.tf
+++ b/deploy/aws/terraform/cognito.tf
@@ -1,0 +1,106 @@
+# ---------------------------------------------------------------------------
+# Cognito User Pool – OAuth2/OIDC front-door for the AgentCore MCP runtime
+# ---------------------------------------------------------------------------
+# AgentCore automatically wires its MCP runtime to an OIDC provider.
+# We create the Cognito resources here so they are fully managed by
+# Terraform and can be referenced both by AgentCore and the token helper
+# script.
+
+resource "aws_cognito_user_pool" "mcp" {
+  name = var.cognito_user_pool_name
+
+  # ---- Sign-in configuration ----
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+
+  username_configuration {
+    case_sensitive = false
+  }
+
+  # ---- Password policy ----
+  password_policy {
+    minimum_length                   = 12
+    require_lowercase                = true
+    require_numbers                  = true
+    require_symbols                  = true
+    require_uppercase                = true
+    temporary_password_validity_days = 7
+  }
+
+  # ---- MFA (optional – disabled for simplicity, enable for production) ----
+  mfa_configuration = "OFF"
+
+  # ---- Account recovery ----
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
+
+  # ---- Token validity ----
+  user_pool_add_ons {
+    advanced_security_mode = "ENFORCED"
+  }
+}
+
+# Cognito domain – required to expose the OAuth2 token endpoint
+resource "aws_cognito_user_pool_domain" "mcp" {
+  domain       = "${var.cognito_user_pool_name}-${local.account_id}"
+  user_pool_id = aws_cognito_user_pool.mcp.id
+}
+
+# App client used by the AgentCore runtime and the token helper script
+resource "aws_cognito_user_pool_client" "mcp" {
+  name         = "${var.agentcore_runtime_name}-client"
+  user_pool_id = aws_cognito_user_pool.mcp.id
+
+  # ---- OAuth2 flows ----
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["code", "implicit"]
+  allowed_oauth_scopes                 = ["openid", "profile", "email"]
+
+  # Callback / sign-out URLs (adjust for your application)
+  callback_urls = ["https://localhost/callback"]
+  logout_urls   = ["https://localhost/logout"]
+
+  # Explicit auth flows – enables USER_PASSWORD_AUTH for the token script
+  explicit_auth_flows = [
+    "ALLOW_USER_PASSWORD_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+    "ALLOW_USER_SRP_AUTH",
+  ]
+
+  # Token validity
+  access_token_validity  = 60   # minutes
+  id_token_validity      = 60   # minutes
+  refresh_token_validity = 30   # days
+
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "days"
+  }
+
+  prevent_user_existence_errors = "ENABLED"
+  generate_secret               = false
+}
+
+# ---------------------------------------------------------------------------
+# Test user – used by the get_token.py helper script
+# ---------------------------------------------------------------------------
+
+resource "aws_cognito_user" "test_user" {
+  user_pool_id = aws_cognito_user_pool.mcp.id
+  # User pool uses email as the username attribute — must pass an email address
+  username     = var.cognito_test_user_email
+
+  attributes = {
+    email          = var.cognito_test_user_email
+    email_verified = "true"
+  }
+
+  # Temporary password; the helper script handles the NEW_PASSWORD_REQUIRED
+  # challenge automatically on first use.
+  temporary_password = var.cognito_test_user_password
+}

--- a/deploy/aws/terraform/ecr.tf
+++ b/deploy/aws/terraform/ecr.tf
@@ -1,0 +1,78 @@
+# ---------------------------------------------------------------------------
+# ECR Repository
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_repository" "mcp_server" {
+  name                 = var.ecr_repository_name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "mcp_server" {
+  repository = aws_ecr_repository.mcp_server.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 10
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Docker build & push (linux/arm64 — required by AgentCore)
+# ---------------------------------------------------------------------------
+# This null_resource runs on every `terraform apply` when the Dockerfile
+# or the image tag changes. It authenticates to ECR, builds the image for
+# linux/arm64, and pushes it.
+
+resource "null_resource" "docker_build_push" {
+  triggers = {
+    # Re-run when the image tag or the Dockerfile content changes.
+    image_tag        = var.image_tag
+    dockerfile_hash  = filemd5("${var.dockerfile_context_path}/Dockerfile")
+    repository_url   = aws_ecr_repository.mcp_server.repository_url
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOF
+      set -euo pipefail
+
+      ECR_REGISTRY="${local.account_id}.dkr.ecr.${local.region}.amazonaws.com"
+      IMAGE_URI="${local.ecr_image_uri}"
+
+      echo "==> Authenticating with ECR..."
+      aws ecr get-login-password --region "${local.region}" --profile "${var.aws_profile}" \
+        | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+      echo "==> Building image for linux/arm64..."
+      docker build \
+        --platform linux/arm64 \
+        -t "$IMAGE_URI" \
+        --push \
+        "${var.dockerfile_context_path}"
+
+      echo "==> Image pushed: $IMAGE_URI"
+    EOF
+  }
+
+  depends_on = [aws_ecr_repository.mcp_server]
+}

--- a/deploy/aws/terraform/iam.tf
+++ b/deploy/aws/terraform/iam.tf
@@ -64,15 +64,35 @@ resource "aws_iam_role_policy_attachment" "agentcore_ecr" {
 # Allow runtime logs to be written to CloudWatch
 data "aws_iam_policy_document" "agentcore_logs" {
   statement {
-    sid    = "CloudWatchLogs"
+    sid    = "CloudWatchLogsGroup"
     effect = "Allow"
     actions = [
       "logs:CreateLogGroup",
+      "logs:DescribeLogStreams",
+    ]
+    resources = [
+      "arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*",
+    ]
+  }
+
+  statement {
+    sid     = "CloudWatchLogsDescribeGroups"
+    effect  = "Allow"
+    actions = ["logs:DescribeLogGroups"]
+    resources = [
+      "arn:aws:logs:${local.region}:${local.account_id}:log-group:*",
+    ]
+  }
+
+  statement {
+    sid    = "CloudWatchLogsStream"
+    effect = "Allow"
+    actions = [
       "logs:CreateLogStream",
       "logs:PutLogEvents",
     ]
     resources = [
-      "arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/bedrock-agentcore/*",
+      "arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*",
     ]
   }
 }
@@ -86,4 +106,111 @@ resource "aws_iam_policy" "agentcore_logs" {
 resource "aws_iam_role_policy_attachment" "agentcore_logs" {
   role       = aws_iam_role.agentcore_execution.name
   policy_arn = aws_iam_policy.agentcore_logs.arn
+}
+
+# Allow X-Ray tracing
+data "aws_iam_policy_document" "agentcore_xray" {
+  statement {
+    sid    = "XRayTracing"
+    effect = "Allow"
+    actions = [
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+      "xray:GetSamplingRules",
+      "xray:GetSamplingTargets",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "agentcore_xray" {
+  name        = "${var.agentcore_runtime_name}-xray"
+  description = "Allow AgentCore runtime to send X-Ray traces"
+  policy      = data.aws_iam_policy_document.agentcore_xray.json
+}
+
+resource "aws_iam_role_policy_attachment" "agentcore_xray" {
+  role       = aws_iam_role.agentcore_execution.name
+  policy_arn = aws_iam_policy.agentcore_xray.arn
+}
+
+# Allow CloudWatch metrics under the bedrock-agentcore namespace
+data "aws_iam_policy_document" "agentcore_metrics" {
+  statement {
+    sid     = "CloudWatchMetrics"
+    effect  = "Allow"
+    actions = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "cloudwatch:namespace"
+      values   = ["bedrock-agentcore"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "agentcore_metrics" {
+  name        = "${var.agentcore_runtime_name}-cloudwatch-metrics"
+  description = "Allow AgentCore runtime to publish metrics to CloudWatch"
+  policy      = data.aws_iam_policy_document.agentcore_metrics.json
+}
+
+resource "aws_iam_role_policy_attachment" "agentcore_metrics" {
+  role       = aws_iam_role.agentcore_execution.name
+  policy_arn = aws_iam_policy.agentcore_metrics.arn
+}
+
+# Allow AgentCore workload identity access tokens
+data "aws_iam_policy_document" "agentcore_workload_identity" {
+  statement {
+    sid    = "GetAgentAccessToken"
+    effect = "Allow"
+    actions = [
+      "bedrock-agentcore:GetWorkloadAccessToken",
+      "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+      "bedrock-agentcore:GetWorkloadAccessTokenForUserId",
+    ]
+    resources = [
+      "arn:aws:bedrock-agentcore:${local.region}:${local.account_id}:workload-identity-directory/default",
+      "arn:aws:bedrock-agentcore:${local.region}:${local.account_id}:workload-identity-directory/default/workload-identity/${var.agentcore_runtime_name}-*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "agentcore_workload_identity" {
+  name        = "${var.agentcore_runtime_name}-workload-identity"
+  description = "Allow AgentCore runtime to obtain workload access tokens"
+  policy      = data.aws_iam_policy_document.agentcore_workload_identity.json
+}
+
+resource "aws_iam_role_policy_attachment" "agentcore_workload_identity" {
+  role       = aws_iam_role.agentcore_execution.name
+  policy_arn = aws_iam_policy.agentcore_workload_identity.arn
+}
+
+# Allow Bedrock model invocation
+data "aws_iam_policy_document" "agentcore_bedrock" {
+  statement {
+    sid    = "BedrockModelInvocation"
+    effect = "Allow"
+    actions = [
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream",
+    ]
+    resources = [
+      "arn:aws:bedrock:*::foundation-model/*",
+      "arn:aws:bedrock:${local.region}:${local.account_id}:*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "agentcore_bedrock" {
+  name        = "${var.agentcore_runtime_name}-bedrock-invoke"
+  description = "Allow AgentCore runtime to invoke Bedrock foundation models"
+  policy      = data.aws_iam_policy_document.agentcore_bedrock.json
+}
+
+resource "aws_iam_role_policy_attachment" "agentcore_bedrock" {
+  role       = aws_iam_role.agentcore_execution.name
+  policy_arn = aws_iam_policy.agentcore_bedrock.arn
 }

--- a/deploy/aws/terraform/iam.tf
+++ b/deploy/aws/terraform/iam.tf
@@ -1,0 +1,89 @@
+# ---------------------------------------------------------------------------
+# IAM – Execution role for the AgentCore MCP runtime
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "agentcore_trust" {
+  statement {
+    sid     = "AgentCoreTrust"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["bedrock-agentcore.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [local.account_id]
+    }
+  }
+}
+
+resource "aws_iam_role" "agentcore_execution" {
+  name               = "${var.agentcore_runtime_name}-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.agentcore_trust.json
+  description        = "Execution role for the ${var.agentcore_runtime_name} AgentCore MCP runtime"
+}
+
+# Allow the runtime to pull from ECR
+data "aws_iam_policy_document" "agentcore_ecr" {
+  statement {
+    sid    = "ECRGetAuthToken"
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ECRPullImage"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchCheckLayerAvailability",
+    ]
+    resources = [aws_ecr_repository.mcp_server.arn]
+  }
+}
+
+resource "aws_iam_policy" "agentcore_ecr" {
+  name        = "${var.agentcore_runtime_name}-ecr-pull"
+  description = "Allow AgentCore execution role to pull from ECR"
+  policy      = data.aws_iam_policy_document.agentcore_ecr.json
+}
+
+resource "aws_iam_role_policy_attachment" "agentcore_ecr" {
+  role       = aws_iam_role.agentcore_execution.name
+  policy_arn = aws_iam_policy.agentcore_ecr.arn
+}
+
+# Allow runtime logs to be written to CloudWatch
+data "aws_iam_policy_document" "agentcore_logs" {
+  statement {
+    sid    = "CloudWatchLogs"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = [
+      "arn:aws:logs:${local.region}:${local.account_id}:log-group:/aws/bedrock-agentcore/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "agentcore_logs" {
+  name        = "${var.agentcore_runtime_name}-cloudwatch-logs"
+  description = "Allow AgentCore runtime to write CloudWatch logs"
+  policy      = data.aws_iam_policy_document.agentcore_logs.json
+}
+
+resource "aws_iam_role_policy_attachment" "agentcore_logs" {
+  role       = aws_iam_role.agentcore_execution.name
+  policy_arn = aws_iam_policy.agentcore_logs.arn
+}

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -15,7 +15,7 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  profile = "anuj-ps"
+  profile = "<PROFILE_NAME>" # Replace with your AWS CLI profile name if needed
 
   default_tags {
     tags = var.tags

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -15,7 +15,7 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  profile = "<PROFILE_NAME>" # Replace with your AWS CLI profile name if needed
+  profile = "anuj-ps" # Replace with your AWS CLI profile name if needed
 
   default_tags {
     tags = var.tags

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -15,7 +15,7 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
-  profile = "anuj-ps" # Replace with your AWS CLI profile name if needed
+  profile = "<PROFILE_NAME>" # Replace with your AWS CLI profile name if needed
 
   default_tags {
     tags = var.tags

--- a/deploy/aws/terraform/main.tf
+++ b/deploy/aws/terraform/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.50.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  profile = "anuj-ps"
+
+  default_tags {
+    tags = var.tags
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  account_id    = data.aws_caller_identity.current.account_id
+  region        = data.aws_region.current.id
+  ecr_image_uri = "${local.account_id}.dkr.ecr.${local.region}.amazonaws.com/${var.ecr_repository_name}:${var.image_tag}"
+}

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -23,6 +23,11 @@ output "agentcore_runtime_arn" {
   value       = aws_bedrockagentcore_agent_runtime.mcp.agent_runtime_arn
 }
 
+output "agentcore_log_group" {
+  description = "CloudWatch log group for AgentCore runtime invocation logs"
+  value       = aws_cloudwatch_log_group.agentcore_invocations.name
+}
+
 output "agentcore_invocation_url" {
   description = "URL for invoking the AgentCore runtime"
   value       = "https://bedrock-agentcore.${local.region}.amazonaws.com/runtimes/${urlencode(aws_bedrockagentcore_agent_runtime.mcp.agent_runtime_arn)}/invocations?qualifier=DEFAULT"

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -1,0 +1,66 @@
+output "ecr_repository_url" {
+  description = "ECR repository URL"
+  value       = aws_ecr_repository.mcp_server.repository_url
+}
+
+output "ecr_image_uri" {
+  description = "Full ECR image URI that was built and pushed"
+  value       = local.ecr_image_uri
+}
+
+output "agentcore_execution_role_arn" {
+  description = "IAM execution role ARN used by the AgentCore runtime"
+  value       = aws_iam_role.agentcore_execution.arn
+}
+
+output "agentcore_runtime_id" {
+  description = "Bedrock AgentCore runtime ID"
+  value       = aws_bedrockagentcore_agent_runtime.mcp.agent_runtime_id
+}
+
+output "agentcore_runtime_arn" {
+  description = "Bedrock AgentCore runtime ARN"
+  value       = aws_bedrockagentcore_agent_runtime.mcp.agent_runtime_arn
+}
+
+output "agentcore_invocation_url" {
+  description = "URL for invoking the AgentCore runtime"
+  value       = "https://bedrock-agentcore.${local.region}.amazonaws.com/runtimes/${urlencode(aws_bedrockagentcore_agent_runtime.mcp.agent_runtime_arn)}/invocations?qualifier=DEFAULT"
+}
+
+output "cognito_user_pool_id" {
+  description = "Cognito user pool ID"
+  value       = aws_cognito_user_pool.mcp.id
+}
+
+output "cognito_user_pool_client_id" {
+  description = "Cognito app client ID"
+  value       = aws_cognito_user_pool_client.mcp.id
+}
+
+# output "cognito_token_endpoint" {
+#   description = "Cognito OAuth2 token endpoint"
+#   value       = local.token_endpoint
+# }
+
+# output "cognito_jwks_uri" {
+#   description = "Cognito JWKS URI (used by AgentCore to verify tokens)"
+#   value       = local.jwks_uri
+# }
+
+output "cognito_test_username" {
+  description = "Cognito test user username (email)"
+  value       = var.cognito_test_user_email
+}
+
+output "get_token_command" {
+  description = "Command to generate an OAuth token for the test user"
+  value       = <<-EOT
+    python3 scripts/get_token.py \
+      --region ${local.region} \
+      --user-pool-id ${aws_cognito_user_pool.mcp.id} \
+      --client-id ${aws_cognito_user_pool_client.mcp.id} \
+      --username ${var.cognito_test_username} \
+      --password <PASSWORD>
+  EOT
+}

--- a/deploy/aws/terraform/scripts/get_token.py
+++ b/deploy/aws/terraform/scripts/get_token.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+get_token.py — Generate a Cognito OAuth2 ID token for testing the
+               MongoDB MCP Server deployed on AWS Bedrock AgentCore.
+
+Usage:
+    python3 get_token.py \
+        --region us-east-1 \
+        --user-pool-id us-east-1_XXXXXXXXX \
+        --client-id XXXXXXXXXXXXXXXXXXXXXXXXXX \
+        --username mcp-test-user \
+        --password "MySecretP@ssword1"
+
+    # Or read credentials from environment variables:
+    export COGNITO_USER_POOL_ID=us-east-1_XXXXXXXXX
+    export COGNITO_CLIENT_ID=XXXXXXXXXXXXXXXXXXXXXXXXXX
+    export COGNITO_USERNAME=mcp-test-user
+    export COGNITO_PASSWORD="MySecretP@ssword1"
+    python3 get_token.py --region us-east-1
+
+The script handles the NEW_PASSWORD_REQUIRED challenge that Cognito raises on
+first sign-in when a temporary password was set via Terraform/the AWS console.
+In that case, pass --new-password to set a permanent password in one step.
+
+Output (JSON):
+    {
+      "access_token": "...",
+      "id_token": "...",
+      "refresh_token": "...",
+      "expires_in": 3600,
+      "token_type": "Bearer"
+    }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+except ImportError:
+    print("ERROR: boto3 is required. Install it with:  pip install boto3", file=sys.stderr)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+def initiate_auth(cognito: "boto3.client", client_id: str, username: str, password: str) -> dict:
+    """Start USER_PASSWORD_AUTH flow and return the raw Cognito response."""
+    return cognito.initiate_auth(
+        AuthFlow="USER_PASSWORD_AUTH",
+        AuthParameters={
+            "USERNAME": username,
+            "PASSWORD": password,
+        },
+        ClientId=client_id,
+    )
+
+
+def respond_to_new_password_challenge(
+    cognito: "boto3.client",
+    client_id: str,
+    username: str,
+    session: str,
+    new_password: str,
+) -> dict:
+    """Satisfy the NEW_PASSWORD_REQUIRED challenge."""
+    return cognito.respond_to_auth_challenge(
+        ChallengeName="NEW_PASSWORD_REQUIRED",
+        ClientId=client_id,
+        Session=session,
+        ChallengeResponses={
+            "USERNAME": username,
+            "NEW_PASSWORD": new_password,
+        },
+    )
+
+
+def get_tokens(
+    region: str,
+    user_pool_id: str,
+    client_id: str,
+    username: str,
+    password: str,
+    new_password: str | None = None,
+) -> dict:
+    """
+    Authenticate against Cognito and return access / id / refresh tokens.
+
+    Handles the NEW_PASSWORD_REQUIRED challenge automatically when
+    `new_password` is provided; raises RuntimeError otherwise.
+    """
+    cognito = boto3.client("cognito-idp", region_name=region)
+
+    try:
+        resp = initiate_auth(cognito, client_id, username, password)
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        msg  = exc.response["Error"]["Message"]
+        raise RuntimeError(f"Cognito auth failed [{code}]: {msg}") from exc
+
+    # ---- Handle challenges ----
+    challenge = resp.get("ChallengeName")
+
+    if challenge == "NEW_PASSWORD_REQUIRED":
+        if not new_password:
+            raise RuntimeError(
+                "Cognito requires a new password (NEW_PASSWORD_REQUIRED challenge). "
+                "Re-run with --new-password <permanent-password>."
+            )
+        try:
+            resp = respond_to_new_password_challenge(
+                cognito, client_id, username, resp["Session"], new_password
+            )
+        except ClientError as exc:
+            code = exc.response["Error"]["Code"]
+            msg  = exc.response["Error"]["Message"]
+            raise RuntimeError(f"Failed to set new password [{code}]: {msg}") from exc
+
+    elif challenge is not None:
+        raise RuntimeError(
+            f"Unhandled Cognito challenge: {challenge}. "
+            "Complete this challenge manually in the AWS console before retrying."
+        )
+
+    auth_result = resp.get("AuthenticationResult", {})
+    if not auth_result:
+        raise RuntimeError(f"No AuthenticationResult in Cognito response: {resp}")
+
+    return {
+        "access_token":  auth_result["AccessToken"],
+        "id_token":      auth_result["IdToken"],
+        "refresh_token": auth_result.get("RefreshToken", ""),
+        "expires_in":    auth_result["ExpiresIn"],
+        "token_type":    auth_result["TokenType"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Convenience: decode and print token claims (without verification)
+# ---------------------------------------------------------------------------
+
+def _decode_jwt_payload(token: str) -> dict:
+    """Base64-decode the JWT payload (no signature verification)."""
+    import base64
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1]
+    # Pad to a multiple of 4
+    payload += "=" * (-len(payload) % 4)
+    try:
+        return json.loads(base64.urlsafe_b64decode(payload))
+    except Exception:
+        return {}
+
+
+def print_token_info(tokens: dict) -> None:
+    claims = _decode_jwt_payload(tokens["id_token"])
+    print("\n--- Token claims (id_token) ---", file=sys.stderr)
+    for key in ("sub", "email", "cognito:username", "exp", "iat", "iss", "aud"):
+        if key in claims:
+            import datetime
+            val = claims[key]
+            if key in ("exp", "iat"):
+                val = f"{val}  ({datetime.datetime.utcfromtimestamp(val).isoformat()}Z)"
+            print(f"  {key}: {val}", file=sys.stderr)
+    print(
+        f"\nToken expires in {tokens['expires_in']}s "
+        f"(type: {tokens['token_type']})\n",
+        file=sys.stderr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Example: invoke AgentCore runtime with the token
+# ---------------------------------------------------------------------------
+
+def invoke_agentcore(
+    region: str,
+    runtime_arn: str,
+    id_token: str,
+    payload: dict | None = None,
+) -> None:
+    """
+    Example helper: call the AgentCore MCP runtime with the obtained token.
+
+    Requires: pip install requests
+    """
+    try:
+        import urllib.parse
+        import urllib.request
+    except ImportError:
+        print("urllib not available", file=sys.stderr)
+        return
+
+    encoded_arn = urllib.parse.quote(runtime_arn, safe="")
+    url = (
+        f"https://bedrock-agentcore.{region}.amazonaws.com"
+        f"/runtimes/{encoded_arn}/invocations?qualifier=DEFAULT"
+    )
+    body = json.dumps(payload or {"jsonrpc": "2.0", "method": "tools/list", "id": 1}).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {id_token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    print(f"\n--- AgentCore invocation: {url} ---", file=sys.stderr)
+    try:
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            result = json.loads(resp.read())
+            print(json.dumps(result, indent=2))
+    except urllib.error.HTTPError as exc:
+        print(f"HTTP {exc.code}: {exc.read().decode()}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Generate a Cognito OAuth2 token for the MongoDB MCP Server on AgentCore.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument("--region",        default=os.getenv("AWS_REGION", "us-east-1"),            help="AWS region (default: us-east-1 or $AWS_REGION)")
+    p.add_argument("--user-pool-id",  default=os.getenv("COGNITO_USER_POOL_ID", ""),           help="Cognito user pool ID ($COGNITO_USER_POOL_ID)")
+    p.add_argument("--client-id",     default=os.getenv("COGNITO_CLIENT_ID", ""),              help="Cognito app client ID ($COGNITO_CLIENT_ID)")
+    p.add_argument("--username",      default=os.getenv("COGNITO_USERNAME", ""),               help="Cognito username ($COGNITO_USERNAME)")
+    p.add_argument("--password",      default=os.getenv("COGNITO_PASSWORD", ""),               help="Cognito password ($COGNITO_PASSWORD)")
+    p.add_argument("--new-password",  default=os.getenv("COGNITO_NEW_PASSWORD", ""),           help="Permanent password to set when NEW_PASSWORD_REQUIRED is raised")
+    p.add_argument("--runtime-arn",   default=os.getenv("AGENTCORE_RUNTIME_ARN", ""),          help="(Optional) AgentCore runtime ARN – triggers a tools/list invocation to smoke-test the token")
+    p.add_argument("--output",        choices=["json", "id_token", "access_token"],            default="json", help="Output format (default: json)")
+    p.add_argument("--verbose", "-v", action="store_true",                                     help="Print decoded token claims to stderr")
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+
+    # Validate required arguments
+    missing = [f for f, v in [
+        ("--user-pool-id", args.user_pool_id),
+        ("--client-id",    args.client_id),
+        ("--username",     args.username),
+        ("--password",     args.password),
+    ] if not v]
+    if missing:
+        print(f"ERROR: missing required arguments: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        tokens = get_tokens(
+            region       = args.region,
+            user_pool_id = args.user_pool_id,
+            client_id    = args.client_id,
+            username     = args.username,
+            password     = args.password,
+            new_password = args.new_password or None,
+        )
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.verbose:
+        print_token_info(tokens)
+
+    # Output
+    if args.output == "json":
+        print(json.dumps(tokens, indent=2))
+    elif args.output == "id_token":
+        print(tokens["id_token"])
+    elif args.output == "access_token":
+        print(tokens["access_token"])
+
+    # Optional smoke-test invocation
+    if args.runtime_arn:
+        invoke_agentcore(args.region, args.runtime_arn, tokens["id_token"])
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/aws/terraform/terraform.tfvars
+++ b/deploy/aws/terraform/terraform.tfvars
@@ -1,0 +1,6 @@
+aws_region                 = "us-east-1"
+cognito_test_user_email    = ""
+cognito_test_user_password = ""
+mdb_connection_string      = ""
+# If you are logging in to your AWS account using SSO
+aws_profile                = ""

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -1,0 +1,89 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI profile to use for ECR authentication"
+  type        = string
+  default     = "default"
+}
+
+variable "ecr_repository_name" {
+  description = "Name of the ECR repository"
+  type        = string
+  default     = "mongodb_mcp_server_terraform"
+}
+
+variable "image_tag" {
+  description = "Docker image tag to build and push"
+  type        = string
+  default     = "latest"
+}
+
+variable "agentcore_runtime_name" {
+  description = "Name of the Bedrock AgentCore MCP runtime"
+  type        = string
+  default     = "mongodb_mcp_server_runtime"
+}
+
+variable "cognito_user_pool_name" {
+  description = "Name of the Cognito user pool for AgentCore authentication"
+  type        = string
+  default     = "mongodb-mcp-server-pool-terraform"
+}
+
+variable "cognito_test_username" {
+  description = "Username for the Cognito test user"
+  type        = string
+  default     = "mcp-test-user"
+}
+
+variable "cognito_test_user_email" {
+  description = "Email for the Cognito test user"
+  type        = string
+}
+
+variable "cognito_test_user_password" {
+  description = "Temporary password for the Cognito test user (must meet Cognito password policy)"
+  type        = string
+  sensitive   = true
+}
+
+# MongoDB / Atlas credentials passed to the MCP server at runtime
+variable "mdb_connection_string" {
+  description = "MongoDB connection string (mongodb:// format; mongodb+srv:// is not supported by AgentCore)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "mdb_api_client_id" {
+  description = "MongoDB Atlas API client ID (optional, only if Atlas tools are enabled)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "mdb_api_client_secret" {
+  description = "MongoDB Atlas API client secret (optional, only if Atlas tools are enabled)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "dockerfile_context_path" {
+  description = "Path to the directory containing the Dockerfile (relative to where terraform is run)"
+  type        = string
+  default     = ".."
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources"
+  type        = map(string)
+  default = {
+    Project     = "mongodb-mcp-server"
+    ManagedBy   = "terraform"
+  }
+}

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -56,7 +56,6 @@ variable "mdb_connection_string" {
   description = "MongoDB connection string (mongodb:// format; mongodb+srv:// is not supported by AgentCore)"
   type        = string
   sensitive   = true
-  default     = ""
 }
 
 variable "mdb_api_client_id" {


### PR DESCRIPTION
## Proposed changes
- Includes the terraform script required to deploy the MCP server on AWS Bedrock Agentcore Runtime.
- Added some files that need to be ignored in .gitignore

## Checklist

- I have signed the MongoDB Contributor agreement
[MongoDB Contributor Agreement.pdf](https://github.com/user-attachments/files/26933114/MongoDB.Contributor.Agreement.pdf)

