### PR TITLE
chore: fix flakey Atlas Local tests

### DIFF
--- a/.github/workflows/code-health-fork.yml
+++ b/.github/workflows/code-health-fork.yml
@@ -54,5 +54,10 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Pre-pull Atlas Local images
+        run: |
+          docker pull mongodb/mongodb-atlas-local:preview &
+          docker pull mongodb/mongodb-atlas-local:latest &
+          wait
       - name: Run tests
         run: pnpm test -- tests/integration/tools/atlas-local/

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -95,6 +95,11 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Pre-pull Atlas Local images
+        run: |
+          docker pull mongodb/mongodb-atlas-local:preview &
+          docker pull mongodb/mongodb-atlas-local:latest &
+          wait
       - name: Run tests
         run: pnpm test tests/integration/tools/atlas-local/
       - name: Upload test results

--- a/tests/integration/tools/atlas-local/atlasLocalHelpers.ts
+++ b/tests/integration/tools/atlas-local/atlasLocalHelpers.ts
@@ -1,8 +1,31 @@
 import { defaultTestConfig, setupIntegrationTest, type IntegrationTest } from "../../helpers.js";
 import type { UserConfig } from "../../../../src/common/config/userConfig.js";
 import { describe } from "vitest";
+import type { Client } from "@modelcontextprotocol/sdk/client";
 
 const isMacOSInGitHubActions = process.platform === "darwin" && process.env.GITHUB_ACTIONS === "true";
+
+// Atlas Local create-deployment can take longer than the MCP SDK's default 60s
+// request timeout when the docker image has to be pulled from a cold cache.
+const ATLAS_LOCAL_CALL_TIMEOUT_MS = 180_000;
+
+/**
+ * Helper function to create an Atlas Local deployment via the MCP SDK client. The creation may take a while
+ * if the required Docker image is not already cached, so a longer timeout is used to avoid test failures in that case.
+ */
+export function createAtlasLocalDeployment(
+    integration: IntegrationTest,
+    args: { deploymentName?: string; imageTag?: string } = {}
+): ReturnType<Client["callTool"]> {
+    return integration.mcpClient().callTool(
+        {
+            name: "atlas-local-create-deployment",
+            arguments: args,
+        },
+        undefined,
+        { timeout: ATLAS_LOCAL_CALL_TIMEOUT_MS }
+    );
+}
 
 export type IntegrationTestFunction = (integration: IntegrationTest) => void;
 

--- a/tests/integration/tools/atlas-local/connectDeployment.test.ts
+++ b/tests/integration/tools/atlas-local/connectDeployment.test.ts
@@ -1,6 +1,10 @@
 import { expect, it, beforeAll, afterAll } from "vitest";
 import { expectDefined, getResponseElements, validateToolMetadata } from "../../helpers.js";
-import { describeWithAtlasLocal, describeWithAtlasLocalDisabled } from "./atlasLocalHelpers.js";
+import {
+    createAtlasLocalDeployment,
+    describeWithAtlasLocal,
+    describeWithAtlasLocalDisabled,
+} from "./atlasLocalHelpers.js";
 
 describeWithAtlasLocal("atlas-local-connect-deployment", (integration) => {
     validateToolMetadata(
@@ -46,17 +50,11 @@ describeWithAtlasLocal("atlas-local-connect-deployment with deployments", (integ
         // Create deployments
         deploymentName = `test-deployment-1-${Date.now()}`;
         deploymentNamesToCleanup.push(deploymentName);
-        await integration.mcpClient().callTool({
-            name: "atlas-local-create-deployment",
-            arguments: { deploymentName },
-        });
+        await createAtlasLocalDeployment(integration, { deploymentName });
 
         const anotherDeploymentName = `test-deployment-2-${Date.now()}`;
         deploymentNamesToCleanup.push(anotherDeploymentName);
-        await integration.mcpClient().callTool({
-            name: "atlas-local-create-deployment",
-            arguments: { deploymentName: anotherDeploymentName },
-        });
+        await createAtlasLocalDeployment(integration, { deploymentName: anotherDeploymentName });
     });
 
     afterAll(async () => {

--- a/tests/integration/tools/atlas-local/createDeployment.test.ts
+++ b/tests/integration/tools/atlas-local/createDeployment.test.ts
@@ -1,6 +1,10 @@
 import { defaultTestConfig, expectDefined, getResponseElements } from "../../helpers.js";
 import { afterEach, expect, it } from "vitest";
-import { describeWithAtlasLocal, describeWithAtlasLocalDisabled } from "./atlasLocalHelpers.js";
+import {
+    createAtlasLocalDeployment,
+    describeWithAtlasLocal,
+    describeWithAtlasLocalDisabled,
+} from "./atlasLocalHelpers.js";
 
 // Config used for tests that require a voyageApiKey.
 const configWithVoyageApiKey = { ...defaultTestConfig, voyageApiKey: "test-voyage-api-key" };
@@ -56,10 +60,7 @@ describeWithAtlasLocal(
 
             // Create a deployment
             deploymentNamesToCleanup.push(deploymentName);
-            await integration.mcpClient().callTool({
-                name: "atlas-local-create-deployment",
-                arguments: { deploymentName },
-            });
+            await createAtlasLocalDeployment(integration, { deploymentName });
 
             // Check that deployment exists after creation
             const afterResponse = await integration.mcpClient().callTool({
@@ -76,16 +77,10 @@ describeWithAtlasLocal(
             // Create a deployment
             const deploymentName = `test-deployment-${Date.now()}`;
             deploymentNamesToCleanup.push(deploymentName);
-            await integration.mcpClient().callTool({
-                name: "atlas-local-create-deployment",
-                arguments: { deploymentName },
-            });
+            await createAtlasLocalDeployment(integration, { deploymentName });
 
             // Try to create the same deployment again
-            const response = await integration.mcpClient().callTool({
-                name: "atlas-local-create-deployment",
-                arguments: { deploymentName },
-            });
+            const response = await createAtlasLocalDeployment(integration, { deploymentName });
 
             // Check that the response is an error
             expect(response.isError).toBe(true);
@@ -99,10 +94,7 @@ describeWithAtlasLocal(
             // Create a deployment
             const deploymentName = `test-deployment-${Date.now()}`;
             deploymentNamesToCleanup.push(deploymentName);
-            const createResponse = await integration.mcpClient().callTool({
-                name: "atlas-local-create-deployment",
-                arguments: { deploymentName },
-            });
+            const createResponse = await createAtlasLocalDeployment(integration, { deploymentName });
 
             // Check the response contains the deployment name
             const createElements = getResponseElements(createResponse.content);
@@ -123,10 +115,7 @@ describeWithAtlasLocal(
 
         it("should create a deployment when name is not provided", async () => {
             // Create a deployment
-            const createResponse = await integration.mcpClient().callTool({
-                name: "atlas-local-create-deployment",
-                arguments: {},
-            });
+            const createResponse = await createAtlasLocalDeployment(integration);
 
             // Check the response contains the deployment name
             const createElements = getResponseElements(createResponse.content);
@@ -155,9 +144,9 @@ describeWithAtlasLocal(
             const deploymentName = `test-deployment-preview-${Date.now()}`;
             deploymentNamesToCleanup.push(deploymentName);
 
-            const createResponse = await integration.mcpClient().callTool({
-                name: "atlas-local-create-deployment",
-                arguments: { deploymentName, imageTag: "preview" },
+            const createResponse = await createAtlasLocalDeployment(integration, {
+                deploymentName,
+                imageTag: "preview",
             });
 
             const createElements = getResponseElements(createResponse.content);
@@ -175,9 +164,9 @@ describeWithAtlasLocal(
             deploymentNamesToCleanup.push(deploymentName);
 
             // Create a deployment
-            const createResponse = await integration.mcpClient().callTool({
-                name: "atlas-local-create-deployment",
-                arguments: { deploymentName, imageTag: "latest" },
+            const createResponse = await createAtlasLocalDeployment(integration, {
+                deploymentName,
+                imageTag: "latest",
             });
 
             // Check the response contains the deployment name

--- a/tests/integration/tools/atlas-local/deleteDeployment.test.ts
+++ b/tests/integration/tools/atlas-local/deleteDeployment.test.ts
@@ -1,6 +1,10 @@
 import { expectDefined, getResponseElements } from "../../helpers.js";
 import { expect, it } from "vitest";
-import { describeWithAtlasLocal, describeWithAtlasLocalDisabled } from "./atlasLocalHelpers.js";
+import {
+    createAtlasLocalDeployment,
+    describeWithAtlasLocal,
+    describeWithAtlasLocalDisabled,
+} from "./atlasLocalHelpers.js";
 
 describeWithAtlasLocal("atlas-local-delete-deployment", (integration) => {
     it("should have the atlas-local-delete-deployment tool", async () => {
@@ -35,10 +39,7 @@ describeWithAtlasLocal("atlas-local-delete-deployment", (integration) => {
     it("should delete a deployment when calling the tool", async () => {
         // Create a deployment
         const deploymentName = `test-deployment-${Date.now()}`;
-        await integration.mcpClient().callTool({
-            name: "atlas-local-create-deployment",
-            arguments: { deploymentName },
-        });
+        await createAtlasLocalDeployment(integration, { deploymentName });
 
         // Check that deployment exists before deletion
         const beforeResponse = await integration.mcpClient().callTool({


### PR DESCRIPTION
## Proposed changes

This change attempts to fix the flakey Atlas Local tests we're observing on CI. There are two main components:
1. Pre-pull the docker image so that the client doesn't have to download it during the test run
2. Create a helper to create the docker deployment that has increased call tool timeout