### PR TITLE
fix: fix aggregate-db schema to work with OpenAI models

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -541,6 +541,8 @@ export enum ErrorCodes {
     // (undocumented)
     ForbiddenWriteOperation = 1000003,
     // (undocumented)
+    InvalidPipeline = 1000008,
+    // (undocumented)
     MisconfiguredConnectionString = 1000001,
     // (undocumented)
     NotConnectedToMongoDB = 1000000

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -40,7 +40,7 @@ export class AggregateDBTool extends MongoDBToolBase {
     // (undocumented)
     argsShape: {
         responseBytesLimit: z.ZodDefault<z.ZodOptional<z.ZodNumber>>;
-        pipeline: z.ZodTuple<[z.ZodPipe<z.ZodRecord<z.ZodUnion<readonly [z.ZodLiteral<"$changeStream">, z.ZodLiteral<"$currentOp">, z.ZodLiteral<"$documents">, z.ZodLiteral<"$listLocalSessions">, z.ZodLiteral<"$queryStats">]>, z.ZodUnknown>, z.ZodTransform<Record<"$changeStream" | "$currentOp" | "$documents" | "$listLocalSessions" | "$queryStats", unknown>, Record<"$changeStream" | "$currentOp" | "$documents" | "$listLocalSessions" | "$queryStats", unknown>>>], z.ZodRecord<z.ZodString, z.ZodUnknown>>;
+        pipeline: z.ZodArray<z.ZodRecord<z.ZodString, z.ZodUnknown>>;
         database: z.ZodString;
     };
     // (undocumented)

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -519,6 +519,8 @@ export enum ErrorCodes {
     // (undocumented)
     ForbiddenWriteOperation = 1000003,
     // (undocumented)
+    InvalidPipeline = 1000008,
+    // (undocumented)
     MisconfiguredConnectionString = 1000001,
     // (undocumented)
     NotConnectedToMongoDB = 1000000

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -6,6 +6,7 @@ export enum ErrorCodes {
     AtlasSearchNotSupported = 1_000_004,
     AtlasVectorSearchIndexNotFound = 1_000_006,
     AtlasVectorSearchInvalidQuery = 1_000_007,
+    InvalidPipeline = 1_000_008,
 }
 
 export class MongoDBError<ErrorCode extends ErrorCodes = ErrorCodes> extends Error {

--- a/src/tools/mongodb/mongodbSchemas.ts
+++ b/src/tools/mongodb/mongodbSchemas.ts
@@ -4,16 +4,13 @@ import { toEJSON, zEJSON } from "../args.js";
 export const AnyAggregateStage = zEJSON();
 
 export const DBAggregateStage = z
-    .record(
-        z.union([
-            z.literal("$changeStream"),
-            z.literal("$currentOp"),
-            z.literal("$documents"),
-            z.literal("$listLocalSessions"),
-            z.literal("$queryStats"),
-        ]),
-        z.unknown()
-    )
+    .union([
+        z.object({ $changeStream: z.unknown() }).strict(),
+        z.object({ $currentOp: z.unknown() }).strict(),
+        z.object({ $documents: z.unknown() }).strict(),
+        z.object({ $listLocalSessions: z.unknown() }).strict(),
+        z.object({ $queryStats: z.unknown() }).strict(),
+    ])
     .transform(toEJSON);
 
 // Mirrors mongodb's IndexDirection type. The driver additionally accepts

--- a/src/tools/mongodb/mongodbSchemas.ts
+++ b/src/tools/mongodb/mongodbSchemas.ts
@@ -1,17 +1,15 @@
 import z from "zod";
-import { toEJSON, zEJSON } from "../args.js";
+import { zEJSON } from "../args.js";
 
 export const AnyAggregateStage = zEJSON();
 
-export const DBAggregateStage = z
-    .union([
-        z.object({ $changeStream: z.unknown() }).strict(),
-        z.object({ $currentOp: z.unknown() }).strict(),
-        z.object({ $documents: z.unknown() }).strict(),
-        z.object({ $listLocalSessions: z.unknown() }).strict(),
-        z.object({ $queryStats: z.unknown() }).strict(),
-    ])
-    .transform(toEJSON);
+export const DB_AGGREGATE_STAGE_OPERATORS = [
+    "$changeStream",
+    "$currentOp",
+    "$documents",
+    "$listLocalSessions",
+    "$queryStats",
+] as const;
 
 // Mirrors mongodb's IndexDirection type. The driver additionally accepts
 // arbitrary `number` values, but only 1 and -1 are meaningful in practice -

--- a/src/tools/mongodb/read/aggregateDB.ts
+++ b/src/tools/mongodb/read/aggregateDB.ts
@@ -11,13 +11,14 @@ import { collectCursorUntilMaxBytesLimit } from "../../../helpers/collectCursorU
 import { operationWithFallback } from "../../../helpers/operationWithFallback.js";
 import { AGG_COUNT_MAX_TIME_MS_CAP, ONE_MB, CURSOR_LIMITS_TO_LLM_TEXT } from "../../../helpers/constants.js";
 import { LogId } from "../../../common/logging/index.js";
-import { AnyAggregateStage, DBAggregateStage } from "../mongodbSchemas.js";
+import { AnyAggregateStage, DB_AGGREGATE_STAGE_OPERATORS } from "../mongodbSchemas.js";
 
 export const AggregateArgs = {
     pipeline: z
-        .tuple([DBAggregateStage], AnyAggregateStage)
+        .array(AnyAggregateStage)
+        .min(1)
         .describe(
-            "An array of aggregation stages to execute. Has to start with a database aggregation stage. https://www.mongodb.com/docs/manual/reference/mql/aggregation-stages/#db.aggregate---stages"
+            `An array of aggregation stages to execute. The first stage must be a database-level aggregation stage (one of ${DB_AGGREGATE_STAGE_OPERATORS.map((op) => `\`${op}\``).join(", ")}). https://www.mongodb.com/docs/manual/reference/mql/aggregation-stages/#db.aggregate---stages`
         ),
 };
 
@@ -121,6 +122,14 @@ The maximum number of bytes to return in the response. This value is capped by t
     }
 
     private assertOnlyUsesPermittedStages(pipeline: Record<string, unknown>[]): void {
+        const firstStage = pipeline[0];
+        if (!firstStage || !DB_AGGREGATE_STAGE_OPERATORS.some((op) => op in firstStage)) {
+            throw new MongoDBError(
+                ErrorCodes.InvalidPipeline,
+                `The first stage of the pipeline must be a database-level aggregation stage (one of ${DB_AGGREGATE_STAGE_OPERATORS.join(", ")})`
+            );
+        }
+
         const writeOperations: OperationType[] = ["update", "create", "delete"];
         let writeStageForbiddenError = "";
 

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -21,7 +21,7 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
         {
             name: "pipeline",
             description:
-                "An array of aggregation stages to execute. Has to start with a database aggregation stage. https://www.mongodb.com/docs/manual/reference/mql/aggregation-stages/#db.aggregate---stages",
+                "An array of aggregation stages to execute. The first stage must be a database-level aggregation stage (one of `$changeStream`, `$currentOp`, `$documents`, `$listLocalSessions`, `$queryStats`). https://www.mongodb.com/docs/manual/reference/mql/aggregation-stages/#db.aggregate---stages",
             type: "array",
             required: true,
         },
@@ -38,8 +38,18 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
         { database: "test", collection: "foo" },
         { database: "test", pipeline: {} },
         { database: 123, pipeline: [] },
-        { database: "test", pipeline: [{ $match: { name: "Peter" } }] }, // This is invalid because we don't have any documents yet. The first stage has to be a db level aggregate stage
     ]);
+
+    it("rejects pipelines whose first stage is not a database-level aggregation stage", async () => {
+        await integration.connectMcpClient();
+        const result = await integration.mcpClient().callTool({
+            name: "aggregate-db",
+            arguments: { database: "test", pipeline: [{ $match: { name: "Peter" } }] },
+        });
+        expect(result.isError).toBe(true);
+        const message = getResponseContent(result.content);
+        expect(message).toContain("first stage of the pipeline must be a database-level aggregation stage");
+    });
 
     it("can run aggregation-db on an existing database", async () => {
         await integration.connectMcpClient();

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -440,7 +440,7 @@ describeWithMongoDB(
 
             const { result, error, executionTime } = await aggregatePromise;
 
-            expect(executionTime).toBeLessThan(100); // Ensure it aborted quickly
+            expect(executionTime).toBeLessThan(50); // Ensure it aborted quickly
             expect(result).toBeUndefined();
             expectDefined(error);
             expect(error.message).toContain("This operation was aborted");
@@ -460,7 +460,7 @@ describeWithMongoDB(
 
             // Ensure it aborted quickly, but possibly after some processing
             expect(executionTime).toBeGreaterThanOrEqual(25);
-            expect(executionTime).toBeLessThan(250);
+            expect(executionTime).toBeLessThan(50);
             expect(result).toBeUndefined();
             expectDefined(error);
             expect(error.message).toContain("This operation was aborted");
@@ -471,8 +471,8 @@ describeWithMongoDB(
 
             const { result, error, executionTime } = await runSlowAggregateDb();
 
-            // Complex regex matching and calculations on 10000 docs should take some time
-            expect(executionTime).toBeGreaterThan(100);
+            // Complex regex matching and calculations on 1000 docs should take some time
+            expect(executionTime).toBeGreaterThan(50);
             expectDefined(result);
             expect(error).toBeUndefined();
             const content = getResponseContent(result);


### PR DESCRIPTION
## Proposed changes

The previous schema resulted in json schema that openAI would reject as invalid json schema:

```
'propertyNames': {'anyOf': [{'type': 'string', 'const': '$changeStream'},
                                {'type': 'string', 'const': '$currentOp'},
                                {'type': 'string', 'const': '$documents'},
                                {'type': 'string', 'const': '$listLocalSessions'},
                                {'type': 'string', 'const': '$queryStats'}]}
```

This was causing accuracy tests to consistently fail when run on CI. The updated schema changes from a union of property names to an array of generic aggregate stages and a runtime validation.
