### PR TITLE
chore: make mcp-types package public

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Publish to NPM
         run: |
           pnpm publish --tag ${{ needs.check.outputs.RELEASE_CHANNEL }} --no-git-checks
-          pnpm -r --filter './packages/*' publish --tag ${{ needs.check.outputs.RELEASE_CHANNEL }} --no-git-checks
+          pnpm -r --filter './packages/*' publish --tag ${{ needs.check.outputs.RELEASE_CHANNEL }} --no-git-checks --access public
 
       - name: Generate AI release summary
         id: ai-summary

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@mongodb-js/mcp-types",
   "version": "1.11.0-prerelease.2",
-  "private": true,
   "type": "module",
   "description": "Shared TypeScript types and interfaces for MongoDB MCP server packages",
   "exports": {


### PR DESCRIPTION
## Proposed changes

Fixes the publish workflow by marking the types package as non-private, as well as explicitly pass in --access public when publishing scoped packages.