### PR TITLE
chore: MCP Expose Flex clusters in list tool CLOUDP-397238

### DIFF
--- a/src/tools/atlas/read/listClusters.ts
+++ b/src/tools/atlas/read/listClusters.ts
@@ -41,15 +41,27 @@ export class ListClustersTool extends AtlasToolBase {
                 throw new Error(`Project with ID "${projectId}" not found.`);
             }
 
-            const data = await this.apiClient.listClusters({
-                params: {
-                    path: {
-                        groupId: project.id || "",
+            const [clustersResult, flexClustersResult] = await Promise.allSettled([
+                this.apiClient.listClusters({
+                    params: {
+                        path: {
+                            groupId: project.id || "",
+                        },
                     },
-                },
-            });
+                }),
+                this.apiClient.listFlexClusters({
+                    params: {
+                        path: {
+                            groupId: project.id || "",
+                        },
+                    },
+                }),
+            ]);
 
-            return this.formatClustersTable(project, data);
+            const clusters = clustersResult.status === "fulfilled" ? clustersResult.value : undefined;
+            const flexClusters = flexClustersResult.status === "fulfilled" ? flexClustersResult.value : undefined;
+
+            return this.formatClustersTable(project, clusters, flexClusters);
         }
     }
 

--- a/src/tools/atlas/read/listClusters.ts
+++ b/src/tools/atlas/read/listClusters.ts
@@ -92,8 +92,8 @@ export class ListClustersTool extends AtlasToolBase {
 
     private formatClustersTable(
         project: Group,
-        clusters?: PaginatedClusterDescription20240805,
-        flexClusters?: PaginatedFlexClusters20241113
+        clusters: PaginatedClusterDescription20240805 | undefined,
+        flexClusters: PaginatedFlexClusters20241113 | undefined
     ): CallToolResult {
         // Check if both traditional clusters and flex clusters are absent
         if (!clusters?.results?.length && !flexClusters?.results?.length) {

--- a/src/tools/atlas/update/upgradeCluster.ts
+++ b/src/tools/atlas/update/upgradeCluster.ts
@@ -11,6 +11,11 @@ import type { AtlasClusterConnectionInfo } from "../../../common/connectionInfo.
 
 const ALLOWED_PROVIDER_REGEX = /^[A-Z_]+$/;
 
+const REGION_RECOMMENDATIONS = `Common region mappings by provider (default recommendation: AWS US_EAST_1):
+AWS: "East Coast"/"Virginia"/"US East" → US_EAST_1, "Ohio" → US_EAST_2, "California"/"West Coast" → US_WEST_2, "Southeast Asia"/"APAC"/"Singapore" → AP_SOUTHEAST_1, "Europe"/"EU"/"Ireland" → EU_WEST_1.
+GCP: "Central US" → CENTRAL_US, "Western US" → WESTERN_US, "Southeast Asia"/"APAC" → SOUTHEASTERN_ASIA_PACIFIC, "Europe"/"EU" → WESTERN_EUROPE.
+AZURE: "East US" → US_EAST_2, "West US" → US_WEST_2, "Europe"/"EU" → EUROPE_NORTH.`;
+
 // Hardcoded defaults for all dedicated (M10) upgrade paths.
 // provider and region are the only fields callers may override.
 const DEDICATED_CLUSTER_DEFAULTS = {
@@ -137,8 +142,7 @@ async function resolveClusterInfo(
 
 export class UpgradeClusterTool extends AtlasToolBase {
     static toolName = "atlas-upgrade-cluster";
-    public description =
-        "Upgrade a MongoDB Atlas cluster tier. Upgrades Free (M0) clusters to Flex or M10 Dedicated, or Flex clusters to M10 Dedicated. The upgrade path is determined automatically from the current tier unless overridden with targetTier.";
+    public description = `Upgrade a MongoDB Atlas cluster tier. Upgrades Free (M0) clusters to Flex or M10 Dedicated, or Flex clusters to M10 Dedicated. The upgrade path is determined automatically from the current tier unless overridden with targetTier. Note to LLM: If provider and region are not already known, ask for both together in a single question before calling this tool. ${REGION_RECOMMENDATIONS}`;
     static operationType: OperationType = "update";
     public argsShape = {
         projectId: AtlasArgs.projectId()

--- a/tests/integration/tools/atlas/clusters.test.ts
+++ b/tests/integration/tools/atlas/clusters.test.ts
@@ -102,8 +102,12 @@ describeWithAtlas("clusters", (integration) => {
             });
 
             it("returns clusters by project", async () => {
-                const projectId = getProjectId();
+                const session = integration.mcpServer().session;
+                assertApiClientIsAvailable(session);
+                const listClustersSpy = vitest.spyOn(session.apiClient, "listClusters");
+                const listFlexClustersSpy = vitest.spyOn(session.apiClient, "listFlexClusters");
 
+                const projectId = getProjectId();
                 const response = await integration
                     .mcpClient()
                     .callTool({ name: "atlas-list-clusters", arguments: { projectId } });
@@ -112,6 +116,39 @@ describeWithAtlas("clusters", (integration) => {
                 expect(content).toContain("<untrusted-user-data-");
                 expect(content).toMatch(/Found \d+ clusters in project/);
                 expect(content).toContain(projectId);
+                expect(listClustersSpy).toHaveBeenCalledTimes(1);
+                expect(listFlexClustersSpy).toHaveBeenCalledTimes(1);
+            });
+
+            it("returns clusters when listFlexClusters fails", async () => {
+                const session = integration.mcpServer().session;
+                assertApiClientIsAvailable(session);
+                vitest
+                    .spyOn(session.apiClient, "listFlexClusters")
+                    .mockRejectedValue(new Error("Flex clusters not available"));
+
+                const projectId = getProjectId();
+                const response = await integration
+                    .mcpClient()
+                    .callTool({ name: "atlas-list-clusters", arguments: { projectId } });
+
+                const content = getResponseContent(response.content);
+                expect(content).toMatch(/Found \d+ clusters in project/);
+                expect(content).toContain(projectId);
+            });
+
+            it("returns clusters when listClusters fails", async () => {
+                const session = integration.mcpServer().session;
+                assertApiClientIsAvailable(session);
+                vitest.spyOn(session.apiClient, "listClusters").mockRejectedValue(new Error("Clusters not available"));
+
+                const projectId = getProjectId();
+                const response = await integration
+                    .mcpClient()
+                    .callTool({ name: "atlas-list-clusters", arguments: { projectId } });
+
+                const content = getResponseContent(response.content);
+                expect(content).toBeDefined();
             });
         });
 


### PR DESCRIPTION
## Proposed changes
After QA session for upgrade tool and alerts hook, we saw issues:

- [x] List tool does not show flex clusters
- [x] Add more detail to upgrade tool regarding valid cluster configurations

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
