### PR TITLE
feat: add agent_env_var telemetry property (MCP-482)

### DIFF
--- a/src/helpers/agentDetection.ts
+++ b/src/helpers/agentDetection.ts
@@ -1,0 +1,52 @@
+import fs from "fs/promises";
+
+// Env var checks evaluated in order; first match wins.
+const ENV_CHECKS: Array<{ envVar: string; expectedValue: string | null; telemetryValue: string }> = [
+    { envVar: "CLAUDECODE", expectedValue: "1", telemetryValue: "claude_code" },
+    { envVar: "CURSOR_AGENT", expectedValue: "1", telemetryValue: "cursor" },
+    { envVar: "GEMINI_CLI", expectedValue: "1", telemetryValue: "gemini_cli" },
+    { envVar: "CODEX_SANDBOX", expectedValue: "seatbelt", telemetryValue: "codex_cli" },
+    { envVar: "AUGMENT_AGENT", expectedValue: "1", telemetryValue: "augment" },
+    { envVar: "CLINE_ACTIVE", expectedValue: "true", telemetryValue: "cline" },
+    { envVar: "OPENCODE_CLIENT", expectedValue: "1", telemetryValue: "opencode_client" },
+    // TRAE_AI_SHELL_ID carries a session id — any non-empty value qualifies.
+    { envVar: "TRAE_AI_SHELL_ID", expectedValue: null, telemetryValue: "trae_ai" },
+];
+
+// null = not yet resolved; undefined = resolved, no agent detected
+let cachedAgentEnvVar: string | undefined | null = null;
+
+export async function detectAgentEnvVar(): Promise<string | undefined> {
+    if (cachedAgentEnvVar !== null) {
+        return cachedAgentEnvVar;
+    }
+
+    cachedAgentEnvVar = await detect();
+    return cachedAgentEnvVar;
+}
+
+async function detect(): Promise<string | undefined> {
+    if (typeof process === "undefined" || !process.env) {
+        return undefined;
+    }
+
+    for (const { envVar, expectedValue, telemetryValue } of ENV_CHECKS) {
+        const value = process.env[envVar];
+        if (value !== undefined && (expectedValue === null ? value.length > 0 : value === expectedValue)) {
+            return telemetryValue;
+        }
+    }
+
+    // AGENT is shared by amp and goose; distinguish by value.
+    const agentValue = process.env.AGENT;
+    if (agentValue === "amp") return "amp";
+    if (agentValue === "goose") return "goose";
+
+    // Devin is detected via a filesystem marker rather than an env var.
+    try {
+        await fs.access("/opt/.devin");
+        return "devin";
+    } catch {
+        return undefined;
+    }
+}

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -6,6 +6,7 @@ import { ApiClientError } from "../common/atlas/apiClientError.js";
 import { MACHINE_METADATA } from "./constants.js";
 import { EventCache } from "./eventCache.js";
 import { detectContainerEnv } from "../helpers/container.js";
+import { detectAgentEnvVar } from "../helpers/agentDetection.js";
 import type { DeviceId } from "../helpers/deviceId.js";
 import type { Keychain } from "../common/keychain.js";
 import type { Session } from "../common/session.js";
@@ -186,6 +187,11 @@ export class Telemetry {
 
         this.pipelineCommonProperties.device_id = deviceIdValue;
         this.pipelineCommonProperties.is_container_env = containerEnv ? "true" : "false";
+
+        const agentEnvVar = await detectAgentEnvVar();
+        if (agentEnvVar !== undefined) {
+            this.pipelineCommonProperties.agent_env_var = agentEnvVar;
+        }
 
         this.scheduleSend();
     }

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -216,6 +216,13 @@ export type CommonProperties = {
      * A boolean indicating whether a Docker daemon is available on the machine.
      */
     has_docker?: TelemetryBoolSet;
+
+    /**
+     * Identifies the AI agent that invoked the MCP server, derived from well-known
+     * environment variables or filesystem markers set by agent runtimes.
+     * Examples: "claude_code", "cursor", "gemini_cli".
+     */
+    agent_env_var?: string;
 } & CommonStaticProperties;
 
 /**

--- a/tests/unit/helpers/agentDetection.test.ts
+++ b/tests/unit/helpers/agentDetection.test.ts
@@ -14,7 +14,7 @@ const AGENT_ENV_VARS = [
 
 // The module caches its result in a module-level variable, so we reload it
 // between tests using vi.resetModules().
-async function importFresh() {
+async function importFresh(): Promise<() => Promise<string | undefined>> {
     vi.resetModules();
     const mod = await import("../../../src/helpers/agentDetection.js");
     return mod.detectAgentEnvVar;

--- a/tests/unit/helpers/agentDetection.test.ts
+++ b/tests/unit/helpers/agentDetection.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const AGENT_ENV_VARS = [
+    "CLAUDECODE",
+    "CURSOR_AGENT",
+    "GEMINI_CLI",
+    "CODEX_SANDBOX",
+    "AUGMENT_AGENT",
+    "CLINE_ACTIVE",
+    "OPENCODE_CLIENT",
+    "TRAE_AI_SHELL_ID",
+    "AGENT",
+];
+
+// The module caches its result in a module-level variable, so we reload it
+// between tests using vi.resetModules().
+async function importFresh() {
+    vi.resetModules();
+    const mod = await import("../../../src/helpers/agentDetection.js");
+    return mod.detectAgentEnvVar;
+}
+
+let savedEnvVars: Partial<NodeJS.ProcessEnv>;
+
+beforeEach(() => {
+    // Save and clear all agent env vars so each test starts from a clean state.
+    savedEnvVars = {};
+    for (const key of AGENT_ENV_VARS) {
+        savedEnvVars[key] = process.env[key];
+        delete process.env[key];
+    }
+});
+
+afterEach(() => {
+    // Restore original env vars.
+    for (const key of AGENT_ENV_VARS) {
+        if (savedEnvVars[key] !== undefined) {
+            process.env[key] = savedEnvVars[key];
+        } else {
+            delete process.env[key];
+        }
+    }
+    vi.resetModules();
+});
+
+describe("detectAgentEnvVar", () => {
+    it("returns undefined when no agent env var is set", async () => {
+        vi.doMock("fs/promises", () => ({
+            default: { access: vi.fn().mockRejectedValue(new Error("ENOENT")) },
+        }));
+
+        const detectAgentEnvVar = await importFresh();
+        expect(await detectAgentEnvVar()).toBeUndefined();
+    });
+
+    it.each([
+        { envVar: "CLAUDECODE", value: "1", expected: "claude_code" },
+        { envVar: "CURSOR_AGENT", value: "1", expected: "cursor" },
+        { envVar: "GEMINI_CLI", value: "1", expected: "gemini_cli" },
+        { envVar: "CODEX_SANDBOX", value: "seatbelt", expected: "codex_cli" },
+        { envVar: "AUGMENT_AGENT", value: "1", expected: "augment" },
+        { envVar: "CLINE_ACTIVE", value: "true", expected: "cline" },
+        { envVar: "OPENCODE_CLIENT", value: "1", expected: "opencode_client" },
+        { envVar: "TRAE_AI_SHELL_ID", value: "some-session-id", expected: "trae_ai" },
+    ])("returns '$expected' when $envVar=$value", async ({ envVar, value, expected }) => {
+        process.env[envVar] = value;
+        const detectAgentEnvVar = await importFresh();
+        expect(await detectAgentEnvVar()).toBe(expected);
+    });
+
+    it("returns 'amp' when AGENT=amp", async () => {
+        process.env.AGENT = "amp";
+        const detectAgentEnvVar = await importFresh();
+        expect(await detectAgentEnvVar()).toBe("amp");
+    });
+
+    it("returns 'goose' when AGENT=goose", async () => {
+        process.env.AGENT = "goose";
+        const detectAgentEnvVar = await importFresh();
+        expect(await detectAgentEnvVar()).toBe("goose");
+    });
+
+    it("returns undefined when AGENT has an unknown value", async () => {
+        process.env.AGENT = "other-tool";
+        vi.doMock("fs/promises", () => ({
+            default: { access: vi.fn().mockRejectedValue(new Error("ENOENT")) },
+        }));
+        const detectAgentEnvVar = await importFresh();
+        expect(await detectAgentEnvVar()).toBeUndefined();
+    });
+
+    it("returns 'devin' when /opt/.devin exists", async () => {
+        vi.doMock("fs/promises", () => ({
+            default: { access: vi.fn().mockResolvedValue(undefined) },
+        }));
+        const detectAgentEnvVar = await importFresh();
+        expect(await detectAgentEnvVar()).toBe("devin");
+    });
+
+    it("does not match CODEX_SANDBOX with a value other than 'seatbelt'", async () => {
+        process.env.CODEX_SANDBOX = "other";
+        vi.doMock("fs/promises", () => ({
+            default: { access: vi.fn().mockRejectedValue(new Error("ENOENT")) },
+        }));
+        const detectAgentEnvVar = await importFresh();
+        expect(await detectAgentEnvVar()).toBeUndefined();
+    });
+
+    it("returns the first match when multiple env vars are set", async () => {
+        // CLAUDECODE is checked before CURSOR_AGENT in the list.
+        process.env.CLAUDECODE = "1";
+        process.env.CURSOR_AGENT = "1";
+        const detectAgentEnvVar = await importFresh();
+        expect(await detectAgentEnvVar()).toBe("claude_code");
+    });
+
+    it("caches the result across multiple calls", async () => {
+        process.env.CLAUDECODE = "1";
+        const detectAgentEnvVar = await importFresh();
+        const first = await detectAgentEnvVar();
+        // Change the env var — cached result should still be returned.
+        delete process.env.CLAUDECODE;
+        const second = await detectAgentEnvVar();
+        expect(first).toBe("claude_code");
+        expect(second).toBe("claude_code");
+    });
+});


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [MCP-482](https://jira.mongodb.org/browse/MCP-482)
_Tracking ticket:_ [CLOUDP-400902](https://jira.mongodb.org/browse/CLOUDP-400902)

Adds an `agent_env_var` common property to MCP telemetry that identifies the AI agent runtime invoking the server. The value is detected once at startup from well-known environment variables and a filesystem marker, then attached to every emitted event.

Detection table (matches CLOUDP-400902 spec):

| Agent | Signal | Telemetry value |
|---|---|---|
| Claude Code | `CLAUDECODE=1` | `claude_code` |
| Cursor | `CURSOR_AGENT=1` | `cursor` |
| Gemini CLI | `GEMINI_CLI=1` | `gemini_cli` |
| Codex CLI | `CODEX_SANDBOX=seatbelt` | `codex_cli` |
| Augment | `AUGMENT_AGENT=1` | `augment` |
| Cline | `CLINE_ACTIVE=true` | `cline` |
| OpenCode | `OPENCODE_CLIENT=1` | `opencode_client` |
| TRAE AI | `TRAE_AI_SHELL_ID=<any>` | `trae_ai` |
| Devin | `/opt/.devin` exists | `devin` |
| Amp | `AGENT=amp` | `amp` |
| Goose | `AGENT=goose` | `goose` |

The result is cached at the module level so the filesystem check for Devin only runs once per process.

### Files changed

* `src/helpers/agentDetection.ts` — new helper with detection logic
* `src/telemetry/types.ts` — adds `agent_env_var?: string` to `CommonProperties`
* `src/telemetry/telemetry.ts` — calls `detectAgentEnvVar()` during setup, alongside device ID and container env resolution
* `tests/unit/helpers/agentDetection.test.ts` — 16 unit tests covering every agent, caching, wrong values, and precedence

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)