### PR TITLE
fix: sanitize workflow inputs VULN-995 VULN-996

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,8 +34,10 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Bump versions
         id: bump-version
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
         run: |
-          pnpm run bump -- --override mongodb-mcp-server:${{ inputs.version }}
+          pnpm run bump -- --override "mongodb-mcp-server:$INPUTS_VERSION"
           NEW_VERSION=$(npm pkg get version | tr -d '"')
           echo "NEW_VERSION=v${NEW_VERSION}" >> $GITHUB_OUTPUT
 
@@ -88,7 +90,7 @@ jobs:
 
           urlencode() { echo -n "$1" | jq -sRr @uri; }
 
-          ALL_JQL="project = ${PROJECT_KEY} AND fixVersion = vNext"
+          ALL_JQL="project = ${PROJECT_KEY} AND fixVersion = ${vnext_id}"
           RESOLVED_JQL="${ALL_JQL} AND resolution != Unresolved"
           UNRESOLVED_JQL="${ALL_JQL} AND resolution = Unresolved"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
         id: ai-summary
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
         run: ./scripts/generate-release-notes.sh ${{ needs.check.outputs.GIT_TAG_VERSION }} ${{ github.sha }}
         shell: bash
 


### PR DESCRIPTION
## Proposed changes

Sanitizes the input for the release workflow. Additionally, drive-by fixes the jira query to use the version id rather than the name.