### PR TITLE
fix(v2): use native fetch in OIDC curl.mjs fixture

### DIFF
--- a/tests/integration/fixtures/curl.mjs
+++ b/tests/integration/fixtures/curl.mjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import fetch from "node-fetch";
 
 if (process.env.MONGOSH_E2E_TEST_CURL_ALLOW_INVALID_TLS) {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";


### PR DESCRIPTION
## Summary

- `node-fetch` was removed from root `package.json` dependencies in v2 (moved into `packages/atlas-api-client`), but `tests/integration/fixtures/curl.mjs` still imported it
- In pnpm's strict isolation model, `node-fetch` is no longer resolvable from the root, so when the MongoDB OIDC driver spawns `curl.mjs` to complete the auth-code browser flow, the import fails
- The auth flow silently errors, the connection state never reaches `"connected"`, and `waitUntil<ConnectionStateConnected>` polls until the 60s timeout
- Device-flow tests pass because they never spawn `curl.mjs` (`browser: false`)

## Fix

Drop the `node-fetch` import and use the native `fetch` API, which is available in Node.js ≥ 18 (project requires ≥ 20).