### PR TITLE
fix: apply mongosh CLI options (e.g. oidcTrustedEndpoint) in connect-tool path

### DIFF
--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from "events";
 import { MongoServerError } from "mongodb";
 import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import { generateConnectionInfoFromCliArgs, type ConnectionInfo } from "@mongosh/arg-parser";
-import { CliOptionsSchema as MongoshCliOptionsSchema } from "@mongosh/arg-parser/arg-parser";
 import type { DeviceId } from "../helpers/deviceId.js";
 import { type UserConfig } from "./config/userConfig.js";
 import { MongoDBError, ErrorCodes } from "./errors.js";
@@ -273,15 +272,6 @@ export class MCPConnectionManager extends ConnectionManager {
         this.deviceId = deviceId;
     }
 
-    private getMongoshUserConfig(): Partial<UserConfig> {
-        const mongoshKeys = Object.keys(MongoshCliOptionsSchema.shape) as (keyof UserConfig)[];
-        return Object.fromEntries(
-            mongoshKeys
-                .filter((key) => this.userConfig[key] !== undefined)
-                .map((key) => [key, this.userConfig[key]])
-        ) as Partial<UserConfig>;
-    }
-
     /**
      * Opens a new MongoDB connection from the supplied {@link ConnectionSettings},
      * disconnecting any prior connection first.
@@ -323,7 +313,7 @@ export class MCPConnectionManager extends ConnectionManager {
                   }
                 : generateConnectionInfoFromCliArgs({
                       ...defaultDriverOptions,
-                      ...this.getMongoshUserConfig(),
+                      ...this.userConfig,
                       connectionSpecifier: settings.connectionString,
                   });
 

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "events";
 import { MongoServerError } from "mongodb";
 import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import { generateConnectionInfoFromCliArgs, type ConnectionInfo } from "@mongosh/arg-parser";
+import { CliOptionsSchema as MongoshCliOptionsSchema } from "@mongosh/arg-parser/arg-parser";
 import type { DeviceId } from "../helpers/deviceId.js";
 import { type UserConfig } from "./config/userConfig.js";
 import { MongoDBError, ErrorCodes } from "./errors.js";
@@ -272,6 +273,15 @@ export class MCPConnectionManager extends ConnectionManager {
         this.deviceId = deviceId;
     }
 
+    private getMongoshUserConfig(): Partial<UserConfig> {
+        const mongoshKeys = Object.keys(MongoshCliOptionsSchema.shape) as (keyof UserConfig)[];
+        return Object.fromEntries(
+            mongoshKeys
+                .filter((key) => this.userConfig[key] !== undefined)
+                .map((key) => [key, this.userConfig[key]])
+        ) as Partial<UserConfig>;
+    }
+
     /**
      * Opens a new MongoDB connection from the supplied {@link ConnectionSettings},
      * disconnecting any prior connection first.
@@ -313,6 +323,7 @@ export class MCPConnectionManager extends ConnectionManager {
                   }
                 : generateConnectionInfoFromCliArgs({
                       ...defaultDriverOptions,
+                      ...this.getMongoshUserConfig(),
                       connectionSpecifier: settings.connectionString,
                   });
 

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -313,6 +313,7 @@ export class MCPConnectionManager extends ConnectionManager {
                   }
                 : generateConnectionInfoFromCliArgs({
                       ...defaultDriverOptions,
+                      /** TODO: Currently we're passing the entire user config to make it apply the mongosh CLI commands that were passed in. We should consider seperating the fields in the future. */
                       ...this.userConfig,
                       connectionSpecifier: settings.connectionString,
                   });

--- a/tests/integration/common/connectionManager.oidc.test.ts
+++ b/tests/integration/common/connectionManager.oidc.test.ts
@@ -1,11 +1,10 @@
-import { generateConnectionInfoFromCliArgs } from "@mongosh/arg-parser";
 import type { TestContext } from "vitest";
 import { describe, beforeEach, afterAll, it, expect, vi } from "vitest";
 import semver from "semver";
 import process from "process";
 import type { MongoDBIntegrationTestCase } from "../tools/mongodb/mongodbHelpers.js";
 import { describeWithMongoDB, isCommunityServer, getServerVersion } from "../tools/mongodb/mongodbHelpers.js";
-import { defaultTestConfig, responseAsText, timeout, waitUntil } from "../helpers.js";
+import { connect, defaultTestConfig, responseAsText, timeout, waitUntil } from "../helpers.js";
 import type { ConnectionStateConnected, ConnectionStateConnecting } from "../../../src/common/connectionManager.js";
 import type { UserConfig } from "../../../src/common/config/userConfig.js";
 import path from "path";
@@ -139,28 +138,10 @@ describe.skipIf(process.platform !== "linux")("ConnectionManager OIDC Tests", as
 
                     const connectionManager = integration.mcpServer().session
                         .connectionManager as TestConnectionManager;
-                    // disconnect on purpose doesn't change the state if it was failed to avoid losing
-                    // information in production.
                     await connectionManager.disconnect();
-                    // for testing, force disconnecting AND setting the connection to closed to reset the
-                    // state of the connection manager
                     connectionManager.changeState("connection-close", { tag: "disconnected" });
 
-                    // Note: Instead of using `integration.connectMcpClient`,
-                    // we're connecting straight using Session because
-                    // `integration.connectMcpClient` uses `connect` tool which
-                    // does not work the same way as connect on server start up.
-                    // So to mimic the same functionality as that of server
-                    // startup we call the connectToMongoDB the same way as the
-                    // `Server.connectToConfigConnectionString` does.
-                    const connectionInfo = generateConnectionInfoFromCliArgs({
-                        ...oidcConfig,
-                        connectionSpecifier: integration.connectionString(),
-                    });
-
-                    expect(connectionInfo.driverOptions.oidc?.redirectURI).toBe("http://localhost:0/");
-
-                    await integration.mcpServer().session.connectToMongoDB(connectionInfo);
+                    await connect(integration.mcpClient(), integration.connectionString());
                 }, DEFAULT_TIMEOUT);
 
                 addCb?.(oidcIt);

--- a/tests/integration/common/connectionManager.oidc.test.ts
+++ b/tests/integration/common/connectionManager.oidc.test.ts
@@ -138,7 +138,11 @@ describe.skipIf(process.platform !== "linux")("ConnectionManager OIDC Tests", as
 
                     const connectionManager = integration.mcpServer().session
                         .connectionManager as TestConnectionManager;
+                    // disconnect on purpose doesn't change the state if it was failed to avoid losing
+                    // information in production.
                     await connectionManager.disconnect();
+                    // for testing, force disconnecting AND setting the connection to closed to reset the
+                    // state of the connection manager
                     connectionManager.changeState("connection-close", { tag: "disconnected" });
 
                     await connect(integration.mcpClient(), integration.connectionString());

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -257,7 +257,7 @@ export function getResponseElements(content: unknown): ResponseElement[] {
 export async function connect(client: Client, connectionString: string): Promise<void> {
     await client.callTool({
         name: "connect",
-        arguments: { connectionStringOrClusterName: connectionString },
+        arguments: { connectionString },
     });
 }
 

--- a/tests/integration/tools/mongodb/connect/connect.test.ts
+++ b/tests/integration/tools/mongodb/connect/connect.test.ts
@@ -102,17 +102,22 @@ describeWithMongoDB(
             });
         });
 
-        it("should be able to connect to next connection and not use the connect options of the connection setup during server boot", async () => {
+        it("should connect to the provided connection string while applying user config driver options", async () => {
             const newConnectionString = `${integration.connectionString()}`;
-            // Note: The connect function is called with OIDC options for the
-            // configured string
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const expectedDriverOptions = expect.objectContaining({
+                applyProxyToOIDC: true,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                oidc: expect.objectContaining({ openBrowser: { command: "not-a-browser" } }),
+                productDocsLink: "https://github.com/mongodb-js/mongodb-mcp-server/",
+                productName: "MongoDB MCP",
+                proxy: { useEnvironmentVariableProxies: true },
+            });
+
             expect(connectFnSpy).toHaveBeenNthCalledWith(
                 1,
                 expect.stringContaining(`${integration.connectionString()}/?directConnection=true`),
-                expect.objectContaining({
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    oidc: expect.objectContaining({ openBrowser: { command: "not-a-browser" } }),
-                }),
+                expectedDriverOptions,
                 undefined,
                 expect.anything()
             );
@@ -129,16 +134,10 @@ describeWithMongoDB(
             // for OIDC handling.
             expect(content).toContain("Successfully connected");
 
-            // Now that we're connected lets verify the config
-            // Note: The connect function is called with OIDC options for the
-            // configured string
             expect(connectFnSpy).toHaveBeenNthCalledWith(
                 2,
                 expect.stringContaining(`${integration.connectionString()}`),
-                expect.not.objectContaining({
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                    oidc: expect.objectContaining({ openBrowser: { command: "not-a-browser" } }),
-                }),
+                expectedDriverOptions,
                 undefined,
                 expect.anything()
             );

--- a/tests/unit/common/connectionManager.oidc-trusted-endpoint.test.ts
+++ b/tests/unit/common/connectionManager.oidc-trusted-endpoint.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { generateConnectionInfoFromCliArgs } from "@mongosh/arg-parser";
+import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import { MCPConnectionManager } from "../../../src/common/connectionManager.js";
+import { defaultTestConfig } from "../../integration/helpers.js";
+
+vi.mock("@mongosh/service-provider-node-driver");
+vi.mock("@mongosh/arg-parser", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@mongosh/arg-parser")>();
+    return {
+        ...actual,
+        generateConnectionInfoFromCliArgs: vi.fn(actual.generateConnectionInfoFromCliArgs),
+    };
+});
+
+const mockGenerateFn = vi.mocked(generateConnectionInfoFromCliArgs);
+const MockNodeDriverServiceProvider = vi.mocked(NodeDriverServiceProvider);
+
+describe("MCPConnectionManager.connect() — mongosh CLI option propagation", () => {
+    beforeEach(() => {
+        mockGenerateFn.mockClear();
+        MockNodeDriverServiceProvider.connect = vi.fn().mockResolvedValue({} as unknown as NodeDriverServiceProvider);
+    });
+
+    it("passes oidcTrustedEndpoint from userConfig when no driverOptions are provided", async () => {
+        const userConfig = {
+            ...defaultTestConfig,
+            oidcTrustedEndpoint: true,
+        };
+
+        const manager = new MCPConnectionManager(userConfig, {} as any, { get: async () => "test-device-id" });
+
+        const connectionString = "mongodb://localhost:27017/";
+
+        await manager.connect({ connectionString }).catch(() => {});
+
+        expect(mockGenerateFn).toHaveBeenCalledWith(
+            expect.objectContaining({
+                oidcTrustedEndpoint: true,
+                connectionSpecifier: expect.stringContaining("mongodb://localhost:27017/"),
+            })
+        );
+    });
+
+    it("does NOT pass oidcTrustedEndpoint when it is not set in userConfig", async () => {
+        const userConfig = {
+            ...defaultTestConfig,
+            oidcTrustedEndpoint: undefined,
+        };
+
+        const manager = new MCPConnectionManager(userConfig, {} as any, { get: async () => "test-device-id" });
+
+        const connectionString = "mongodb://localhost:27017/";
+
+        await manager.connect({ connectionString }).catch(() => {});
+
+        expect(mockGenerateFn).toHaveBeenCalledWith(
+            expect.not.objectContaining({ oidcTrustedEndpoint: true })
+        );
+    });
+});

--- a/tests/unit/common/connectionManager.oidc-trusted-endpoint.test.ts
+++ b/tests/unit/common/connectionManager.oidc-trusted-endpoint.test.ts
@@ -28,7 +28,7 @@ describe("MCPConnectionManager.connect() — mongosh CLI option propagation", ()
             oidcTrustedEndpoint: true,
         };
 
-        const manager = new MCPConnectionManager(userConfig, {} as any, { get: async () => "test-device-id" });
+        const manager = new MCPConnectionManager(userConfig, {} as any, { get: async () => "test-device-id" } as any);
 
         const connectionString = "mongodb://localhost:27017/";
 
@@ -48,7 +48,7 @@ describe("MCPConnectionManager.connect() — mongosh CLI option propagation", ()
             oidcTrustedEndpoint: undefined,
         };
 
-        const manager = new MCPConnectionManager(userConfig, {} as any, { get: async () => "test-device-id" });
+        const manager = new MCPConnectionManager(userConfig, {} as any, { get: async () => "test-device-id" } as any);
 
         const connectionString = "mongodb://localhost:27017/";
 

--- a/tests/unit/common/connectionManager.oidc-trusted-endpoint.test.ts
+++ b/tests/unit/common/connectionManager.oidc-trusted-endpoint.test.ts
@@ -6,6 +6,7 @@ import { defaultTestConfig } from "../../integration/helpers.js";
 
 vi.mock("@mongosh/service-provider-node-driver");
 vi.mock("@mongosh/arg-parser", async (importOriginal) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     const actual = await importOriginal<typeof import("@mongosh/arg-parser")>();
     return {
         ...actual,
@@ -28,7 +29,13 @@ describe("MCPConnectionManager.connect() — mongosh CLI option propagation", ()
             oidcTrustedEndpoint: true,
         };
 
-        const manager = new MCPConnectionManager(userConfig, {} as any, { get: async () => "test-device-id" } as any);
+        const manager = new MCPConnectionManager(
+            userConfig,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+            {} as any,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+            { get: async () => Promise.resolve("test-device-id") } as any
+        );
 
         const connectionString = "mongodb://localhost:27017/";
 
@@ -37,6 +44,7 @@ describe("MCPConnectionManager.connect() — mongosh CLI option propagation", ()
         expect(mockGenerateFn).toHaveBeenCalledWith(
             expect.objectContaining({
                 oidcTrustedEndpoint: true,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 connectionSpecifier: expect.stringContaining("mongodb://localhost:27017/"),
             })
         );
@@ -48,7 +56,13 @@ describe("MCPConnectionManager.connect() — mongosh CLI option propagation", ()
             oidcTrustedEndpoint: undefined,
         };
 
-        const manager = new MCPConnectionManager(userConfig, {} as any, { get: async () => "test-device-id" } as any);
+        const manager = new MCPConnectionManager(
+            userConfig,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+            {} as any,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+            { get: async () => Promise.resolve("test-device-id") } as any
+        );
 
         const connectionString = "mongodb://localhost:27017/";
 

--- a/tests/unit/common/connectionManager.oidc-trusted-endpoint.test.ts
+++ b/tests/unit/common/connectionManager.oidc-trusted-endpoint.test.ts
@@ -54,8 +54,6 @@ describe("MCPConnectionManager.connect() — mongosh CLI option propagation", ()
 
         await manager.connect({ connectionString }).catch(() => {});
 
-        expect(mockGenerateFn).toHaveBeenCalledWith(
-            expect.not.objectContaining({ oidcTrustedEndpoint: true })
-        );
+        expect(mockGenerateFn).toHaveBeenCalledWith(expect.not.objectContaining({ oidcTrustedEndpoint: true }));
     });
 });


### PR DESCRIPTION
When a user calls the MCP 'connect' tool with a non-Atlas MongoDB host
and MONGODB-OIDC auth, the driver raised:

  MongoInvalidArgumentError: Host 'foo.example.com' is not valid for OIDC
  authentication with ALLOWED_HOSTS of '*.mongodb.net,...'

Root cause: generateConnectionInfoFromCliArgs was called with only
defaultDriverOptions, omitting the mongosh CLI options stored in
userConfig. The startup (connectToConfiguredConnection) path already
spread the full userConfig; this commit makes the connect-tool path
consistent by extracting the mongosh-specific subset via
getMongoshUserConfig() and merging it in.

Fixes: the existing OIDC integration test workaround comment at
tests/integration/common/connectionManager.oidc.test.ts:~142

NOTE: i wrote this PR with Claude Code, i verified this works with my case (mongodb running on k8s, the mcp is running also in k8s, the client is a local claude code session that is using connect tool)
## Checklist

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
