### PR TITLE
chore: group vitest deps together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,10 @@ updates:
         patterns:
           - ai
           - "@ai-sdk/*"
+      vitest:
+        patterns:
+          - vitest
+          - "@vitest/*"
     versioning-strategy: increase
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Proposed changes

Per title - we're just grouping the vitest deps so dependabot upgrades them together.