### PR TITLE
ci(label-pr): run labeler with target context

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,10 +1,11 @@
 name: Label PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 permissions:
+  contents: read
   pull-requests: write
   issues: write
 
@@ -14,13 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
       - name: Apply label based on conventional commit prefix
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |


### PR DESCRIPTION
## Background

Fork PRs can trigger the current `Label PR` workflow with a read-only `GITHUB_TOKEN`. The label step then fails while calling `gh pr edit --add-label`, for example in #1097 with `GraphQL: Resource not accessible by integration (addLabelsToLabelable)`.

## What Changed

- Run the label workflow on `pull_request_target` so it executes in the base repository context and can update PR labels for fork PRs.
- Keep explicit least-privilege permissions, adding `contents: read` alongside the existing label-related write scopes.
- Remove the checkout step because this workflow only reads PR metadata and edits labels.
- Set `GH_REPO` explicitly so `gh pr view/edit` works without a checked-out repository.

## Not Changed

- The conventional commit prefix to label mapping is unchanged.
- No project code, tests, dependencies, or build configuration are changed.

## Risk

Low for this workflow because it does not checkout or execute pull request code. It only reads the PR title/number from the event payload and uses `gh` to update labels.

## Validation

- Parsed `.github/workflows/label-pr.yml` with the repository `yaml` package.
- `pnpm exec prettier -c .github/workflows/label-pr.yml`
- `git diff --check`

## Linked Issues

Unblocks fork PR labeling failures such as #1097.