### PR TITLE
fix: preserve optional logger for search support probe

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -358,7 +358,7 @@ export class ConnectionStateConnected implements ConnectionState {
     // (undocumented)
     connectionStringInfo?: ConnectionStringInfo | undefined;
     // (undocumented)
-    isSearchSupported(logger: LoggerBase): Promise<boolean>;
+    isSearchSupported(logger?: LoggerBase): Promise<boolean>;
     // (undocumented)
     serviceProvider: NodeDriverServiceProvider;
     // (undocumented)

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -382,7 +382,7 @@ export class ConnectionStateConnected implements ConnectionState {
     // (undocumented)
     connectionStringInfo?: ConnectionStringInfo | undefined;
     // (undocumented)
-    isSearchSupported(logger: LoggerBase): Promise<boolean>;
+    isSearchSupported(logger?: LoggerBase): Promise<boolean>;
     // (undocumented)
     serviceProvider: NodeDriverServiceProvider;
     // (undocumented)

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -5,7 +5,7 @@ import { generateConnectionInfoFromCliArgs, type ConnectionInfo } from "@mongosh
 import type { DeviceId } from "../helpers/deviceId.js";
 import { type UserConfig } from "./config/userConfig.js";
 import { MongoDBError, ErrorCodes } from "./errors.js";
-import { type LoggerBase, LogId } from "./logging/index.js";
+import { LogId, NullLogger, type LoggerBase } from "./logging/index.js";
 import { packageInfo } from "./packageInfo.js";
 import { type AppNameComponents, setAppNameParamIfMissing } from "../helpers/connectionOptions.js";
 import {
@@ -59,9 +59,9 @@ export class ConnectionStateConnected implements ConnectionState {
 
     private _isSearchSupported?: boolean;
 
-    public async isSearchSupported(logger: LoggerBase): Promise<boolean> {
+    public async isSearchSupported(logger?: LoggerBase): Promise<boolean> {
         if (this._isSearchSupported === undefined) {
-            this._isSearchSupported = await this.probeSearchCapability(logger);
+            this._isSearchSupported = await this.probeSearchCapability(logger ?? new NullLogger());
         }
 
         return this._isSearchSupported;

--- a/tests/unit/common/session.test.ts
+++ b/tests/unit/common/session.test.ts
@@ -4,7 +4,7 @@ import { MongoServerError } from "mongodb";
 import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import { Session } from "../../../src/common/session.js";
 import { CompositeLogger } from "../../../src/common/logging/index.js";
-import { MCPConnectionManager } from "../../../src/common/connectionManager.js";
+import { type ConnectionStateConnected, MCPConnectionManager } from "../../../src/common/connectionManager.js";
 import { ExportsManager } from "../../../src/common/exportsManager.js";
 import { DeviceId } from "../../../src/helpers/deviceId.js";
 import { Keychain } from "../../../src/common/keychain.js";
@@ -192,6 +192,17 @@ describe("Session", () => {
             expect(await session.isSearchSupported()).toEqual(true);
             expect(await session.isSearchSupported()).toEqual(true);
             expect(getSearchIndexesMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("should allow direct search support checks without a logger", async () => {
+            getSearchIndexesMock.mockResolvedValue([]);
+
+            await session.connectToMongoDB({
+                connectionString: "mongodb://localhost:27017",
+            });
+
+            const connectionState = session.connectionManager.currentConnectionState as ConnectionStateConnected;
+            expect(await connectionState.isSearchSupported()).toEqual(true);
         });
     });
 


### PR DESCRIPTION
## Background

PR #1095 adds debug logging to the Atlas Search capability probe. That changes `ConnectionStateConnected.isSearchSupported()` from a no-argument public method to requiring a `LoggerBase`, which can break direct consumers even though the normal `Session` path passes a logger.

## What Changed

- Made the `logger` parameter optional for `ConnectionStateConnected.isSearchSupported()`.
- Fall back to the existing `NullLogger` when the method is called directly without a logger.
- Updated the public API reports to show the optional parameter.
- Added a unit test covering direct no-argument calls.

## Not Changed

- The search capability probe behavior is unchanged.
- The database candidate order and bounded candidate list from #1095 are unchanged.
- The integration test harness changes from #1095 are unchanged.

## Risk

Low. Existing internal calls still pass the session logger. Direct calls without a logger keep working and simply use no-op logging during the first probe.

## Validation

- `pnpm exec vitest --project unit-and-integration tests/unit/common/session.test.ts --run`
- `pnpm run check:types`
- `pnpm run check:api`
- `pnpm run check:format`
- `pnpm run check:lint`
- `pnpm run check:dependencies`
- `pnpm run check`

## Linked Issues

Supports #1095 / #1022.