### PR TITLE
chore: fixup mcp-types package.json

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Publish to NPM
         run: |
           pnpm publish --tag ${{ needs.check.outputs.RELEASE_CHANNEL }} --no-git-checks
-          pnpm -r --filter './packages/*' publish --tag ${{ needs.check.outputs.RELEASE_CHANNEL }} --no-git-checks --access public
+          pnpm -r --filter './packages/*' publish --tag ${{ needs.check.outputs.RELEASE_CHANNEL }} --no-git-checks
 
       - name: Generate AI release summary
         id: ai-summary

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@mongodb-js/mcp-types",
+  "description": "Shared TypeScript types and interfaces for MongoDB MCP server packages",
   "version": "1.11.0-prerelease.2",
   "type": "module",
-  "description": "Shared TypeScript types and interfaces for MongoDB MCP server packages",
+  "license": "Apache-2.0",
+  "author": "MongoDB <info@mongodb.com>",
+  "repository": {
+    "url": "https://github.com/mongodb-js/mongodb-mcp-server.git",
+    "directory": "packages/metrics"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Follow-up for https://github.com/mongodb-js/mongodb-mcp-server/pull/1156 since that got merged without addressing the comments.