### PR TITLE
chore: skip pre-commit during release, consider release commit as a bump

### DIFF
--- a/.github/workflows/bump-auxiliary-packages.yml
+++ b/.github/workflows/bump-auxiliary-packages.yml
@@ -45,6 +45,8 @@ jobs:
         if: steps.bump.outputs.HAS_CHANGES == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # 8.1.1
         id: create-pr
+        env:
+          HUSKY: 0
         with:
           title: "chore: bump auxiliary packages"
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -31,9 +31,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
       - name: Install dependencies
-        run: |
-          sudo apt-get install -y git-secrets
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: Bump versions
         id: bump-version
         run: |
@@ -120,10 +118,12 @@ jobs:
       - name: Create release PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # 8.1.1
         id: create-pr
+        env:
+          HUSKY: 0
         with:
-          title: "chore: release ${{ steps.bump-version.outputs.NEW_VERSION }}"
+          title: "chore: release mongodb-mcp-server ${{ steps.bump-version.outputs.NEW_VERSION }}"
           token: ${{ steps.app-token.outputs.token }}
-          commit-message: "chore: release ${{ steps.bump-version.outputs.NEW_VERSION }}"
+          commit-message: "chore: release mongodb-mcp-server ${{ steps.bump-version.outputs.NEW_VERSION }}"
           body: |
             This PR bumps the package version to ${{ steps.bump-version.outputs.NEW_VERSION }}.
             Once merged, the new version will be published to npm.

--- a/scripts/bumpPackages.ts
+++ b/scripts/bumpPackages.ts
@@ -137,8 +137,6 @@ function getPackages({ filters, overrideNames }: { filters: string[]; overrideNa
 
 function getLastVersionCommit(): string | undefined {
     try {
-        // Find the most recent commit that matches either bump or release pattern
-        // Using git log with multiple --grep patterns (OR logic when combined with --all-match disabled)
         const sha = execSync(
             `git log --first-parent --format=%H --grep="${BUMP_COMMIT_PREFIX}" --grep="${RELEASE_COMMIT_PREFIX}" -1`,
             {

--- a/scripts/bumpPackages.ts
+++ b/scripts/bumpPackages.ts
@@ -19,6 +19,7 @@ import type { ReleaseType } from "semver";
 import { z } from "zod";
 
 export const BUMP_COMMIT_PREFIX = "chore: bump auxiliary packages";
+export const RELEASE_COMMIT_PREFIX = "chore: release mongodb-mcp-server";
 const ROOT = join(import.meta.dirname, "..");
 
 const BUMP_ORDER: Record<string, number> = { major: 3, minor: 2, patch: 1 };
@@ -134,13 +135,56 @@ function getPackages({ filters, overrideNames }: { filters: string[]; overrideNa
     return all.filter((pkg) => filters.includes(pkg.name) || (filters.includes(".") && pkg.isRoot));
 }
 
-function getLastBumpCommit(): string | undefined {
+function getLastVersionCommit(): string | undefined {
     try {
-        const sha = execSync(`git log --all --grep="${BUMP_COMMIT_PREFIX}" --format=%H -1`, {
+        // Look for both bump and release commits, return the most recent one
+        const bumpSha = execSync(`git log --all --grep="${BUMP_COMMIT_PREFIX}" --format=%H -1`, {
             cwd: ROOT,
             encoding: "utf-8",
         }).trim();
-        return sha || undefined;
+
+        const releaseSha = execSync(`git log --all --grep="${RELEASE_COMMIT_PREFIX}" --format=%H -1`, {
+            cwd: ROOT,
+            encoding: "utf-8",
+        }).trim();
+
+        if (!bumpSha && !releaseSha) {
+            return undefined;
+        }
+
+        if (!bumpSha) {
+            return releaseSha;
+        }
+
+        if (!releaseSha) {
+            return bumpSha;
+        }
+
+        // Both exist, find which is more recent by checking if bump is ancestor of release
+        try {
+            execSync(`git merge-base --is-ancestor ${bumpSha} ${releaseSha}`, { cwd: ROOT });
+            // If bump is ancestor of release, release is newer
+            return releaseSha;
+        } catch {
+            // bump is not ancestor of release, so bump is newer or they're on different branches
+            // Check the reverse
+            try {
+                execSync(`git merge-base --is-ancestor ${releaseSha} ${bumpSha}`, { cwd: ROOT });
+                // If release is ancestor of bump, bump is newer
+                return bumpSha;
+            } catch {
+                // Not ancestor either way, fall back to commit date comparison
+                const bumpDate = parseInt(
+                    execSync(`git log -1 --format=%ct ${bumpSha}`, { cwd: ROOT, encoding: "utf-8" }).trim(),
+                    10
+                );
+                const releaseDate = parseInt(
+                    execSync(`git log -1 --format=%ct ${releaseSha}`, { cwd: ROOT, encoding: "utf-8" }).trim(),
+                    10
+                );
+                return bumpDate >= releaseDate ? bumpSha : releaseSha;
+            }
+        }
     } catch {
         return undefined;
     }
@@ -247,11 +291,11 @@ function main(): BumpResult[] {
         return [];
     }
 
-    const lastBumpSha = getLastBumpCommit();
-    if (lastBumpSha) {
-        console.log(`Last bump commit: ${lastBumpSha}`);
+    const lastVersionCommitSha = getLastVersionCommit();
+    if (lastVersionCommitSha) {
+        console.log(`Last version commit: ${lastVersionCommitSha}`);
     } else {
-        console.log("No previous bump commit found, scanning all history");
+        console.log("No previous version commit found, scanning all history");
     }
 
     const results: BumpResult[] = [];
@@ -261,7 +305,7 @@ function main(): BumpResult[] {
         const override = overrideMap.get(pkg.name);
         const result = override
             ? resolveExplicitVersion({ pkg, version: override })
-            : resolveConventionalVersion({ pkg, since: lastBumpSha });
+            : resolveConventionalVersion({ pkg, since: lastVersionCommitSha });
 
         if (!result) {
             if (override) {

--- a/scripts/bumpPackages.ts
+++ b/scripts/bumpPackages.ts
@@ -140,7 +140,7 @@ function getLastVersionCommit(): string | undefined {
         // Find the most recent commit that matches either bump or release pattern
         // Using git log with multiple --grep patterns (OR logic when combined with --all-match disabled)
         const sha = execSync(
-            `git log --all --format=%H --grep="${BUMP_COMMIT_PREFIX}" --grep="${RELEASE_COMMIT_PREFIX}" -1`,
+            `git log --first-parent --format=%H --grep="${BUMP_COMMIT_PREFIX}" --grep="${RELEASE_COMMIT_PREFIX}" -1`,
             {
                 cwd: ROOT,
                 encoding: "utf-8",

--- a/scripts/bumpPackages.ts
+++ b/scripts/bumpPackages.ts
@@ -137,54 +137,16 @@ function getPackages({ filters, overrideNames }: { filters: string[]; overrideNa
 
 function getLastVersionCommit(): string | undefined {
     try {
-        // Look for both bump and release commits, return the most recent one
-        const bumpSha = execSync(`git log --all --grep="${BUMP_COMMIT_PREFIX}" --format=%H -1`, {
-            cwd: ROOT,
-            encoding: "utf-8",
-        }).trim();
-
-        const releaseSha = execSync(`git log --all --grep="${RELEASE_COMMIT_PREFIX}" --format=%H -1`, {
-            cwd: ROOT,
-            encoding: "utf-8",
-        }).trim();
-
-        if (!bumpSha && !releaseSha) {
-            return undefined;
-        }
-
-        if (!bumpSha) {
-            return releaseSha;
-        }
-
-        if (!releaseSha) {
-            return bumpSha;
-        }
-
-        // Both exist, find which is more recent by checking if bump is ancestor of release
-        try {
-            execSync(`git merge-base --is-ancestor ${bumpSha} ${releaseSha}`, { cwd: ROOT });
-            // If bump is ancestor of release, release is newer
-            return releaseSha;
-        } catch {
-            // bump is not ancestor of release, so bump is newer or they're on different branches
-            // Check the reverse
-            try {
-                execSync(`git merge-base --is-ancestor ${releaseSha} ${bumpSha}`, { cwd: ROOT });
-                // If release is ancestor of bump, bump is newer
-                return bumpSha;
-            } catch {
-                // Not ancestor either way, fall back to commit date comparison
-                const bumpDate = parseInt(
-                    execSync(`git log -1 --format=%ct ${bumpSha}`, { cwd: ROOT, encoding: "utf-8" }).trim(),
-                    10
-                );
-                const releaseDate = parseInt(
-                    execSync(`git log -1 --format=%ct ${releaseSha}`, { cwd: ROOT, encoding: "utf-8" }).trim(),
-                    10
-                );
-                return bumpDate >= releaseDate ? bumpSha : releaseSha;
+        // Find the most recent commit that matches either bump or release pattern
+        // Using git log with multiple --grep patterns (OR logic when combined with --all-match disabled)
+        const sha = execSync(
+            `git log --all --format=%H --grep="${BUMP_COMMIT_PREFIX}" --grep="${RELEASE_COMMIT_PREFIX}" -1`,
+            {
+                cwd: ROOT,
+                encoding: "utf-8",
             }
-        }
+        ).trim();
+        return sha || undefined;
     } catch {
         return undefined;
     }


### PR DESCRIPTION
I don't really see a reason to use git-secrets during PR bump, it's a very controlled environment.

Also, we should look into last release when figuring out the needed bumps.
