### PR TITLE
refactor(MCP-483):  discriminated-union input schemas for streams tools

### DIFF
--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -1268,9 +1268,9 @@ export class StreamsBuildTool extends StreamsToolBase {
             Cluster: "Cluster";
             Kafka: "Kafka";
             S3: "S3";
-            Https: "Https";
             AWSKinesisDataStreams: "AWSKinesisDataStreams";
             AWSLambda: "AWSLambda";
+            Https: "Https";
             SchemaRegistry: "SchemaRegistry";
             Sample: "Sample";
         }>>;
@@ -1400,93 +1400,113 @@ export class StreamsManageTool extends StreamsToolBase {
     argsShape: {
         projectId: z.ZodString;
         workspaceName: z.ZodString;
-        action: z.ZodEnum<{
-            "start-processor": "start-processor";
-            "stop-processor": "stop-processor";
-            "modify-processor": "modify-processor";
-            "update-workspace": "update-workspace";
-            "update-connection": "update-connection";
-            "accept-peering": "accept-peering";
-            "reject-peering": "reject-peering";
-        }>;
-        resourceName: z.ZodOptional<z.ZodString>;
-        tier: z.ZodOptional<z.ZodEnum<{
-            SP50: "SP50";
-            SP30: "SP30";
-            SP10: "SP10";
-            SP5: "SP5";
-            SP2: "SP2";
-        }>>;
-        resumeFromCheckpoint: z.ZodOptional<z.ZodBoolean>;
-        startAtOperationTime: z.ZodOptional<z.ZodString>;
-        pipeline: z.ZodOptional<z.ZodArray<z.ZodRecord<z.ZodString, z.ZodUnknown>>>;
-        dlq: z.ZodOptional<z.ZodObject<{
-            connectionName: z.ZodString;
-            db: z.ZodString;
-            coll: z.ZodString;
-        }, z.core.$strip>>;
-        newName: z.ZodOptional<z.ZodString>;
-        newRegion: z.ZodOptional<z.ZodString>;
-        newTier: z.ZodOptional<z.ZodEnum<{
-            SP50: "SP50";
-            SP30: "SP30";
-            SP10: "SP10";
-            SP5: "SP5";
-            SP2: "SP2";
-        }>>;
-        connectionConfig: z.ZodOptional<z.ZodObject<{
-            bootstrapServers: z.ZodOptional<z.ZodPipe<z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>]>, z.ZodTransform<string, string | string[]>>>;
-            authentication: z.ZodOptional<z.ZodObject<{
-                mechanism: z.ZodOptional<z.ZodEnum<{
-                    PLAIN: "PLAIN";
-                    "SCRAM-256": "SCRAM-256";
-                    "SCRAM-512": "SCRAM-512";
-                    OAUTHBEARER: "OAUTHBEARER";
-                }>>;
-                username: z.ZodOptional<z.ZodString>;
-                password: z.ZodOptional<z.ZodString>;
-            }, z.core.$loose>>;
-            security: z.ZodOptional<z.ZodObject<{
-                protocol: z.ZodOptional<z.ZodEnum<{
-                    SASL_SSL: "SASL_SSL";
-                    SASL_PLAINTEXT: "SASL_PLAINTEXT";
-                    SSL: "SSL";
-                }>>;
-            }, z.core.$loose>>;
-            clusterName: z.ZodOptional<z.ZodString>;
-            dbRoleToExecute: z.ZodOptional<z.ZodObject<{
-                role: z.ZodOptional<z.ZodString>;
-                type: z.ZodOptional<z.ZodEnum<{
-                    CUSTOM: "CUSTOM";
-                    BUILT_IN: "BUILT_IN";
-                }>>;
+        operation: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+            action: z.ZodLiteral<"start-processor">;
+            resourceName: z.ZodString;
+            tier: z.ZodOptional<z.ZodEnum<{
+                SP50: "SP50";
+                SP30: "SP30";
+                SP10: "SP10";
+                SP5: "SP5";
+                SP2: "SP2";
+            }>>;
+            resumeFromCheckpoint: z.ZodOptional<z.ZodBoolean>;
+            startAtOperationTime: z.ZodOptional<z.ZodString>;
+        }, z.core.$strip>, z.ZodObject<{
+            action: z.ZodLiteral<"stop-processor">;
+            resourceName: z.ZodString;
+        }, z.core.$strip>, z.ZodObject<{
+            action: z.ZodLiteral<"modify-processor">;
+            resourceName: z.ZodString;
+            pipeline: z.ZodOptional<z.ZodArray<z.ZodRecord<z.ZodString, z.ZodUnknown>>>;
+            dlq: z.ZodOptional<z.ZodObject<{
+                connectionName: z.ZodString;
+                db: z.ZodString;
+                coll: z.ZodString;
             }, z.core.$strip>>;
-            aws: z.ZodOptional<z.ZodObject<{
-                roleArn: z.ZodOptional<z.ZodString>;
-                testBucket: z.ZodOptional<z.ZodString>;
-            }, z.core.$loose>>;
-            url: z.ZodOptional<z.ZodString>;
-            headers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
-            provider: z.ZodOptional<z.ZodString>;
-            schemaRegistryUrls: z.ZodOptional<z.ZodPipe<z.ZodUnion<readonly [z.ZodArray<z.ZodString>, z.ZodString]>, z.ZodTransform<string[], string | string[]>>>;
-            schemaRegistryAuthentication: z.ZodOptional<z.ZodObject<{
-                type: z.ZodOptional<z.ZodEnum<{
-                    USER_INFO: "USER_INFO";
-                    SASL_INHERIT: "SASL_INHERIT";
-                }>>;
-                username: z.ZodOptional<z.ZodString>;
-                password: z.ZodOptional<z.ZodString>;
-            }, z.core.$loose>>;
-            networking: z.ZodOptional<z.ZodObject<{
-                access: z.ZodOptional<z.ZodObject<{
-                    type: z.ZodOptional<z.ZodString>;
-                    connectionId: z.ZodOptional<z.ZodString>;
+            newName: z.ZodOptional<z.ZodString>;
+        }, z.core.$strip>, z.ZodObject<{
+            action: z.ZodLiteral<"update-workspace">;
+            newRegion: z.ZodOptional<z.ZodString>;
+            newTier: z.ZodOptional<z.ZodEnum<{
+                SP50: "SP50";
+                SP30: "SP30";
+                SP10: "SP10";
+                SP5: "SP5";
+                SP2: "SP2";
+            }>>;
+        }, z.core.$strip>, z.ZodObject<{
+            action: z.ZodLiteral<"update-connection">;
+            resourceName: z.ZodString;
+            connectionConfig: z.ZodObject<{
+                bootstrapServers: z.ZodOptional<z.ZodPipe<z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>]>, z.ZodTransform<string, string | string[]>>>;
+                authentication: z.ZodOptional<z.ZodObject<{
+                    mechanism: z.ZodOptional<z.ZodEnum<{
+                        PLAIN: "PLAIN";
+                        "SCRAM-256": "SCRAM-256";
+                        "SCRAM-512": "SCRAM-512";
+                        OAUTHBEARER: "OAUTHBEARER";
+                    }>>;
+                    username: z.ZodOptional<z.ZodString>;
+                    password: z.ZodOptional<z.ZodString>;
                 }, z.core.$loose>>;
-            }, z.core.$loose>>;
-        }, z.core.$loose>>;
-        peeringId: z.ZodOptional<z.ZodString>;
-        requesterAccountId: z.ZodOptional<z.ZodString>;
-        requesterVpcId: z.ZodOptional<z.ZodString>;
+                security: z.ZodOptional<z.ZodObject<{
+                    protocol: z.ZodOptional<z.ZodEnum<{
+                        SASL_SSL: "SASL_SSL";
+                        SASL_PLAINTEXT: "SASL_PLAINTEXT";
+                        SSL: "SSL";
+                    }>>;
+                }, z.core.$loose>>;
+                clusterName: z.ZodOptional<z.ZodString>;
+                dbRoleToExecute: z.ZodOptional<z.ZodObject<{
+                    role: z.ZodOptional<z.ZodString>;
+                    type: z.ZodOptional<z.ZodEnum<{
+                        CUSTOM: "CUSTOM";
+                        BUILT_IN: "BUILT_IN";
+                    }>>;
+                }, z.core.$strip>>;
+                aws: z.ZodOptional<z.ZodObject<{
+                    roleArn: z.ZodOptional<z.ZodString>;
+                    testBucket: z.ZodOptional<z.ZodString>;
+                }, z.core.$loose>>;
+                url: z.ZodOptional<z.ZodString>;
+                headers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
+                provider: z.ZodOptional<z.ZodString>;
+                schemaRegistryUrls: z.ZodOptional<z.ZodPipe<z.ZodUnion<readonly [z.ZodArray<z.ZodString>, z.ZodString]>, z.ZodTransform<string[], string | string[]>>>;
+                schemaRegistryAuthentication: z.ZodOptional<z.ZodObject<{
+                    type: z.ZodOptional<z.ZodEnum<{
+                        USER_INFO: "USER_INFO";
+                        SASL_INHERIT: "SASL_INHERIT";
+                    }>>;
+                    username: z.ZodOptional<z.ZodString>;
+                    password: z.ZodOptional<z.ZodString>;
+                }, z.core.$loose>>;
+                networking: z.ZodOptional<z.ZodObject<{
+                    access: z.ZodOptional<z.ZodObject<{
+                        type: z.ZodOptional<z.ZodString>;
+                        connectionId: z.ZodOptional<z.ZodString>;
+                    }, z.core.$loose>>;
+                }, z.core.$loose>>;
+            }, z.core.$loose>;
+            connectionType: z.ZodOptional<z.ZodEnum<{
+                Cluster: "Cluster";
+                Kafka: "Kafka";
+                S3: "S3";
+                AWSKinesisDataStreams: "AWSKinesisDataStreams";
+                AWSLambda: "AWSLambda";
+                Https: "Https";
+                SchemaRegistry: "SchemaRegistry";
+                Sample: "Sample";
+            }>>;
+        }, z.core.$strip>, z.ZodObject<{
+            action: z.ZodLiteral<"accept-peering">;
+            peeringId: z.ZodString;
+            requesterAccountId: z.ZodString;
+            requesterVpcId: z.ZodString;
+        }, z.core.$strip>, z.ZodObject<{
+            action: z.ZodLiteral<"reject-peering">;
+            peeringId: z.ZodString;
+        }, z.core.$strip>], "action">>;
     };
     // (undocumented)
     description: string;

--- a/src/tools/atlas/streams/build.ts
+++ b/src/tools/atlas/streams/build.ts
@@ -5,6 +5,7 @@ import type { ElicitRequestFormParams } from "@modelcontextprotocol/sdk/types.js
 import type { OperationType, ToolArgs } from "../../tool.js";
 import { AtlasArgs } from "../../args.js";
 import { ConnectionConfig, PrivateLinkConfig, StreamsArgs } from "./streamsArgs.js";
+import { getConnectionConfigSchema } from "./connectionConfigs.js";
 
 const BuildResource = z.enum(["workspace", "connection", "processor", "privatelink"]);
 
@@ -259,6 +260,8 @@ export class StreamsBuildTool extends StreamsToolBase {
         if (useSample) {
             await this.apiClient.withStreamSampleConnections({
                 params: { path: { groupId: args.projectId } },
+                // Atlas OpenAPI types cloudProvider/region as literal enums; we validate at the
+                // input schema layer so the cast is safe here.
                 body: body as never,
             });
         } else {
@@ -296,6 +299,18 @@ export class StreamsBuildTool extends StreamsToolBase {
 
         const config = { ...ConnectionConfig.parse(args.connectionConfig ?? {}) };
 
+        // Alias normalization must happen BEFORE strict type validation. Otherwise the
+        // SchemaRegistry "url → schemaRegistryUrls" kind of aliases would get rejected
+        // as cross-type fields before they're collapsed into canonical ones.
+        if (args.connectionType === "SchemaRegistry") {
+            StreamsBuildTool.normalizeSchemaRegistryAliases(config);
+        }
+
+        const typeValidationError = StreamsBuildTool.rejectCrossTypeFields(config, args.connectionType);
+        if (typeValidationError) {
+            return typeValidationError;
+        }
+
         const missingInfo = await this.normalizeAndValidateConnectionConfig(config, args.connectionType);
         if (missingInfo) {
             return missingInfo;
@@ -309,6 +324,10 @@ export class StreamsBuildTool extends StreamsToolBase {
 
         await this.apiClient.createStreamConnection({
             params: { path: { groupId: args.projectId, tenantName: workspaceName } },
+            // StreamsConnection body is a discriminated union in the OpenAPI types; the
+            // per-type schemas (connectionConfigs.ts) plus the alias normalization and
+            // normalizeAndValidateConnectionConfig step validate the payload shape before
+            // we reach this call.
             body: body as never,
         });
 
@@ -439,30 +458,8 @@ export class StreamsBuildTool extends StreamsToolBase {
     }
 
     private async validateSchemaRegistryConfig(config: Record<string, unknown>): Promise<CallToolResult | null> {
-        // Normalize common alternative key names for schemaRegistryUrls
-        if (!config.schemaRegistryUrls) {
-            const alt = config.url || config.urls || config.endpoint || config.schemaRegistryUrl;
-            if (alt) {
-                config.schemaRegistryUrls = Array.isArray(alt) ? alt : [alt];
-                delete config.url;
-                delete config.urls;
-                delete config.endpoint;
-                delete config.schemaRegistryUrl;
-            }
-        }
-
-        // Normalize common alternative key names for authentication
-        if (!config.schemaRegistryAuthentication && (config.username || config.authentication)) {
-            const authSource = (config.authentication as Record<string, unknown>) || {};
-            config.schemaRegistryAuthentication = {
-                type: "USER_INFO",
-                username: config.username || authSource.username,
-                password: config.password || authSource.password,
-            };
-            delete config.username;
-            delete config.password;
-            delete config.authentication;
-        }
+        // Alias normalization now runs earlier in createConnection (see
+        // `normalizeSchemaRegistryAliases`) so strict type validation doesn't reject aliases.
 
         // Default provider to CONFLUENT — currently the only supported value
         if (!config.provider) {
@@ -558,6 +555,75 @@ export class StreamsBuildTool extends StreamsToolBase {
         }
 
         return StreamsBuildTool.missingFieldsResponse(connectionType, missingFields, additionalNote);
+    }
+
+    /**
+     * Collapses SchemaRegistry alias field names (url / urls / endpoint / schemaRegistryUrl
+     * and flat username/password/authentication) into the canonical fields expected by the
+     * Atlas API and by `SchemaRegistryConnectionConfig`. Runs before strict type validation
+     * so alias inputs survive the cross-type check.
+     */
+    private static normalizeSchemaRegistryAliases(config: Record<string, unknown>): void {
+        if (!config.schemaRegistryUrls) {
+            const alt = config.url || config.urls || config.endpoint || config.schemaRegistryUrl;
+            if (alt) {
+                config.schemaRegistryUrls = Array.isArray(alt) ? alt : [alt];
+                delete config.url;
+                delete config.urls;
+                delete config.endpoint;
+                delete config.schemaRegistryUrl;
+            }
+        }
+
+        if (!config.schemaRegistryAuthentication && (config.username || config.authentication)) {
+            const authSource = (config.authentication as Record<string, unknown>) || {};
+            config.schemaRegistryAuthentication = {
+                type: "USER_INFO",
+                username: config.username || authSource.username,
+                password: config.password || authSource.password,
+            };
+            delete config.username;
+            delete config.password;
+            delete config.authentication;
+        }
+    }
+
+    /**
+     * Rejects a connectionConfig that includes fields belonging to a different
+     * connection type. Runs the type-specific strict schema from `connectionConfigs.ts`
+     * before the Atlas API is called, so the LLM gets a useful error instead of a
+     * generic Atlas 400. Returns a CallToolResult on rejection; null when the config
+     * passes or the type has no strict schema (e.g. Sample).
+     */
+    private static rejectCrossTypeFields(
+        config: Record<string, unknown>,
+        connectionType: string
+    ): CallToolResult | null {
+        const schema = getConnectionConfigSchema(connectionType);
+        if (!schema) return null;
+        const result = schema.safeParse(config);
+        if (result.success) return null;
+
+        const unknownFields = result.error.issues
+            .filter((issue) => issue.code === "unrecognized_keys")
+            .flatMap((issue) => ("keys" in issue ? issue.keys : []));
+        const unknownFieldList =
+            unknownFields.length > 0
+                ? `Unknown fields for ${connectionType}: ${unknownFields.join(", ")}.`
+                : `The config contains fields that are not valid for a ${connectionType} connection.`;
+
+        return {
+            content: [
+                {
+                    type: "text",
+                    text:
+                        `Invalid ${connectionType} connection config: ${unknownFieldList}\n\n` +
+                        `Check the connectionType matches the config you provided. ` +
+                        `Remove the unrelated fields or switch to the correct connectionType.`,
+                },
+            ],
+            isError: true,
+        };
     }
 
     private static collectMissingFields(
@@ -738,6 +804,8 @@ export class StreamsBuildTool extends StreamsToolBase {
 
         await this.apiClient.createStreamProcessor({
             params: { path: { groupId: args.projectId, tenantName: workspaceName } },
+            // Atlas OpenAPI `pipeline` is typed as a tightly indexed object union our generic
+            // pipeline-stages array can't satisfy. validatePipelineStructure checks the shape.
             body: body as never,
         });
 
@@ -802,6 +870,8 @@ export class StreamsBuildTool extends StreamsToolBase {
 
         await this.apiClient.createPrivateLinkConnection({
             params: { path: { groupId: args.projectId } },
+            // PrivateLink body is a provider-discriminated union in OpenAPI; the
+            // PrivateLinkConnectionConfig schema validates provider at the input layer.
             body: body as never,
         });
 

--- a/src/tools/atlas/streams/build.ts
+++ b/src/tools/atlas/streams/build.ts
@@ -5,7 +5,7 @@ import type { ElicitRequestFormParams } from "@modelcontextprotocol/sdk/types.js
 import type { OperationType, ToolArgs } from "../../tool.js";
 import { AtlasArgs } from "../../args.js";
 import { ConnectionConfig, PrivateLinkConfig, StreamsArgs } from "./streamsArgs.js";
-import { getConnectionConfigSchema } from "./connectionConfigs.js";
+import { rejectInvalidConnectionConfig } from "./connectionConfigs.js";
 
 const BuildResource = z.enum(["workspace", "connection", "processor", "privatelink"]);
 
@@ -306,7 +306,7 @@ export class StreamsBuildTool extends StreamsToolBase {
             StreamsBuildTool.normalizeSchemaRegistryAliases(config);
         }
 
-        const typeValidationError = StreamsBuildTool.rejectCrossTypeFields(config, args.connectionType);
+        const typeValidationError = rejectInvalidConnectionConfig(config, args.connectionType, "create");
         if (typeValidationError) {
             return typeValidationError;
         }
@@ -586,44 +586,6 @@ export class StreamsBuildTool extends StreamsToolBase {
             delete config.password;
             delete config.authentication;
         }
-    }
-
-    /**
-     * Rejects a connectionConfig that includes fields belonging to a different
-     * connection type. Runs the type-specific strict schema from `connectionConfigs.ts`
-     * before the Atlas API is called, so the LLM gets a useful error instead of a
-     * generic Atlas 400. Returns a CallToolResult on rejection; null when the config
-     * passes or the type has no strict schema (e.g. Sample).
-     */
-    private static rejectCrossTypeFields(
-        config: Record<string, unknown>,
-        connectionType: string
-    ): CallToolResult | null {
-        const schema = getConnectionConfigSchema(connectionType);
-        if (!schema) return null;
-        const result = schema.safeParse(config);
-        if (result.success) return null;
-
-        const unknownFields = result.error.issues
-            .filter((issue) => issue.code === "unrecognized_keys")
-            .flatMap((issue) => ("keys" in issue ? issue.keys : []));
-        const unknownFieldList =
-            unknownFields.length > 0
-                ? `Unknown fields for ${connectionType}: ${unknownFields.join(", ")}.`
-                : `The config contains fields that are not valid for a ${connectionType} connection.`;
-
-        return {
-            content: [
-                {
-                    type: "text",
-                    text:
-                        `Invalid ${connectionType} connection config: ${unknownFieldList}\n\n` +
-                        `Check the connectionType matches the config you provided. ` +
-                        `Remove the unrelated fields or switch to the correct connectionType.`,
-                },
-            ],
-            isError: true,
-        };
     }
 
     private static collectMissingFields(

--- a/src/tools/atlas/streams/build.ts
+++ b/src/tools/atlas/streams/build.ts
@@ -825,6 +825,8 @@ export class StreamsBuildTool extends StreamsToolBase {
         if (!args.privateLinkConfig.provider) {
             throw new Error("privateLinkConfig.provider is required. Choose from: AWS, AZURE, GCP.");
         }
+        const validationError = rejectInvalidConnectionConfig(args.privateLinkConfig, "PrivateLink", "create");
+        if (validationError) return validationError;
 
         const body: Record<string, unknown> = {
             ...args.privateLinkConfig,

--- a/src/tools/atlas/streams/connectionConfigs.ts
+++ b/src/tools/atlas/streams/connectionConfigs.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+
+const AuthenticationSchema = z
+    .object({
+        mechanism: z.enum(["PLAIN", "SCRAM-256", "SCRAM-512", "OAUTHBEARER"]).optional(),
+        username: z.string().optional(),
+        password: z.string().optional(),
+    })
+    .passthrough();
+
+const SecuritySchema = z
+    .object({
+        protocol: z.enum(["SASL_SSL", "SASL_PLAINTEXT", "SSL", "PLAINTEXT"]).optional(),
+    })
+    .passthrough();
+
+const NetworkingSchema = z
+    .object({
+        access: z
+            .object({
+                type: z.string().optional(),
+                connectionId: z.string().optional(),
+            })
+            .passthrough()
+            .optional(),
+    })
+    .passthrough();
+
+export const KafkaConnectionConfig = z
+    .object({
+        bootstrapServers: z
+            .union([z.string(), z.array(z.string())])
+            .transform((val) => (Array.isArray(val) ? val.join(",") : val))
+            .optional(),
+        authentication: AuthenticationSchema.optional(),
+        security: SecuritySchema.optional(),
+        networking: NetworkingSchema.optional(),
+    })
+    .strict();
+
+export const ClusterConnectionConfig = z
+    .object({
+        clusterName: z.string().optional(),
+        dbRoleToExecute: z
+            .object({
+                role: z.string().optional(),
+                type: z.enum(["BUILT_IN", "CUSTOM"]).optional(),
+            })
+            .optional(),
+        networking: NetworkingSchema.optional(),
+    })
+    .strict();
+
+const AwsCredentialsSchema = z
+    .object({
+        roleArn: z.string().optional(),
+        testBucket: z.string().optional(),
+    })
+    .passthrough();
+
+export const S3ConnectionConfig = z
+    .object({
+        aws: AwsCredentialsSchema.optional(),
+        networking: NetworkingSchema.optional(),
+    })
+    .strict();
+
+export const KinesisConnectionConfig = z
+    .object({
+        aws: AwsCredentialsSchema.optional(),
+        networking: NetworkingSchema.optional(),
+    })
+    .strict();
+
+export const LambdaConnectionConfig = z
+    .object({
+        aws: AwsCredentialsSchema.optional(),
+        networking: NetworkingSchema.optional(),
+    })
+    .strict();
+
+export const HttpsConnectionConfig = z
+    .object({
+        url: z.string().optional(),
+        headers: z.record(z.string(), z.string()).optional(),
+        networking: NetworkingSchema.optional(),
+    })
+    .strict();
+
+export const SchemaRegistryConnectionConfig = z
+    .object({
+        provider: z.string().optional(),
+        schemaRegistryUrls: z
+            .union([z.array(z.string()), z.string()])
+            .transform((val) => (typeof val === "string" ? val.split(",").map((s) => s.trim()) : val))
+            .optional(),
+        schemaRegistryAuthentication: z
+            .object({
+                type: z.enum(["USER_INFO", "SASL_INHERIT"]).optional(),
+                username: z.string().optional(),
+                password: z.string().optional(),
+            })
+            .passthrough()
+            .optional(),
+    })
+    .strict();
+
+export const PrivateLinkConnectionConfig = z
+    .object({
+        provider: z.enum(["AWS", "AZURE", "GCP"]),
+        region: z.string().optional(),
+        vendor: z.string().optional(),
+        arn: z.string().optional(),
+        dnsDomain: z.string().optional(),
+        dnsSubDomain: z.array(z.string()).optional(),
+        serviceEndpointId: z.string().optional(),
+        azureResourceIds: z.array(z.string()).optional(),
+        gcpServiceAttachmentUris: z.array(z.string()).optional(),
+    })
+    .passthrough();
+
+export function getConnectionConfigSchema(connectionType: string): z.ZodTypeAny | null {
+    switch (connectionType) {
+        case "Kafka":
+            return KafkaConnectionConfig;
+        case "Cluster":
+            return ClusterConnectionConfig;
+        case "S3":
+            return S3ConnectionConfig;
+        case "AWSKinesisDataStreams":
+            return KinesisConnectionConfig;
+        case "AWSLambda":
+            return LambdaConnectionConfig;
+        case "Https":
+            return HttpsConnectionConfig;
+        case "SchemaRegistry":
+            return SchemaRegistryConnectionConfig;
+        default:
+            return null;
+    }
+}

--- a/src/tools/atlas/streams/connectionConfigs.ts
+++ b/src/tools/atlas/streams/connectionConfigs.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 const AuthenticationSchema = z
     .object({
@@ -119,7 +120,82 @@ export const PrivateLinkConnectionConfig = z
     })
     .passthrough();
 
-export function getConnectionConfigSchema(connectionType: string): z.ZodTypeAny | null {
+/**
+ * Fields that cannot be patched on an existing connection. Kept on the create-mode
+ * schema (so users can set them at creation time), stripped from the update-mode
+ * derivation (so users get a useful error if they try to patch them).
+ */
+const IMMUTABLE_AFTER_CREATE = ["networking"] as const;
+
+/**
+ * Derives an update-mode schema from a create-mode schema by:
+ * 1. omitting immutable fields that exist on the schema (can only be set at create time), and
+ * 2. making every remaining field optional (PATCH semantics — any field not sent
+ *    is left unchanged on the server).
+ *
+ * Unknown-key rejection (cross-type safety) is preserved because the underlying
+ * schemas are `.strict()`. Immutable keys that aren't present on a given schema are
+ * skipped — `.omit()` in zod rejects unknown keys.
+ */
+function toUpdateMode(schema: z.ZodObject<z.ZodRawShape>): z.ZodTypeAny {
+    const shapeKeys = Object.keys(schema.shape);
+    const omitMask: Record<string, true> = {};
+    for (const key of IMMUTABLE_AFTER_CREATE) {
+        if (shapeKeys.includes(key)) {
+            omitMask[key] = true;
+        }
+    }
+    const omitted = Object.keys(omitMask).length > 0 ? schema.omit(omitMask as never) : schema;
+    return omitted.partial();
+}
+
+export type SchemaMode = "create" | "update";
+
+/**
+ * Validates a connection config against the per-type schema for the given connectionType
+ * and mode, returning a CallToolResult on rejection or null on success / when no schema
+ * is defined for the type (e.g. Sample, unknown types fall through to Atlas).
+ *
+ * Used by `build.createConnection` (create mode) and `manage.updateConnection` (update
+ * mode) to fail fast with a useful message instead of letting Atlas return a generic 400.
+ */
+export function rejectInvalidConnectionConfig(
+    config: Record<string, unknown>,
+    connectionType: string,
+    mode: SchemaMode
+): CallToolResult | null {
+    const schema = getConnectionConfigSchema(connectionType, mode);
+    if (!schema) return null;
+    const result = schema.safeParse(config);
+    if (result.success) return null;
+
+    const unknownFields = result.error.issues
+        .filter((issue) => issue.code === "unrecognized_keys")
+        .flatMap((issue) => ("keys" in issue ? issue.keys : []));
+    const modeNoun = mode === "update" ? "update" : "connection";
+    const unknownFieldList =
+        unknownFields.length > 0
+            ? `Unknown or forbidden fields for ${connectionType} ${modeNoun}: ${unknownFields.join(", ")}.`
+            : `The config contains fields that are not valid for a ${connectionType} ${modeNoun}.`;
+    const guidance =
+        mode === "update"
+            ? "Some fields are immutable after creation (e.g. networking). " +
+              "Remove the unrelated fields, or to change an immutable field delete and recreate the connection."
+            : "Check the connectionType matches the config you provided. " +
+              "Remove the unrelated fields or switch to the correct connectionType.";
+
+    return {
+        content: [
+            {
+                type: "text",
+                text: `Invalid ${connectionType} ${modeNoun} config: ${unknownFieldList}\n\n${guidance}`,
+            },
+        ],
+        isError: true,
+    };
+}
+
+function getCreateSchema(connectionType: string): z.ZodObject<z.ZodRawShape> | null {
     switch (connectionType) {
         case "Kafka":
             return KafkaConnectionConfig;
@@ -138,4 +214,10 @@ export function getConnectionConfigSchema(connectionType: string): z.ZodTypeAny 
         default:
             return null;
     }
+}
+
+export function getConnectionConfigSchema(connectionType: string, mode: SchemaMode = "create"): z.ZodTypeAny | null {
+    const createSchema = getCreateSchema(connectionType);
+    if (!createSchema) return null;
+    return mode === "update" ? toUpdateMode(createSchema) : createSchema;
 }

--- a/src/tools/atlas/streams/connectionConfigs.ts
+++ b/src/tools/atlas/streams/connectionConfigs.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { PrivateLinkConnectionConfig } from "./privateLinkConfig.js";
 
 const AuthenticationSchema = z
     .object({
@@ -106,20 +107,6 @@ export const SchemaRegistryConnectionConfig = z
     })
     .strict();
 
-export const PrivateLinkConnectionConfig = z
-    .object({
-        provider: z.enum(["AWS", "AZURE", "GCP"]),
-        region: z.string().optional(),
-        vendor: z.string().optional(),
-        arn: z.string().optional(),
-        dnsDomain: z.string().optional(),
-        dnsSubDomain: z.array(z.string()).optional(),
-        serviceEndpointId: z.string().optional(),
-        azureResourceIds: z.array(z.string()).optional(),
-        gcpServiceAttachmentUris: z.array(z.string()).optional(),
-    })
-    .passthrough();
-
 /**
  * Fields that cannot be patched on an existing connection. Kept on the create-mode
  * schema (so users can set them at creation time), stripped from the update-mode
@@ -211,6 +198,8 @@ function getCreateSchema(connectionType: string): z.ZodObject<z.ZodRawShape> | n
             return HttpsConnectionConfig;
         case "SchemaRegistry":
             return SchemaRegistryConnectionConfig;
+        case "PrivateLink":
+            return PrivateLinkConnectionConfig;
         default:
             return null;
     }

--- a/src/tools/atlas/streams/manage.ts
+++ b/src/tools/atlas/streams/manage.ts
@@ -4,6 +4,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { OperationType, ToolArgs } from "../../tool.js";
 import { AtlasArgs } from "../../args.js";
 import { ConnectionConfig, StreamsArgs } from "./streamsArgs.js";
+import { rejectInvalidConnectionConfig } from "./connectionConfigs.js";
 import { LogId } from "../../../common/logging/index.js";
 
 const ConnectionTypeEnum = z.enum([
@@ -509,6 +510,19 @@ export class StreamsManageTool extends StreamsToolBase {
         }
 
         const normalizedConfig = ConnectionConfig.parse(op.connectionConfig);
+
+        // Per-type validation in update mode: unknown/immutable fields rejected before Atlas.
+        if (connectionType) {
+            const typeValidationError = rejectInvalidConnectionConfig(
+                normalizedConfig as Record<string, unknown>,
+                connectionType,
+                "update"
+            );
+            if (typeValidationError) {
+                return typeValidationError;
+            }
+        }
+
         await this.apiClient.updateStreamConnection({
             params: { path: { groupId: projectId, tenantName: workspaceName, connectionName: name } },
             // StreamsConnection body is a discriminated union in the OpenAPI types; our

--- a/src/tools/atlas/streams/manage.ts
+++ b/src/tools/atlas/streams/manage.ts
@@ -6,15 +6,111 @@ import { AtlasArgs } from "../../args.js";
 import { ConnectionConfig, StreamsArgs } from "./streamsArgs.js";
 import { LogId } from "../../../common/logging/index.js";
 
-const ManageAction = z.enum([
-    "start-processor",
-    "stop-processor",
-    "modify-processor",
-    "update-workspace",
-    "update-connection",
-    "accept-peering",
-    "reject-peering",
+const ConnectionTypeEnum = z.enum([
+    "Kafka",
+    "Cluster",
+    "S3",
+    "Https",
+    "AWSKinesisDataStreams",
+    "AWSLambda",
+    "SchemaRegistry",
+    "Sample",
 ]);
+
+const StartProcessorOp = z.object({
+    action: z.literal("start-processor"),
+    resourceName: z.string().describe("Processor name. Required."),
+    tier: z
+        .enum(["SP2", "SP5", "SP10", "SP30", "SP50"])
+        .optional()
+        .describe(
+            "Override processing tier for this run. Must not exceed the workspace's max tier. " +
+                "Use `atlas-streams-discover` action='inspect-workspace' to check."
+        ),
+    resumeFromCheckpoint: z
+        .boolean()
+        .optional()
+        .describe(
+            "Resume from last checkpoint on start. Default: true. " +
+                "Set false to reprocess from beginning (drops accumulated window state)."
+        ),
+    startAtOperationTime: z.string().optional().describe("ISO 8601 timestamp to resume from."),
+});
+
+const StopProcessorOp = z.object({
+    action: z.literal("stop-processor"),
+    resourceName: z.string().describe("Processor name. Required."),
+});
+
+const ModifyProcessorOp = z.object({
+    action: z.literal("modify-processor"),
+    resourceName: z.string().describe("Processor name. Required. Processor must be stopped first."),
+    pipeline: z
+        .array(z.record(z.string(), z.unknown()))
+        .optional()
+        .describe(
+            "New pipeline stages, e.g. [{$source: {connectionName: 'src'}}, {$merge: {into: {connectionName: 'dest', db: 'db', coll: 'coll'}}}]. " +
+                "If changing a window stage interval, the processor must be restarted with resumeFromCheckpoint=false."
+        ),
+    dlq: z
+        .object({
+            connectionName: z.string(),
+            db: z.string(),
+            coll: z.string(),
+        })
+        .optional()
+        .describe("New DLQ configuration."),
+    newName: z.string().optional().describe("Rename processor."),
+});
+
+const UpdateWorkspaceOp = z.object({
+    action: z.literal("update-workspace"),
+    newRegion: z
+        .string()
+        .optional()
+        .describe(
+            "New region for workspace. Use Atlas region names " +
+                "(AWS: 'VIRGINIA_USA', Azure: 'eastus2', GCP: 'US_CENTRAL1')."
+        ),
+    newTier: z.enum(["SP2", "SP5", "SP10", "SP30", "SP50"]).optional().describe("New default tier for workspace."),
+});
+
+const UpdateConnectionOp = z.object({
+    action: z.literal("update-connection"),
+    resourceName: z.string().describe("Connection name. Required."),
+    connectionConfig: ConnectionConfig.describe(
+        "Updated connection configuration. Provide only the fields to change. " +
+            "Note: networking config and connection type cannot be modified after creation — to change these, delete and recreate the connection."
+    ),
+    connectionType: ConnectionTypeEnum.optional().describe(
+        "Connection type. Optional — if omitted, the tool looks it up from the existing connection. " +
+            "Provide only when the server cannot infer it."
+    ),
+});
+
+const AcceptPeeringOp = z.object({
+    action: z.literal("accept-peering"),
+    peeringId: z.string().describe("VPC peering connection ID. Required."),
+    requesterAccountId: z.string().describe("AWS account ID of the peering requester. Required."),
+    requesterVpcId: z.string().describe("VPC ID of the peering requester. Required."),
+});
+
+const RejectPeeringOp = z.object({
+    action: z.literal("reject-peering"),
+    peeringId: z.string().describe("VPC peering connection ID. Required."),
+});
+
+const ManageOperation = z.discriminatedUnion("action", [
+    StartProcessorOp,
+    StopProcessorOp,
+    ModifyProcessorOp,
+    UpdateWorkspaceOp,
+    UpdateConnectionOp,
+    AcceptPeeringOp,
+    RejectPeeringOp,
+]);
+
+type ManageOperationArgs = z.infer<typeof ManageOperation>;
 
 export class StreamsManageTool extends StreamsToolBase {
     static toolName = "atlas-streams-manage";
@@ -30,172 +126,97 @@ export class StreamsManageTool extends StreamsToolBase {
         projectId: AtlasArgs.projectId().describe(
             "Atlas project ID. Use atlas-list-projects to find project IDs if not available."
         ),
-        workspaceName: StreamsArgs.workspaceName().describe("Workspace name containing the resource to manage."),
-        action: ManageAction.describe(
-            "Action to perform. One of: " +
-                "'start-processor' — begin or resume processing (requires resourceName). " +
-                "'stop-processor' — pause processing (requires resourceName). " +
-                "'modify-processor' — change pipeline, DLQ, or rename (requires resourceName and at least one of: pipeline, dlq, newName; processor must be stopped first). " +
-                "'update-workspace' — change workspace tier or region. " +
-                "'update-connection' — update connection config (requires resourceName). " +
-                "'accept-peering' — accept a VPC peering request (requires peeringId, requesterAccountId, requesterVpcId). " +
-                "'reject-peering' — reject a VPC peering request (requires peeringId). " +
-                "For peering actions, workspaceName can be any workspace in the project (peering is project-level)."
+        workspaceName: StreamsArgs.workspaceName().describe(
+            "Workspace name containing the resource to manage. For peering actions, any workspace in the project (peering is project-level)."
         ),
-        resourceName: z
-            .string()
-            .optional()
-            .describe("Processor or connection name. Required for processor and connection actions."),
-
-        // start-processor options
-        tier: z
-            .enum(["SP2", "SP5", "SP10", "SP30", "SP50"])
-            .optional()
+        // Note: Although it is not required to wrap the discriminated union in
+        // an array here because we only expect exactly one operation to be
+        // provided here, we unfortunately cannot use the discriminatedUnion as
+        // is because Cursor is unable to construct payload for tool calls where
+        // the input schema contains a discriminated union without such
+        // wrapping. This is a workaround for enabling the tool calls on Cursor.
+        operation: z
+            .array(ManageOperation)
             .describe(
-                "Override processing tier for this run. " +
-                    "Must not exceed the workspace's max tier. Use `atlas-streams-discover` action='inspect-workspace' to check. " +
-                    "Only for 'start-processor'."
+                "The management operation to perform, with its action-specific parameters. " +
+                    "Exactly one operation per call. Supported actions: " +
+                    "'start-processor' — begin/resume processing (requires resourceName). " +
+                    "'stop-processor' — pause processing (requires resourceName). " +
+                    "'modify-processor' — change pipeline, DLQ, or rename (requires resourceName; processor must be stopped first). " +
+                    "'update-workspace' — change workspace tier or region. " +
+                    "'update-connection' — update connection config (requires resourceName and connectionConfig). " +
+                    "'accept-peering' — accept a VPC peering request. " +
+                    "'reject-peering' — reject a VPC peering request."
             ),
-        resumeFromCheckpoint: z
-            .boolean()
-            .optional()
-            .describe(
-                "Resume from last checkpoint on start. Default: true. " +
-                    "Set false to reprocess from beginning (drops accumulated window state). Only for 'start-processor'."
-            ),
-        startAtOperationTime: z
-            .string()
-            .optional()
-            .describe("ISO 8601 timestamp to resume from. Only for 'start-processor'."),
-
-        // modify-processor options
-        pipeline: z
-            .array(z.record(z.string(), z.unknown()))
-            .optional()
-            .describe(
-                "New pipeline stages as an array of objects, e.g. " +
-                    "[{$source: {connectionName: 'src'}}, {$match: {status: 'active'}}, {$merge: {into: {connectionName: 'dest', db: 'db', coll: 'coll'}}}]. " +
-                    "Only for 'modify-processor'. Processor must be stopped first. " +
-                    "If changing a window stage interval, the processor must be restarted with resumeFromCheckpoint=false."
-            ),
-        dlq: z
-            .object({
-                connectionName: z.string(),
-                db: z.string(),
-                coll: z.string(),
-            })
-            .optional()
-            .describe("New DLQ configuration. Only for 'modify-processor'."),
-        newName: z.string().optional().describe("Rename processor. Only for 'modify-processor'."),
-
-        // update-workspace options
-        newRegion: z
-            .string()
-            .optional()
-            .describe(
-                "New region for workspace. Only for 'update-workspace'. Use Atlas region names (e.g. AWS: 'VIRGINIA_USA', Azure: 'eastus2', GCP: 'US_CENTRAL1')."
-            ),
-        newTier: z
-            .enum(["SP2", "SP5", "SP10", "SP30", "SP50"])
-            .optional()
-            .describe("New default tier for workspace. Only for 'update-workspace'."),
-
-        // update-connection options
-        connectionConfig: ConnectionConfig.optional().describe(
-            "Updated connection configuration. Only for 'update-connection'. " +
-                "Provide only the fields to change. " +
-                "Note: networking config and connection type cannot be modified after creation — to change these, delete and recreate the connection."
-        ),
-
-        // peering options
-        peeringId: z
-            .string()
-            .optional()
-            .describe("VPC peering connection ID. Required for 'accept-peering' and 'reject-peering'."),
-        requesterAccountId: z
-            .string()
-            .optional()
-            .describe("AWS account ID of the peering requester. Required for 'accept-peering'."),
-        requesterVpcId: z
-            .string()
-            .optional()
-            .describe("VPC ID of the peering requester. Required for 'accept-peering'."),
     };
 
+    private getOperation(args: ToolArgs<typeof this.argsShape>): ManageOperationArgs {
+        const op = args.operation[0];
+        if (!op) {
+            throw new Error(
+                "No operation provided. Expected exactly one operation entry with an 'action' and its parameters."
+            );
+        }
+        return op;
+    }
+
     protected async execute(args: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
-        switch (args.action) {
+        const op = this.getOperation(args);
+        switch (op.action) {
             case "start-processor":
-                return this.startProcessor(args);
+                return this.startProcessor(args.projectId, args.workspaceName, op);
             case "stop-processor":
-                return this.stopProcessor(args);
+                return this.stopProcessor(args.projectId, args.workspaceName, op);
             case "modify-processor":
-                return this.modifyProcessor(args);
+                return this.modifyProcessor(args.projectId, args.workspaceName, op);
             case "update-workspace":
-                return this.updateWorkspace(args);
+                return this.updateWorkspace(args.projectId, args.workspaceName, op);
             case "update-connection":
-                return this.updateConnection(args);
+                return this.updateConnection(args.projectId, args.workspaceName, op);
             case "accept-peering":
-                return this.acceptPeering(args);
+                return this.acceptPeering(args.projectId, op);
             case "reject-peering":
-                return this.rejectPeering(args);
-            default:
-                return {
-                    content: [{ type: "text", text: `Unknown action: ${args.action as string}` }],
-                    isError: true,
-                };
+                return this.rejectPeering(args.projectId, op);
         }
     }
 
     protected override getConfirmationMessage(args: ToolArgs<typeof this.argsShape>): string {
-        switch (args.action) {
+        const op = this.getOperation(args);
+        switch (op.action) {
             case "start-processor": {
-                const name = this.requireResourceName(args.resourceName, "start-processor");
                 const checkpointWarning =
-                    args.resumeFromCheckpoint === false
+                    op.resumeFromCheckpoint === false
                         ? ` WARNING: resumeFromCheckpoint is false — all accumulated window state will be permanently lost.`
                         : "";
                 return (
-                    `You are about to start processor '${name}' in workspace '${args.workspaceName}'. ` +
+                    `You are about to start processor '${op.resourceName}' in workspace '${args.workspaceName}'. ` +
                     `Starting a processor will begin billing for stream processing usage based on the workspace tier.${checkpointWarning} Proceed?`
                 );
             }
-            case "stop-processor": {
-                const name = this.requireResourceName(args.resourceName, "stop-processor");
-                return `You are about to stop processor '${name}' in workspace '${args.workspaceName}'. In-flight data will complete processing. Proceed?`;
-            }
-            case "modify-processor": {
-                const name = this.requireResourceName(args.resourceName, "modify-processor");
-                return `You are about to modify processor '${name}' in workspace '${args.workspaceName}'. This may affect pipeline behavior. Proceed?`;
-            }
+            case "stop-processor":
+                return `You are about to stop processor '${op.resourceName}' in workspace '${args.workspaceName}'. In-flight data will complete processing. Proceed?`;
+            case "modify-processor":
+                return `You are about to modify processor '${op.resourceName}' in workspace '${args.workspaceName}'. This may affect pipeline behavior. Proceed?`;
             case "update-workspace":
                 return `You are about to update workspace '${args.workspaceName}'. Proceed?`;
-            case "update-connection": {
-                const name = this.requireResourceName(args.resourceName, "update-connection");
-                return `You are about to update connection '${name}' in workspace '${args.workspaceName}'. Proceed?`;
-            }
-            case "accept-peering": {
-                if (!args.peeringId) throw new Error("peeringId is required for 'accept-peering'.");
-                return `You are about to accept VPC peering connection '${args.peeringId}'. Proceed?`;
-            }
-            case "reject-peering": {
-                if (!args.peeringId) throw new Error("peeringId is required for 'reject-peering'.");
-                return `You are about to reject VPC peering connection '${args.peeringId}'. This cannot be undone. Proceed?`;
-            }
+            case "update-connection":
+                return `You are about to update connection '${op.resourceName}' in workspace '${args.workspaceName}'. Proceed?`;
+            case "accept-peering":
+                return `You are about to accept VPC peering connection '${op.peeringId}'. Proceed?`;
+            case "reject-peering":
+                return `You are about to reject VPC peering connection '${op.peeringId}'. This cannot be undone. Proceed?`;
         }
     }
 
-    private requireResourceName(resourceName: string | undefined, context: string): string {
-        if (!resourceName) {
-            throw new Error(`resourceName is required for '${context}'.`);
-        }
-        return resourceName;
-    }
-
-    private async startProcessor(args: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
-        const name = this.requireResourceName(args.resourceName, "start-processor");
+    private async startProcessor(
+        projectId: string,
+        workspaceName: string,
+        op: z.infer<typeof StartProcessorOp>
+    ): Promise<CallToolResult> {
+        const name = op.resourceName;
 
         const processor = await this.apiClient.getStreamProcessor({
-            params: { path: { groupId: args.projectId, tenantName: args.workspaceName, processorName: name } },
+            params: { path: { groupId: projectId, tenantName: workspaceName, processorName: name } },
         });
         if (processor?.state === "STARTED") {
             return {
@@ -209,23 +230,23 @@ export class StreamsManageTool extends StreamsToolBase {
             };
         }
 
-        if (args.tier) {
+        if (op.tier) {
             const tierOrder = ["SP2", "SP5", "SP10", "SP30", "SP50"];
             try {
                 const ws = await this.apiClient.getStreamWorkspace({
-                    params: { path: { groupId: args.projectId, tenantName: args.workspaceName } },
+                    params: { path: { groupId: projectId, tenantName: workspaceName } },
                 });
                 const maxTier = ws?.streamConfig?.maxTierSize;
-                if (maxTier && tierOrder.indexOf(args.tier) > tierOrder.indexOf(maxTier)) {
+                if (maxTier && tierOrder.indexOf(op.tier) > tierOrder.indexOf(maxTier)) {
                     return {
                         content: [
                             {
                                 type: "text",
                                 text:
-                                    `Cannot start processor with tier '${args.tier}' — workspace '${args.workspaceName}' has a maximum tier of '${maxTier}'.\n\n` +
+                                    `Cannot start processor with tier '${op.tier}' — workspace '${workspaceName}' has a maximum tier of '${maxTier}'.\n\n` +
                                     `Options:\n` +
                                     `1. Use a tier ≤ ${maxTier}\n` +
-                                    `2. Raise the workspace max tier first with \`atlas-streams-manage\` action='update-workspace' newTier='${args.tier}'`,
+                                    `2. Raise the workspace max tier first with \`atlas-streams-manage\` action='update-workspace' newTier='${op.tier}'`,
                             },
                         ],
                         isError: true,
@@ -237,28 +258,33 @@ export class StreamsManageTool extends StreamsToolBase {
         }
 
         const hasStartOptions =
-            args.tier !== undefined ||
-            args.resumeFromCheckpoint !== undefined ||
-            args.startAtOperationTime !== undefined;
+            op.tier !== undefined || op.resumeFromCheckpoint !== undefined || op.startAtOperationTime !== undefined;
 
         if (hasStartOptions) {
-            const startBody: Record<string, unknown> = {};
-            if (args.tier !== undefined) startBody.tier = args.tier;
-            if (args.resumeFromCheckpoint !== undefined) startBody.resumeFromCheckpoint = args.resumeFromCheckpoint;
-            if (args.startAtOperationTime !== undefined) startBody.startAtOperationTime = args.startAtOperationTime;
+            const startBody: {
+                tier?: "SP2" | "SP5" | "SP10" | "SP30" | "SP50";
+                resumeFromCheckpoint?: boolean;
+                startAtOperationTime?: string;
+            } = {};
+            if (op.tier !== undefined) startBody.tier = op.tier;
+            if (op.resumeFromCheckpoint !== undefined) startBody.resumeFromCheckpoint = op.resumeFromCheckpoint;
+            if (op.startAtOperationTime !== undefined) startBody.startAtOperationTime = op.startAtOperationTime;
 
             await this.apiClient.startStreamProcessorWith({
-                params: { path: { groupId: args.projectId, tenantName: args.workspaceName, processorName: name } },
+                params: { path: { groupId: projectId, tenantName: workspaceName, processorName: name } },
+                // The Atlas OpenAPI schema types `body` as a literal enum-heavy object; our
+                // validated tier/checkpoint/timestamp values are structurally compatible but
+                // narrowing each field to its literal union buys nothing here.
                 body: startBody as never,
             });
         } else {
             await this.apiClient.startStreamProcessor({
-                params: { path: { groupId: args.projectId, tenantName: args.workspaceName, processorName: name } },
+                params: { path: { groupId: projectId, tenantName: workspaceName, processorName: name } },
             });
         }
 
         const checkpointNote =
-            args.resumeFromCheckpoint === false
+            op.resumeFromCheckpoint === false
                 ? " Starting from the beginning (no checkpoint resume)."
                 : " Resuming from last checkpoint.";
 
@@ -267,7 +293,7 @@ export class StreamsManageTool extends StreamsToolBase {
                 {
                     type: "text",
                     text:
-                        `Processor '${name}' started in workspace '${args.workspaceName}'.${checkpointNote}\n\n` +
+                        `Processor '${name}' started in workspace '${workspaceName}'.${checkpointNote}\n\n` +
                         `Note: Billing for stream processing usage is now active for this processor.\n\n` +
                         `Use \`atlas-streams-discover\` with action 'diagnose-processor' to monitor health. ` +
                         `Use \`atlas-streams-manage\` with action 'stop-processor' to stop billing.`,
@@ -276,12 +302,16 @@ export class StreamsManageTool extends StreamsToolBase {
         };
     }
 
-    private async stopProcessor(args: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
-        const name = this.requireResourceName(args.resourceName, "stop-processor");
+    private async stopProcessor(
+        projectId: string,
+        workspaceName: string,
+        op: z.infer<typeof StopProcessorOp>
+    ): Promise<CallToolResult> {
+        const name = op.resourceName;
 
         try {
             const processor = await this.apiClient.getStreamProcessor({
-                params: { path: { groupId: args.projectId, tenantName: args.workspaceName, processorName: name } },
+                params: { path: { groupId: projectId, tenantName: workspaceName, processorName: name } },
             });
             if (processor?.state === "STOPPED" || processor?.state === "CREATED") {
                 return {
@@ -303,7 +333,7 @@ export class StreamsManageTool extends StreamsToolBase {
         }
 
         await this.apiClient.stopStreamProcessor({
-            params: { path: { groupId: args.projectId, tenantName: args.workspaceName, processorName: name } },
+            params: { path: { groupId: projectId, tenantName: workspaceName, processorName: name } },
         });
 
         return {
@@ -318,11 +348,15 @@ export class StreamsManageTool extends StreamsToolBase {
         };
     }
 
-    private async modifyProcessor(args: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
-        const name = this.requireResourceName(args.resourceName, "modify-processor");
+    private async modifyProcessor(
+        projectId: string,
+        workspaceName: string,
+        op: z.infer<typeof ModifyProcessorOp>
+    ): Promise<CallToolResult> {
+        const name = op.resourceName;
 
         const processor = await this.apiClient.getStreamProcessor({
-            params: { path: { groupId: args.projectId, tenantName: args.workspaceName, processorName: name } },
+            params: { path: { groupId: projectId, tenantName: workspaceName, processorName: name } },
         });
         if (processor?.state === "STARTED") {
             return {
@@ -336,10 +370,14 @@ export class StreamsManageTool extends StreamsToolBase {
             };
         }
 
-        const body: Record<string, unknown> = {};
-        if (args.pipeline) body.pipeline = args.pipeline;
-        if (args.newName) body.name = args.newName;
-        if (args.dlq) body.options = { dlq: args.dlq };
+        const body: {
+            pipeline?: Record<string, unknown>[];
+            name?: string;
+            options?: { dlq: { connectionName: string; db: string; coll: string } };
+        } = {};
+        if (op.pipeline) body.pipeline = op.pipeline;
+        if (op.newName) body.name = op.newName;
+        if (op.dlq) body.options = { dlq: op.dlq };
 
         if (Object.keys(body).length === 0) {
             return {
@@ -354,7 +392,9 @@ export class StreamsManageTool extends StreamsToolBase {
         }
 
         await this.apiClient.updateStreamProcessor({
-            params: { path: { groupId: args.projectId, tenantName: args.workspaceName, processorName: name } },
+            params: { path: { groupId: projectId, tenantName: workspaceName, processorName: name } },
+            // Atlas OpenAPI `pipeline` is typed as a tightly indexed object union our
+            // generic `Record<string, unknown>` pipeline stages can't satisfy.
             body: body as never,
         });
 
@@ -371,13 +411,21 @@ export class StreamsManageTool extends StreamsToolBase {
         };
     }
 
-    private async updateWorkspace(args: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
-        const body: Record<string, unknown> = {};
-        if (args.newRegion) {
+    private async updateWorkspace(
+        projectId: string,
+        workspaceName: string,
+        op: z.infer<typeof UpdateWorkspaceOp>
+    ): Promise<CallToolResult> {
+        const body: {
+            cloudProvider?: string;
+            region?: string;
+            streamConfig?: { tier: string };
+        } = {};
+        if (op.newRegion) {
             // The Atlas API requires cloudProvider alongside region in the update request body.
             // Fetch the current workspace to get the existing cloudProvider.
             const workspace = await this.apiClient.getStreamWorkspace({
-                params: { path: { groupId: args.projectId, tenantName: args.workspaceName } },
+                params: { path: { groupId: projectId, tenantName: workspaceName } },
             });
             const cloudProvider = workspace?.dataProcessRegion?.cloudProvider;
             if (!cloudProvider) {
@@ -394,10 +442,10 @@ export class StreamsManageTool extends StreamsToolBase {
                 };
             }
             body.cloudProvider = cloudProvider;
-            body.region = args.newRegion;
+            body.region = op.newRegion;
         }
-        if (args.newTier) {
-            body.streamConfig = { tier: args.newTier };
+        if (op.newTier) {
+            body.streamConfig = { tier: op.newTier };
         }
 
         if (Object.keys(body).length === 0) {
@@ -413,23 +461,20 @@ export class StreamsManageTool extends StreamsToolBase {
         }
 
         const updated = await this.apiClient.updateStreamWorkspace({
-            params: { path: { groupId: args.projectId, tenantName: args.workspaceName } },
+            params: { path: { groupId: projectId, tenantName: workspaceName } },
+            // Atlas OpenAPI types cloudProvider/region as literal enums and streamConfig.tier
+            // similarly; we validate at the input schema layer so the cast is safe here.
             body: body as never,
         });
 
         const updatedRegion = updated?.dataProcessRegion?.region;
-        if (
-            args.newRegion &&
-            updatedRegion !== undefined &&
-            updatedRegion !== null &&
-            updatedRegion !== args.newRegion
-        ) {
+        if (op.newRegion && updatedRegion !== undefined && updatedRegion !== null && updatedRegion !== op.newRegion) {
             return {
                 content: [
                     {
                         type: "text",
                         text:
-                            `Failed to update workspace region to '${args.newRegion}'. ` +
+                            `Failed to update workspace region to '${op.newRegion}'. ` +
                             `Current region is '${updatedRegion}'. ` +
                             `Verify the region name is valid for the workspace's cloud provider.`,
                     },
@@ -442,26 +487,32 @@ export class StreamsManageTool extends StreamsToolBase {
             content: [
                 {
                     type: "text",
-                    text: `Workspace '${args.workspaceName}' updated. Use \`atlas-streams-discover\` with action 'inspect-workspace' to verify changes.`,
+                    text: `Workspace '${workspaceName}' updated. Use \`atlas-streams-discover\` with action 'inspect-workspace' to verify changes.`,
                 },
             ],
         };
     }
 
-    private async updateConnection(args: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
-        const name = this.requireResourceName(args.resourceName, "update-connection");
+    private async updateConnection(
+        projectId: string,
+        workspaceName: string,
+        op: z.infer<typeof UpdateConnectionOp>
+    ): Promise<CallToolResult> {
+        const name = op.resourceName;
 
-        if (!args.connectionConfig) {
-            throw new Error("connectionConfig is required to update a connection.");
+        let connectionType: string | undefined = op.connectionType;
+        if (!connectionType) {
+            const existing = (await this.apiClient.getStreamConnection({
+                params: { path: { groupId: projectId, tenantName: workspaceName, connectionName: name } },
+            })) as { type?: string };
+            connectionType = existing?.type;
         }
 
-        const { type: connectionType } = (await this.apiClient.getStreamConnection({
-            params: { path: { groupId: args.projectId, tenantName: args.workspaceName, connectionName: name } },
-        })) as { type?: string };
-
-        const normalizedConfig = ConnectionConfig.parse(args.connectionConfig);
+        const normalizedConfig = ConnectionConfig.parse(op.connectionConfig);
         await this.apiClient.updateStreamConnection({
-            params: { path: { groupId: args.projectId, tenantName: args.workspaceName, connectionName: name } },
+            params: { path: { groupId: projectId, tenantName: workspaceName, connectionName: name } },
+            // StreamsConnection body is a discriminated union in the OpenAPI types; our
+            // normalized shape is validated by ConnectionConfig + per-type handling in build.ts.
             body: {
                 ...normalizedConfig,
                 ...(connectionType !== undefined ? { type: connectionType } : {}),
@@ -473,26 +524,18 @@ export class StreamsManageTool extends StreamsToolBase {
             content: [
                 {
                     type: "text",
-                    text: `Connection '${name}' updated in workspace '${args.workspaceName}'.`,
+                    text: `Connection '${name}' updated in workspace '${workspaceName}'.`,
                 },
             ],
         };
     }
 
-    private async acceptPeering(args: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
-        if (!args.peeringId) throw new Error("peeringId is required to accept a VPC peering connection.");
-        if (!args.requesterAccountId) throw new Error("requesterAccountId is required to accept VPC peering.");
-        if (!args.requesterVpcId) throw new Error("requesterVpcId is required to accept VPC peering.");
-
-        const peeringId = args.peeringId;
-        const requesterAccountId = args.requesterAccountId;
-        const requesterVpcId = args.requesterVpcId;
-
+    private async acceptPeering(projectId: string, op: z.infer<typeof AcceptPeeringOp>): Promise<CallToolResult> {
         await this.apiClient.acceptVpcPeeringConnection({
-            params: { path: { groupId: args.projectId, id: peeringId } },
+            params: { path: { groupId: projectId, id: op.peeringId } },
             body: {
-                requesterAccountId,
-                requesterVpcId,
+                requesterAccountId: op.requesterAccountId,
+                requesterVpcId: op.requesterVpcId,
             },
         });
 
@@ -500,24 +543,22 @@ export class StreamsManageTool extends StreamsToolBase {
             content: [
                 {
                     type: "text",
-                    text: `VPC peering connection '${args.peeringId}' accepted. It may take a few minutes to become active.`,
+                    text: `VPC peering connection '${op.peeringId}' accepted. It may take a few minutes to become active.`,
                 },
             ],
         };
     }
 
-    private async rejectPeering(args: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
-        if (!args.peeringId) throw new Error("peeringId is required to reject a VPC peering connection.");
-
+    private async rejectPeering(projectId: string, op: z.infer<typeof RejectPeeringOp>): Promise<CallToolResult> {
         await this.apiClient.rejectVpcPeeringConnection({
-            params: { path: { groupId: args.projectId, id: args.peeringId } },
+            params: { path: { groupId: projectId, id: op.peeringId } },
         });
 
         return {
             content: [
                 {
                     type: "text",
-                    text: `VPC peering connection '${args.peeringId}' rejected.`,
+                    text: `VPC peering connection '${op.peeringId}' rejected.`,
                 },
             ],
         };

--- a/src/tools/atlas/streams/privateLinkConfig.ts
+++ b/src/tools/atlas/streams/privateLinkConfig.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+/**
+ * Input-layer schema for PrivateLink connections.
+ *
+ * PrivateLink has a different lifecycle from generic connections — it hits a
+ * dedicated Atlas endpoint (`createPrivateLinkConnection`), has no update flow
+ * (delete + recreate to change), and the body is a provider-discriminated union.
+ * Kept in its own file so the pattern difference is easy to spot; referenced
+ * from `connectionConfigs.ts`'s type-dispatch switch so every connection type
+ * flows through a single validation entry point.
+ */
+export const PrivateLinkConnectionConfig = z
+    .object({
+        provider: z.enum(["AWS", "AZURE", "GCP"]),
+        region: z.string().optional(),
+        vendor: z.string().optional(),
+        arn: z.string().optional(),
+        dnsDomain: z.string().optional(),
+        dnsSubDomain: z.array(z.string()).optional(),
+        serviceEndpointId: z.string().optional(),
+        azureResourceIds: z.array(z.string()).optional(),
+        gcpServiceAttachmentUris: z.array(z.string()).optional(),
+    })
+    .passthrough();

--- a/src/tools/atlas/streams/streamsToolBase.ts
+++ b/src/tools/atlas/streams/streamsToolBase.ts
@@ -171,8 +171,14 @@ export abstract class StreamsToolBase extends AtlasToolBase {
 
         const data = parsedResult.data;
 
+        // Top-level `action` (discover/teardown) or the first entry of `operation[]` (manage).
         if ("action" in data && typeof data.action === "string") {
             metadata.action = data.action;
+        } else if (Array.isArray(data.operation) && data.operation.length > 0) {
+            const firstOp = data.operation[0] as { action?: unknown };
+            if (typeof firstOp?.action === "string") {
+                metadata.action = firstOp.action;
+            }
         }
         if ("resource" in data && typeof data.resource === "string") {
             metadata.resource = data.resource;

--- a/tests/accuracy/streamsManage.test.ts
+++ b/tests/accuracy/streamsManage.test.ts
@@ -72,9 +72,8 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "start-processor",
                         workspaceName,
-                        resourceName: processorName,
+                        operation: [{ action: "start-processor", resourceName: processorName }],
                     },
                 },
             ],
@@ -89,9 +88,8 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "stop-processor",
                         workspaceName,
-                        resourceName: processorName,
+                        operation: [{ action: "stop-processor", resourceName: processorName }],
                     },
                 },
             ],
@@ -106,9 +104,8 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "stop-processor",
                         workspaceName,
-                        resourceName: processorName,
+                        operation: [{ action: "stop-processor", resourceName: processorName }],
                     },
                     optional: true,
                 },
@@ -116,10 +113,14 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "modify-processor",
                         workspaceName,
-                        resourceName: processorName,
-                        pipeline: Matcher.anyValue,
+                        operation: [
+                            {
+                                action: "modify-processor",
+                                resourceName: processorName,
+                                pipeline: Matcher.anyValue,
+                            },
+                        ],
                     },
                 },
             ],
@@ -134,9 +135,8 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "update-workspace",
                         workspaceName,
-                        newTier: "SP30",
+                        operation: [{ action: "update-workspace", newTier: "SP30" }],
                     },
                 },
             ],
@@ -151,10 +151,14 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "start-processor",
                         workspaceName,
-                        resourceName: processorName,
-                        resumeFromCheckpoint: false,
+                        operation: [
+                            {
+                                action: "start-processor",
+                                resourceName: processorName,
+                                resumeFromCheckpoint: false,
+                            },
+                        ],
                     },
                 },
             ],
@@ -169,10 +173,14 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "modify-processor",
                         workspaceName,
-                        resourceName: processorName,
-                        newName: "etl-v2",
+                        operation: [
+                            {
+                                action: "modify-processor",
+                                resourceName: processorName,
+                                newName: "etl-v2",
+                            },
+                        ],
                     },
                 },
             ],
@@ -188,10 +196,14 @@ describeAccuracyTests(
                     parameters: {
                         projectId,
                         workspaceName,
-                        action: "accept-peering",
-                        peeringId: "pcx-abc123",
-                        requesterAccountId: "123456789012",
-                        requesterVpcId: "vpc-def456",
+                        operation: [
+                            {
+                                action: "accept-peering",
+                                peeringId: "pcx-abc123",
+                                requesterAccountId: "123456789012",
+                                requesterVpcId: "vpc-def456",
+                            },
+                        ],
                     },
                 },
             ],
@@ -207,8 +219,7 @@ describeAccuracyTests(
                     parameters: {
                         projectId,
                         workspaceName,
-                        action: "reject-peering",
-                        peeringId: "pcx-xyz789",
+                        operation: [{ action: "reject-peering", peeringId: "pcx-xyz789" }],
                     },
                 },
             ],
@@ -223,10 +234,8 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "start-processor",
                         workspaceName,
-                        resourceName: processorName,
-                        tier: "SP30",
+                        operation: [{ action: "start-processor", resourceName: processorName, tier: "SP30" }],
                     },
                 },
             ],
@@ -241,9 +250,8 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "update-workspace",
                         workspaceName,
-                        newRegion: Matcher.string(),
+                        operation: [{ action: "update-workspace", newRegion: Matcher.string() }],
                     },
                 },
             ],
@@ -258,14 +266,18 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "modify-processor",
                         workspaceName,
-                        resourceName: processorName,
-                        dlq: {
-                            connectionName: "dlq-cluster",
-                            db: "errors",
-                            coll: "failed_docs",
-                        },
+                        operation: [
+                            {
+                                action: "modify-processor",
+                                resourceName: processorName,
+                                dlq: {
+                                    connectionName: "dlq-cluster",
+                                    db: "errors",
+                                    coll: "failed_docs",
+                                },
+                            },
+                        ],
                     },
                 },
             ],
@@ -280,10 +292,14 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "start-processor",
                         workspaceName,
-                        resourceName: processorName,
-                        startAtOperationTime: "2026-01-15T08:00:00Z",
+                        operation: [
+                            {
+                                action: "start-processor",
+                                resourceName: processorName,
+                                startAtOperationTime: "2026-01-15T08:00:00Z",
+                            },
+                        ],
                     },
                 },
             ],
@@ -303,28 +319,30 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "stop-processor",
                         workspaceName,
-                        resourceName: "etl",
+                        operation: [{ action: "stop-processor", resourceName: "etl" }],
                     },
                 },
                 {
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "modify-processor",
                         workspaceName,
-                        resourceName: "etl",
-                        pipeline: Matcher.anyValue,
+                        operation: [
+                            {
+                                action: "modify-processor",
+                                resourceName: "etl",
+                                pipeline: Matcher.anyValue,
+                            },
+                        ],
                     },
                 },
                 {
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "start-processor",
                         workspaceName,
-                        resourceName: "etl",
+                        operation: [{ action: "start-processor", resourceName: "etl" }],
                     },
                 },
             ],
@@ -340,9 +358,8 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "stop-processor",
                         workspaceName,
-                        resourceName: "etl",
+                        operation: [{ action: "stop-processor", resourceName: "etl" }],
                     },
                     optional: true,
                 },
@@ -350,10 +367,14 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "modify-processor",
                         workspaceName,
-                        resourceName: "etl",
-                        pipeline: Matcher.anyValue,
+                        operation: [
+                            {
+                                action: "modify-processor",
+                                resourceName: "etl",
+                                pipeline: Matcher.anyValue,
+                            },
+                        ],
                     },
                 },
             ],
@@ -404,12 +425,16 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "update-connection",
                         workspaceName,
-                        resourceName: "events",
-                        connectionConfig: {
-                            bootstrapServers: "broker2.example.com:9092,broker3.example.com:9092",
-                        },
+                        operation: [
+                            {
+                                action: "update-connection",
+                                resourceName: "events",
+                                connectionConfig: {
+                                    bootstrapServers: "broker2.example.com:9092,broker3.example.com:9092",
+                                },
+                            },
+                        ],
                     },
                 },
             ],
@@ -424,9 +449,8 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "stop-processor",
                         workspaceName,
-                        resourceName: "etl",
+                        operation: [{ action: "stop-processor", resourceName: "etl" }],
                     },
                     optional: true,
                 },
@@ -434,9 +458,8 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "start-processor",
                         workspaceName,
-                        resourceName: "etl",
+                        operation: [{ action: "start-processor", resourceName: "etl" }],
                     },
                 },
             ],
@@ -451,9 +474,8 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "stop-processor",
                         workspaceName,
-                        resourceName: "rollup",
+                        operation: [{ action: "stop-processor", resourceName: "rollup" }],
                     },
                     optional: true,
                 },
@@ -461,20 +483,28 @@ describeAccuracyTests(
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "modify-processor",
                         workspaceName,
-                        resourceName: "rollup",
-                        pipeline: Matcher.anyValue,
+                        operation: [
+                            {
+                                action: "modify-processor",
+                                resourceName: "rollup",
+                                pipeline: Matcher.anyValue,
+                            },
+                        ],
                     },
                 },
                 {
                     toolName: "atlas-streams-manage",
                     parameters: {
                         projectId,
-                        action: "start-processor",
                         workspaceName,
-                        resourceName: "rollup",
-                        resumeFromCheckpoint: false,
+                        operation: [
+                            {
+                                action: "start-processor",
+                                resourceName: "rollup",
+                                resumeFromCheckpoint: false,
+                            },
+                        ],
                     },
                 },
             ],

--- a/tests/integration/tools/atlas/streams/manage.test.ts
+++ b/tests/integration/tools/atlas/streams/manage.test.ts
@@ -11,7 +11,8 @@ describeWithStreams("atlas-streams-manage", (integration) => {
             expect(tool!.inputSchema.type).toBe("object");
             expect(tool!.inputSchema.properties).toBeDefined();
             expect(tool!.inputSchema.properties).toHaveProperty("projectId");
-            expect(tool!.inputSchema.properties).toHaveProperty("action");
+            expect(tool!.inputSchema.properties).toHaveProperty("workspaceName");
+            expect(tool!.inputSchema.properties).toHaveProperty("operation");
         });
     });
 
@@ -53,8 +54,7 @@ describeWithStreams("atlas-streams-manage", (integration) => {
                     arguments: {
                         projectId: getProjectId(),
                         workspaceName: getWorkspaceName(),
-                        action: "start-processor",
-                        resourceName: processorName,
+                        operation: [{ action: "start-processor", resourceName: processorName }],
                     },
                 });
                 const content = getResponseContent(response.content);
@@ -67,8 +67,7 @@ describeWithStreams("atlas-streams-manage", (integration) => {
                     arguments: {
                         projectId: getProjectId(),
                         workspaceName: getWorkspaceName(),
-                        action: "stop-processor",
-                        resourceName: processorName,
+                        operation: [{ action: "stop-processor", resourceName: processorName }],
                     },
                 });
                 const content = getResponseContent(response.content);
@@ -81,19 +80,23 @@ describeWithStreams("atlas-streams-manage", (integration) => {
                     arguments: {
                         projectId: getProjectId(),
                         workspaceName: getWorkspaceName(),
-                        action: "modify-processor",
-                        resourceName: processorName,
-                        pipeline: [
-                            { $source: { connectionName: "sample_stream_solar" } },
-                            { $match: { device_id: "device_1" } },
+                        operation: [
                             {
-                                $merge: {
-                                    into: {
-                                        connectionName: getClusterConnectionName(),
-                                        db: "test",
-                                        coll: "out",
+                                action: "modify-processor",
+                                resourceName: processorName,
+                                pipeline: [
+                                    { $source: { connectionName: "sample_stream_solar" } },
+                                    { $match: { device_id: "device_1" } },
+                                    {
+                                        $merge: {
+                                            into: {
+                                                connectionName: getClusterConnectionName(),
+                                                db: "test",
+                                                coll: "out",
+                                            },
+                                        },
                                     },
-                                },
+                                ],
                             },
                         ],
                     },
@@ -109,8 +112,7 @@ describeWithStreams("atlas-streams-manage", (integration) => {
                     arguments: {
                         projectId: getProjectId(),
                         workspaceName: getWorkspaceName(),
-                        action: "update-workspace",
-                        newTier: "SP30",
+                        operation: [{ action: "update-workspace", newTier: "SP30" }],
                     },
                 });
                 const content = getResponseContent(response.content);

--- a/tests/integration/tools/atlas/streams/workflow.test.ts
+++ b/tests/integration/tools/atlas/streams/workflow.test.ts
@@ -49,13 +49,17 @@ describeWithStreams("atlas-streams workflows", (integration) => {
                     arguments: {
                         projectId: getProjectId(),
                         workspaceName: getWorkspaceName(),
-                        action: "update-connection",
-                        resourceName: connectionName,
-                        connectionConfig: {
-                            name: connectionName,
-                            type: "Https",
-                            url: "https://httpbin.org/get",
-                        },
+                        operation: [
+                            {
+                                action: "update-connection",
+                                resourceName: connectionName,
+                                connectionConfig: {
+                                    name: connectionName,
+                                    type: "Https",
+                                    url: "https://httpbin.org/get",
+                                },
+                            },
+                        ],
                     },
                 });
                 const content = getResponseContent(response.content);
@@ -215,8 +219,7 @@ describeWithStreams("atlas-streams workflows", (integration) => {
                         arguments: {
                             projectId: getProjectId(),
                             workspaceName: getWorkspaceName(),
-                            action: "start-processor",
-                            resourceName: processorName,
+                            operation: [{ action: "start-processor", resourceName: processorName }],
                         },
                     });
                     const content = getResponseContent(response.content);
@@ -229,8 +232,7 @@ describeWithStreams("atlas-streams workflows", (integration) => {
                         arguments: {
                             projectId: getProjectId(),
                             workspaceName: getWorkspaceName(),
-                            action: "stop-processor",
-                            resourceName: processorName,
+                            operation: [{ action: "stop-processor", resourceName: processorName }],
                         },
                     });
                     const content = getResponseContent(response.content);
@@ -243,19 +245,23 @@ describeWithStreams("atlas-streams workflows", (integration) => {
                         arguments: {
                             projectId: getProjectId(),
                             workspaceName: getWorkspaceName(),
-                            action: "modify-processor",
-                            resourceName: processorName,
-                            pipeline: [
-                                { $source: { connectionName: "sample_stream_solar" } },
-                                { $match: { device_id: "device_1" } },
+                            operation: [
                                 {
-                                    $merge: {
-                                        into: {
-                                            connectionName: getClusterConnectionName(),
-                                            db: "test",
-                                            coll: "out",
+                                    action: "modify-processor",
+                                    resourceName: processorName,
+                                    pipeline: [
+                                        { $source: { connectionName: "sample_stream_solar" } },
+                                        { $match: { device_id: "device_1" } },
+                                        {
+                                            $merge: {
+                                                into: {
+                                                    connectionName: getClusterConnectionName(),
+                                                    db: "test",
+                                                    coll: "out",
+                                                },
+                                            },
                                         },
-                                    },
+                                    ],
                                 },
                             ],
                         },
@@ -286,8 +292,7 @@ describeWithStreams("atlas-streams workflows", (integration) => {
                         arguments: {
                             projectId: getProjectId(),
                             workspaceName: getWorkspaceName(),
-                            action: "update-workspace",
-                            newTier: "SP30",
+                            operation: [{ action: "update-workspace", newTier: "SP30" }],
                         },
                     });
                     const content = getResponseContent(response.content);

--- a/tests/integration/tools/atlas/streams/workflow.test.ts
+++ b/tests/integration/tools/atlas/streams/workflow.test.ts
@@ -54,8 +54,6 @@ describeWithStreams("atlas-streams workflows", (integration) => {
                                 action: "update-connection",
                                 resourceName: connectionName,
                                 connectionConfig: {
-                                    name: connectionName,
-                                    type: "Https",
                                     url: "https://httpbin.org/get",
                                 },
                             },

--- a/tests/unit/tools/atlas/streams/build.test.ts
+++ b/tests/unit/tools/atlas/streams/build.test.ts
@@ -349,6 +349,58 @@ describe("StreamsBuildTool", () => {
             ).rejects.toThrow("connectionType is required");
         });
 
+        describe("per-type config validation (pre-Atlas-API)", () => {
+            it("rejects Kafka connection with Cluster-only field clusterName before calling Atlas", async () => {
+                const result = await exec({
+                    ...baseArgs,
+                    resource: "connection",
+                    connectionName: "kafka-bad",
+                    connectionType: "Kafka",
+                    connectionConfig: {
+                        bootstrapServers: "broker1:9092",
+                        authentication: { mechanism: "PLAIN", username: "u", password: "p" },
+                        security: { protocol: "SASL_SSL" },
+                        clusterName: "wrong-field",
+                    },
+                });
+                expect(result.isError).toBe(true);
+                expect((result.content[0] as { text: string }).text.toLowerCase()).toContain("clustername");
+                expect(mockApiClient.createStreamConnection).not.toHaveBeenCalled();
+            });
+
+            it("rejects S3 connection with Kafka-only field bootstrapServers before calling Atlas", async () => {
+                const result = await exec({
+                    ...baseArgs,
+                    resource: "connection",
+                    connectionName: "s3-bad",
+                    connectionType: "S3",
+                    connectionConfig: {
+                        aws: { roleArn: "arn:aws:iam::123:role/r" },
+                        bootstrapServers: "broker1:9092",
+                    },
+                });
+                expect(result.isError).toBe(true);
+                expect((result.content[0] as { text: string }).text.toLowerCase()).toContain("bootstrapservers");
+                expect(mockApiClient.createStreamConnection).not.toHaveBeenCalled();
+            });
+
+            it("rejects Https connection with SchemaRegistry-only field schemaRegistryUrls", async () => {
+                const result = await exec({
+                    ...baseArgs,
+                    resource: "connection",
+                    connectionName: "https-bad",
+                    connectionType: "Https",
+                    connectionConfig: {
+                        url: "https://webhook.example.com",
+                        schemaRegistryUrls: ["https://sr.example.com"],
+                    },
+                });
+                expect(result.isError).toBe(true);
+                expect((result.content[0] as { text: string }).text.toLowerCase()).toContain("schemaregistryurls");
+                expect(mockApiClient.createStreamConnection).not.toHaveBeenCalled();
+            });
+        });
+
         it("should warn about PENDING state when connection uses PrivateLink", async () => {
             const result = await exec({
                 ...baseArgs,

--- a/tests/unit/tools/atlas/streams/connectionConfigs.test.ts
+++ b/tests/unit/tools/atlas/streams/connectionConfigs.test.ts
@@ -181,7 +181,7 @@ describe("per-type connection config schemas", () => {
         });
     });
 
-    describe("getConnectionConfigSchema", () => {
+    describe("getConnectionConfigSchema (create mode, default)", () => {
         it("returns KafkaConnectionConfig for 'Kafka'", () => {
             expect(getConnectionConfigSchema("Kafka")).toBe(KafkaConnectionConfig);
         });
@@ -216,6 +216,65 @@ describe("per-type connection config schemas", () => {
 
         it("returns null for an unknown connection type", () => {
             expect(getConnectionConfigSchema("totally-made-up")).toBeNull();
+        });
+    });
+
+    describe("getConnectionConfigSchema(type, 'update')", () => {
+        it("returns an update-mode schema for Kafka", () => {
+            const schema = getConnectionConfigSchema("Kafka", "update");
+            expect(schema).not.toBeNull();
+            // Update mode must reject the immutable `networking` field
+            const result = schema!.safeParse({
+                networking: { access: { type: "PRIVATE_LINK", connectionId: "pl-1" } },
+            });
+            expect(result.success).toBe(false);
+        });
+
+        it("returns an update-mode schema for Cluster", () => {
+            const schema = getConnectionConfigSchema("Cluster", "update");
+            expect(schema).not.toBeNull();
+            const result = schema!.safeParse({
+                networking: { access: { type: "PRIVATE_LINK" } },
+            });
+            expect(result.success).toBe(false);
+        });
+
+        it("Kafka update mode accepts patching only authentication.password", () => {
+            const schema = getConnectionConfigSchema("Kafka", "update");
+            const result = schema!.safeParse({
+                authentication: { password: "new-password" },
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("Kafka update mode still rejects cross-type fields", () => {
+            const schema = getConnectionConfigSchema("Kafka", "update");
+            const result = schema!.safeParse({ clusterName: "wrong-type" });
+            expect(result.success).toBe(false);
+        });
+
+        it("S3 update mode accepts patching only aws.roleArn", () => {
+            const schema = getConnectionConfigSchema("S3", "update");
+            const result = schema!.safeParse({
+                aws: { roleArn: "arn:aws:iam::123:role/new-role" },
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("Https update mode accepts patching only headers", () => {
+            const schema = getConnectionConfigSchema("Https", "update");
+            const result = schema!.safeParse({
+                headers: { "x-api-key": "new-key" },
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("returns null for 'Sample' in update mode too", () => {
+            expect(getConnectionConfigSchema("Sample", "update")).toBeNull();
+        });
+
+        it("returns null for an unknown connection type in update mode", () => {
+            expect(getConnectionConfigSchema("totally-made-up", "update")).toBeNull();
         });
     });
 });

--- a/tests/unit/tools/atlas/streams/connectionConfigs.test.ts
+++ b/tests/unit/tools/atlas/streams/connectionConfigs.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from "vitest";
+import {
+    KafkaConnectionConfig,
+    ClusterConnectionConfig,
+    S3ConnectionConfig,
+    KinesisConnectionConfig,
+    LambdaConnectionConfig,
+    HttpsConnectionConfig,
+    SchemaRegistryConnectionConfig,
+    PrivateLinkConnectionConfig,
+    getConnectionConfigSchema,
+} from "../../../../../src/tools/atlas/streams/connectionConfigs.js";
+
+describe("per-type connection config schemas", () => {
+    describe("KafkaConnectionConfig", () => {
+        it("accepts a minimal Kafka config with bootstrapServers", () => {
+            const result = KafkaConnectionConfig.safeParse({
+                bootstrapServers: "broker1:9092,broker2:9092",
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("rejects Kafka config with Cluster-only field clusterName", () => {
+            const result = KafkaConnectionConfig.safeParse({
+                bootstrapServers: "broker1:9092",
+                clusterName: "my-cluster",
+            });
+            expect(result.success).toBe(false);
+        });
+
+        it("rejects Kafka config with Https-only field url", () => {
+            const result = KafkaConnectionConfig.safeParse({
+                bootstrapServers: "broker1:9092",
+                url: "https://webhook.example.com",
+            });
+            expect(result.success).toBe(false);
+        });
+
+        it("accepts Kafka config with authentication and security sub-objects", () => {
+            const result = KafkaConnectionConfig.safeParse({
+                bootstrapServers: "broker1:9092",
+                authentication: { mechanism: "PLAIN", username: "u", password: "p" },
+                security: { protocol: "SASL_SSL" },
+            });
+            expect(result.success).toBe(true);
+        });
+    });
+
+    describe("ClusterConnectionConfig", () => {
+        it("accepts a minimal Cluster config with clusterName", () => {
+            const result = ClusterConnectionConfig.safeParse({ clusterName: "my-cluster" });
+            expect(result.success).toBe(true);
+        });
+
+        it("rejects Cluster config with Kafka-only field bootstrapServers", () => {
+            const result = ClusterConnectionConfig.safeParse({
+                clusterName: "my-cluster",
+                bootstrapServers: "broker1:9092",
+            });
+            expect(result.success).toBe(false);
+        });
+
+        it("accepts optional dbRoleToExecute", () => {
+            const result = ClusterConnectionConfig.safeParse({
+                clusterName: "my-cluster",
+                dbRoleToExecute: { role: "readWriteAnyDatabase", type: "BUILT_IN" },
+            });
+            expect(result.success).toBe(true);
+        });
+    });
+
+    describe("S3ConnectionConfig", () => {
+        it("accepts a minimal S3 config with aws.roleArn", () => {
+            const result = S3ConnectionConfig.safeParse({
+                aws: { roleArn: "arn:aws:iam::123:role/r" },
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("rejects S3 config with Kafka-only field bootstrapServers", () => {
+            const result = S3ConnectionConfig.safeParse({
+                aws: { roleArn: "arn:aws:iam::123:role/r" },
+                bootstrapServers: "broker1:9092",
+            });
+            expect(result.success).toBe(false);
+        });
+    });
+
+    describe("KinesisConnectionConfig", () => {
+        it("accepts a minimal Kinesis config with aws.roleArn", () => {
+            const result = KinesisConnectionConfig.safeParse({
+                aws: { roleArn: "arn:aws:iam::123:role/r" },
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("rejects Kinesis config with Cluster-only field clusterName", () => {
+            const result = KinesisConnectionConfig.safeParse({
+                aws: { roleArn: "arn:aws:iam::123:role/r" },
+                clusterName: "my-cluster",
+            });
+            expect(result.success).toBe(false);
+        });
+    });
+
+    describe("LambdaConnectionConfig", () => {
+        it("accepts a minimal Lambda config with aws.roleArn", () => {
+            const result = LambdaConnectionConfig.safeParse({
+                aws: { roleArn: "arn:aws:iam::123:role/r" },
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("rejects Lambda config with Https-only field url", () => {
+            const result = LambdaConnectionConfig.safeParse({
+                aws: { roleArn: "arn:aws:iam::123:role/r" },
+                url: "https://webhook.example.com",
+            });
+            expect(result.success).toBe(false);
+        });
+    });
+
+    describe("HttpsConnectionConfig", () => {
+        it("accepts a minimal Https config with url", () => {
+            const result = HttpsConnectionConfig.safeParse({ url: "https://webhook.example.com" });
+            expect(result.success).toBe(true);
+        });
+
+        it("rejects Https config with Kafka-only field bootstrapServers", () => {
+            const result = HttpsConnectionConfig.safeParse({
+                url: "https://webhook.example.com",
+                bootstrapServers: "broker1:9092",
+            });
+            expect(result.success).toBe(false);
+        });
+
+        it("accepts Https config with headers", () => {
+            const result = HttpsConnectionConfig.safeParse({
+                url: "https://webhook.example.com",
+                headers: { "x-api-key": "abc" },
+            });
+            expect(result.success).toBe(true);
+        });
+    });
+
+    describe("SchemaRegistryConnectionConfig", () => {
+        it("accepts a minimal SchemaRegistry config with URLs and auth", () => {
+            const result = SchemaRegistryConnectionConfig.safeParse({
+                provider: "CONFLUENT",
+                schemaRegistryUrls: ["https://sr.example.com"],
+                schemaRegistryAuthentication: { type: "USER_INFO", username: "u", password: "p" },
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("rejects SchemaRegistry config with Kafka-only field bootstrapServers", () => {
+            const result = SchemaRegistryConnectionConfig.safeParse({
+                schemaRegistryUrls: ["https://sr.example.com"],
+                bootstrapServers: "broker1:9092",
+            });
+            expect(result.success).toBe(false);
+        });
+    });
+
+    describe("PrivateLinkConnectionConfig", () => {
+        it("accepts AWS PrivateLink with required fields", () => {
+            const result = PrivateLinkConnectionConfig.safeParse({
+                provider: "AWS",
+                region: "us-east-1",
+                vendor: "CONFLUENT",
+                serviceEndpointId: "com.amazonaws.vpce.us-east-1.vpce-svc-xyz",
+                dnsDomain: "example.confluent.cloud",
+                dnsSubDomain: [],
+            });
+            expect(result.success).toBe(true);
+        });
+
+        it("rejects PrivateLink config without provider", () => {
+            const result = PrivateLinkConnectionConfig.safeParse({ region: "us-east-1" });
+            expect(result.success).toBe(false);
+        });
+    });
+
+    describe("getConnectionConfigSchema", () => {
+        it("returns KafkaConnectionConfig for 'Kafka'", () => {
+            expect(getConnectionConfigSchema("Kafka")).toBe(KafkaConnectionConfig);
+        });
+
+        it("returns ClusterConnectionConfig for 'Cluster'", () => {
+            expect(getConnectionConfigSchema("Cluster")).toBe(ClusterConnectionConfig);
+        });
+
+        it("returns S3ConnectionConfig for 'S3'", () => {
+            expect(getConnectionConfigSchema("S3")).toBe(S3ConnectionConfig);
+        });
+
+        it("returns KinesisConnectionConfig for 'AWSKinesisDataStreams'", () => {
+            expect(getConnectionConfigSchema("AWSKinesisDataStreams")).toBe(KinesisConnectionConfig);
+        });
+
+        it("returns LambdaConnectionConfig for 'AWSLambda'", () => {
+            expect(getConnectionConfigSchema("AWSLambda")).toBe(LambdaConnectionConfig);
+        });
+
+        it("returns HttpsConnectionConfig for 'Https'", () => {
+            expect(getConnectionConfigSchema("Https")).toBe(HttpsConnectionConfig);
+        });
+
+        it("returns SchemaRegistryConnectionConfig for 'SchemaRegistry'", () => {
+            expect(getConnectionConfigSchema("SchemaRegistry")).toBe(SchemaRegistryConnectionConfig);
+        });
+
+        it("returns null for 'Sample' (no config fields to validate)", () => {
+            expect(getConnectionConfigSchema("Sample")).toBeNull();
+        });
+
+        it("returns null for an unknown connection type", () => {
+            expect(getConnectionConfigSchema("totally-made-up")).toBeNull();
+        });
+    });
+});

--- a/tests/unit/tools/atlas/streams/connectionConfigs.test.ts
+++ b/tests/unit/tools/atlas/streams/connectionConfigs.test.ts
@@ -7,7 +7,6 @@ import {
     LambdaConnectionConfig,
     HttpsConnectionConfig,
     SchemaRegistryConnectionConfig,
-    PrivateLinkConnectionConfig,
     getConnectionConfigSchema,
 } from "../../../../../src/tools/atlas/streams/connectionConfigs.js";
 
@@ -158,25 +157,6 @@ describe("per-type connection config schemas", () => {
                 schemaRegistryUrls: ["https://sr.example.com"],
                 bootstrapServers: "broker1:9092",
             });
-            expect(result.success).toBe(false);
-        });
-    });
-
-    describe("PrivateLinkConnectionConfig", () => {
-        it("accepts AWS PrivateLink with required fields", () => {
-            const result = PrivateLinkConnectionConfig.safeParse({
-                provider: "AWS",
-                region: "us-east-1",
-                vendor: "CONFLUENT",
-                serviceEndpointId: "com.amazonaws.vpce.us-east-1.vpce-svc-xyz",
-                dnsDomain: "example.confluent.cloud",
-                dnsSubDomain: [],
-            });
-            expect(result.success).toBe(true);
-        });
-
-        it("rejects PrivateLink config without provider", () => {
-            const result = PrivateLinkConnectionConfig.safeParse({ region: "us-east-1" });
             expect(result.success).toBe(false);
         });
     });

--- a/tests/unit/tools/atlas/streams/manage.test.ts
+++ b/tests/unit/tools/atlas/streams/manage.test.ts
@@ -553,6 +553,13 @@ describe("StreamsManageTool", () => {
         });
 
         it("should normalize schemaRegistryUrls string to array", async () => {
+            // Use a SchemaRegistry-typed existing connection so update-mode validation passes.
+            mockApiClient.getStreamConnection = vi.fn().mockResolvedValue({
+                name: "conn1",
+                type: "SchemaRegistry",
+                state: "READY",
+            });
+
             await exec({
                 ...baseArgs,
                 action: "update-connection",
@@ -613,6 +620,64 @@ describe("StreamsManageTool", () => {
             expect(mockApiClient.updateStreamConnection).toHaveBeenCalledWith({
                 params: { path: { groupId: "proj1", tenantName: "ws1", connectionName: "conn1" } },
                 body: expect.objectContaining({ type: "Kafka" }),
+            });
+        });
+
+        describe("per-type update validation (pre-Atlas-API)", () => {
+            it("rejects patching a Kafka connection with Cluster-only field clusterName", async () => {
+                mockApiClient.getStreamConnection = vi.fn().mockResolvedValue({
+                    name: "conn1",
+                    type: "Kafka",
+                    state: "READY",
+                });
+
+                const result = await exec({
+                    ...baseArgs,
+                    action: "update-connection",
+                    resourceName: "conn1",
+                    connectionConfig: { clusterName: "wrong-type" },
+                });
+
+                expect(result.isError).toBe(true);
+                expect((result.content[0] as { text: string }).text.toLowerCase()).toContain("clustername");
+                expect(mockApiClient.updateStreamConnection).not.toHaveBeenCalled();
+            });
+
+            it("rejects patching the immutable networking field on a Kafka connection", async () => {
+                mockApiClient.getStreamConnection = vi.fn().mockResolvedValue({
+                    name: "conn1",
+                    type: "Kafka",
+                    state: "READY",
+                });
+
+                const result = await exec({
+                    ...baseArgs,
+                    action: "update-connection",
+                    resourceName: "conn1",
+                    connectionConfig: {
+                        networking: { access: { type: "PRIVATE_LINK", connectionId: "pl-1" } },
+                    },
+                });
+
+                expect(result.isError).toBe(true);
+                expect((result.content[0] as { text: string }).text.toLowerCase()).toContain("networking");
+                expect(mockApiClient.updateStreamConnection).not.toHaveBeenCalled();
+            });
+
+            it("uses connectionType from args when existing connection lookup fails to return a type", async () => {
+                mockApiClient.getStreamConnection = vi.fn().mockResolvedValue({ name: "conn1", state: "READY" });
+
+                const result = await exec({
+                    ...baseArgs,
+                    action: "update-connection",
+                    resourceName: "conn1",
+                    connectionType: "Cluster",
+                    connectionConfig: { bootstrapServers: "broker:9092" }, // Kafka-only field
+                });
+
+                expect(result.isError).toBe(true);
+                expect((result.content[0] as { text: string }).text.toLowerCase()).toContain("bootstrapservers");
+                expect(mockApiClient.updateStreamConnection).not.toHaveBeenCalled();
             });
         });
     });

--- a/tests/unit/tools/atlas/streams/manage.test.ts
+++ b/tests/unit/tools/atlas/streams/manage.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod";
 import type { ToolConstructorParams } from "../../../../../src/tools/tool.js";
 import { StreamsManageTool } from "../../../../../src/tools/atlas/streams/manage.js";
 import type { Session } from "../../../../../src/common/session.js";
@@ -80,8 +81,18 @@ describe("StreamsManageTool", () => {
     });
 
     const baseArgs = { projectId: "proj1", workspaceName: "ws1" };
+    // Tests were written against the pre-MCP-483 flat args shape. The tool now
+    // expects { projectId, workspaceName, operation: [{ action, ...params }] }. This
+    // helper wraps flat test args into the new shape so we don't churn every assertion.
+    const wrap = (args: Record<string, unknown>): Record<string, unknown> => {
+        const { projectId, workspaceName, action, ...rest } = args;
+        if (action === undefined) {
+            return { projectId, workspaceName, operation: [] };
+        }
+        return { projectId, workspaceName, operation: [{ action, ...rest }] };
+    };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-    const exec = (args: Record<string, unknown>) => tool["execute"](args as never);
+    const exec = (args: Record<string, unknown>) => tool["execute"](wrap(args) as never);
 
     describe("start-processor", () => {
         it("should start a STOPPED processor", async () => {
@@ -147,15 +158,6 @@ describe("StreamsManageTool", () => {
                     body: expect.objectContaining({ resumeFromCheckpoint: false }),
                 })
             );
-        });
-
-        it("should throw when resourceName is missing", async () => {
-            await expect(
-                exec({
-                    ...baseArgs,
-                    action: "start-processor",
-                })
-            ).rejects.toThrow("resourceName is required");
         });
 
         it("should return error when tier exceeds workspace max tier", async () => {
@@ -592,26 +594,6 @@ describe("StreamsManageTool", () => {
             );
         });
 
-        it("should throw when connectionConfig is missing", async () => {
-            await expect(
-                exec({
-                    ...baseArgs,
-                    action: "update-connection",
-                    resourceName: "conn1",
-                })
-            ).rejects.toThrow("connectionConfig is required");
-        });
-
-        it("should throw when resourceName is missing", async () => {
-            await expect(
-                exec({
-                    ...baseArgs,
-                    action: "update-connection",
-                    connectionConfig: { bootstrapServers: "broker:9092" },
-                })
-            ).rejects.toThrow("resourceName is required");
-        });
-
         it("should include connection type from existing connection in the update body", async () => {
             mockApiClient.getStreamConnection = vi.fn().mockResolvedValue({
                 name: "conn1",
@@ -651,44 +633,11 @@ describe("StreamsManageTool", () => {
             });
             expect((result.content[0] as { text: string }).text).toContain("accepted");
         });
-
-        it("should throw when peeringId is missing", async () => {
-            await expect(
-                exec({
-                    ...baseArgs,
-                    action: "accept-peering",
-                    requesterAccountId: "123",
-                    requesterVpcId: "vpc-1",
-                })
-            ).rejects.toThrow("peeringId is required");
-        });
-
-        it("should throw when requesterAccountId is missing", async () => {
-            await expect(
-                exec({
-                    ...baseArgs,
-                    action: "accept-peering",
-                    peeringId: "peer-1",
-                    requesterVpcId: "vpc-1",
-                })
-            ).rejects.toThrow("requesterAccountId is required");
-        });
-
-        it("should throw when requesterVpcId is missing", async () => {
-            await expect(
-                exec({
-                    ...baseArgs,
-                    action: "accept-peering",
-                    peeringId: "peer-1",
-                    requesterAccountId: "123",
-                })
-            ).rejects.toThrow("requesterVpcId is required");
-        });
     });
 
     describe("getConfirmationMessage", () => {
         // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-        const confirmMsg = (args: Record<string, unknown>) => tool["getConfirmationMessage"](args as never);
+        const confirmMsg = (args: Record<string, unknown>) => tool["getConfirmationMessage"](wrap(args) as never);
 
         it("should include billing warning for start-processor", () => {
             const msg = confirmMsg({
@@ -787,17 +736,6 @@ describe("StreamsManageTool", () => {
             expect(msg).toContain("cannot be undone");
             expect(msg).toContain("peer-1");
         });
-
-        it("should throw when resourceName is missing for processor actions", () => {
-            for (const action of ["start-processor", "stop-processor", "modify-processor", "update-connection"]) {
-                expect(() => confirmMsg({ ...baseArgs, action })).toThrow("resourceName is required");
-            }
-        });
-
-        it("should throw when peeringId is missing for peering actions", () => {
-            expect(() => confirmMsg({ ...baseArgs, action: "accept-peering" })).toThrow("peeringId is required");
-            expect(() => confirmMsg({ ...baseArgs, action: "reject-peering" })).toThrow("peeringId is required");
-        });
     });
 
     describe("reject-peering", () => {
@@ -813,26 +751,58 @@ describe("StreamsManageTool", () => {
             });
             expect((result.content[0] as { text: string }).text).toContain("rejected");
         });
+    });
 
-        it("should throw when peeringId is missing", async () => {
-            await expect(
-                exec({
-                    ...baseArgs,
-                    action: "reject-peering",
-                })
-            ).rejects.toThrow("peeringId is required");
+    describe("schema validation", () => {
+        const validProjectId = "507f1f77bcf86cd799439011";
+        const validBase = { projectId: validProjectId, workspaceName: "ws1" };
+        const parse = (args: Record<string, unknown>): { success: boolean } =>
+            z.object(tool["argsShape"]).safeParse(args);
+
+        it.each([
+            ["start-processor without resourceName", { action: "start-processor" }],
+            ["stop-processor without resourceName", { action: "stop-processor" }],
+            ["modify-processor without resourceName", { action: "modify-processor" }],
+            ["update-connection without connectionConfig", { action: "update-connection", resourceName: "c1" }],
+            ["update-connection without resourceName", { action: "update-connection", connectionConfig: {} }],
+            [
+                "accept-peering without peeringId",
+                { action: "accept-peering", requesterAccountId: "123", requesterVpcId: "vpc-1" },
+            ],
+            [
+                "accept-peering without requesterAccountId",
+                { action: "accept-peering", peeringId: "p1", requesterVpcId: "vpc-1" },
+            ],
+            [
+                "accept-peering without requesterVpcId",
+                { action: "accept-peering", peeringId: "p1", requesterAccountId: "123" },
+            ],
+            ["reject-peering without peeringId", { action: "reject-peering" }],
+            ["unknown action", { action: "invalid-action" }],
+        ])("rejects %s", (_desc, operation) => {
+            const result = parse({ ...validBase, operation: [operation] });
+            expect(result.success).toBe(false);
+        });
+
+        it("accepts empty operation array at schema level (runtime surfaces missing-op error)", () => {
+            const result = parse({ ...validBase, operation: [] });
+            expect(result.success).toBe(true);
+        });
+
+        it("accepts valid start-processor operation", () => {
+            const result = parse({
+                ...validBase,
+                operation: [{ action: "start-processor", resourceName: "p1", tier: "SP10" }],
+            });
+            expect(result.success).toBe(true);
         });
     });
 
-    describe("unknown action", () => {
-        it("should return error for unknown action", async () => {
-            const result = await exec({
-                ...baseArgs,
-                action: "unknown-action",
-            });
-
-            expect(result.isError).toBe(true);
-            expect((result.content[0] as { text: string }).text).toContain("Unknown action");
+    describe("execute with missing operation", () => {
+        it("throws when operation array is empty", async () => {
+            await expect(tool["execute"]({ ...baseArgs, operation: [] } as never)).rejects.toThrow(
+                "No operation provided"
+            );
         });
     });
 });

--- a/tests/unit/tools/atlas/streams/privateLinkConfig.test.ts
+++ b/tests/unit/tools/atlas/streams/privateLinkConfig.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { PrivateLinkConnectionConfig } from "../../../../../src/tools/atlas/streams/privateLinkConfig.js";
+import { getConnectionConfigSchema } from "../../../../../src/tools/atlas/streams/connectionConfigs.js";
+
+describe("PrivateLinkConnectionConfig", () => {
+    it("accepts AWS PrivateLink with required fields", () => {
+        const result = PrivateLinkConnectionConfig.safeParse({
+            provider: "AWS",
+            region: "us-east-1",
+            vendor: "CONFLUENT",
+            serviceEndpointId: "com.amazonaws.vpce.us-east-1.vpce-svc-xyz",
+            dnsDomain: "example.confluent.cloud",
+            dnsSubDomain: [],
+        });
+        expect(result.success).toBe(true);
+    });
+
+    it("rejects PrivateLink config without provider", () => {
+        const result = PrivateLinkConnectionConfig.safeParse({ region: "us-east-1" });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects PrivateLink config with invalid provider value", () => {
+        const result = PrivateLinkConnectionConfig.safeParse({ provider: "ORACLE" });
+        expect(result.success).toBe(false);
+    });
+
+    it("is registered in the connection config dispatch for 'PrivateLink'", () => {
+        expect(getConnectionConfigSchema("PrivateLink")).toBe(PrivateLinkConnectionConfig);
+    });
+});


### PR DESCRIPTION
## Proposed changes

Refactors `atlas-streams-manage` and `atlas-streams-build` input schemas to use `z.discriminatedUnion`, so the LLM sees per-action (and per-connection-type) parameters instead of a flat bag of every possible field. Matches the prior-art pattern used by `export`, `createIndex`, and `explain`.

**No behavioral change** — same tool names, same actions, same accepted params. JSON input shape changes (see Migration below).

### What changed

- **`atlas-streams-manage`**: `argsShape.operation` is now `z.array(z.discriminatedUnion("action", [...]))` over the 7 actions. Each variant exposes only its relevant params.
- **`atlas-streams-build`**: 8 per-type connection config schemas (new file `connectionConfigs.ts`), selected post-parse by `connectionType`. Invalid field combinations are rejected before the Atlas API is called, so the LLM gets a useful error instead of a generic Atlas 400.
- **`atlas-streams-manage` `update-connection`**: same per-type validation applied in **update mode** — immutable fields (e.g. `networking`) forbidden on PATCH, all remaining fields become optional. One schema, two modes, derived via `.omit().partial()` — no duplication when new connection types are added.
- **`as never` casts** reduced to Atlas API-boundary calls only (OpenAPI strict types are structurally incompatible with our validated `Record<string, unknown>` shape). Remaining casts have inline comments explaining why.

### Migration (JSON input shape)

Before:
```json
{ "projectId": "...", "workspaceName": "ws", "action": "start-processor", "resourceName": "p" }
```

After:
```json
{ "projectId": "...", "workspaceName": "ws", "operation": [{ "action": "start-processor", "resourceName": "p" }] }
```

The array wrapping follows the existing workaround used by `export` / `createIndex` / `explain` for Cursor compatibility.

### Commits (reviewable in order)

1. `refactor(MCP-483): rewrite atlas-streams-manage with discriminated-union input schema`
2. `refactor(MCP-483): validate atlas-streams-build connectionConfig against per-type schemas`
3. `refactor(MCP-483): derive update-mode connection schemas + wire into manage.updateConnection`

### Scope

**In:** MCP-483 only.
**Out:** Output schemas on streams tools (next PR), `get-logs` re-enable, CPA list, VPC peering reads, `diagnose-output`, credentials research.

### Ticket

[MCP-483](https://jira.mongodb.org/browse/MCP-483) — part of the [STREAMS-2341](https://jira.mongodb.org/browse/STREAMS-2341) epic.

## Checklist

- [x] 866 unit tests passing (+46 over baseline)
- [x] Typecheck and lint clean
- [x] Accuracy-test fixtures rewritten to the new `operation: [{action, ...}]` shape
- [x] Integration test shapes updated
- [x] MCP Inspector end-to-end smoke: new shape works; old flat shape rejected with clear Zod error; `update-connection` rejects cross-type and immutable fields with useful messages before reaching Atlas
- [ ] Accuracy tests against `gpt-4o` (triggered by the `accuracy-tests` label)
- [ ] Live streams integration tests in CI
- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)