### PR TITLE
chore: lib export changes to support sticky sessions work - CLOUDP-397025

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -747,6 +747,17 @@ export interface LogPayload {
     noRedaction?: boolean | LoggerType | LoggerType[];
 }
 
+// @public (undocumented)
+export class MCPConnectionManager extends ConnectionManager {
+    constructor(userConfig: UserConfig, logger: LoggerBase, deviceId: DeviceId, bus?: EventEmitter);
+    // (undocumented)
+    close(): Promise<void>;
+    // (undocumented)
+    connect(settings: ConnectionSettings): Promise<AnyConnectionState>;
+    // (undocumented)
+    disconnect(): Promise<ConnectionStateDisconnected | ConnectionStateErrored>;
+}
+
 // Warning: (ae-forgotten-export) The symbol "ExpressBasedHttpServer" needs to be exported by the entry point lib.d.ts
 //
 // @public (undocumented)

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -747,7 +747,7 @@ export interface LogPayload {
     noRedaction?: boolean | LoggerType | LoggerType[];
 }
 
-// @public (undocumented)
+// @public
 export class MCPConnectionManager extends ConnectionManager {
     constructor(userConfig: UserConfig, logger: LoggerBase, deviceId: DeviceId, bus?: EventEmitter);
     // (undocumented)

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -667,22 +667,22 @@ export interface ISessionStore<T extends CloseableTransport = CloseableTransport
     getSession(sessionId: string): Promise<T | undefined>;
 }
 
-// @public (undocumented)
+// @public
 export const JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION = -32005;
 
-// @public (undocumented)
+// @public
 export const JSON_RPC_ERROR_CODE_INVALID_REQUEST = -32004;
 
 // @public
 export const JSON_RPC_ERROR_CODE_PROCESSING_REQUEST_FAILED = -32000;
 
-// @public (undocumented)
+// @public
 export const JSON_RPC_ERROR_CODE_SESSION_ID_INVALID = -32002;
 
-// @public (undocumented)
+// @public
 export const JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED = -32001;
 
-// @public (undocumented)
+// @public
 export const JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND = -32003;
 
 // @public
@@ -750,11 +750,8 @@ export interface LogPayload {
 // @public
 export class MCPConnectionManager extends ConnectionManager {
     constructor(userConfig: UserConfig, logger: LoggerBase, deviceId: DeviceId, bus?: EventEmitter);
-    // (undocumented)
     close(): Promise<void>;
-    // (undocumented)
     connect(settings: ConnectionSettings): Promise<AnyConnectionState>;
-    // (undocumented)
     disconnect(): Promise<ConnectionStateDisconnected | ConnectionStateErrored>;
 }
 

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -667,6 +667,24 @@ export interface ISessionStore<T extends CloseableTransport = CloseableTransport
     getSession(sessionId: string): Promise<T | undefined>;
 }
 
+// @public (undocumented)
+export const JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION = -32005;
+
+// @public (undocumented)
+export const JSON_RPC_ERROR_CODE_INVALID_REQUEST = -32004;
+
+// @public
+export const JSON_RPC_ERROR_CODE_PROCESSING_REQUEST_FAILED = -32000;
+
+// @public (undocumented)
+export const JSON_RPC_ERROR_CODE_SESSION_ID_INVALID = -32002;
+
+// @public (undocumented)
+export const JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED = -32001;
+
+// @public (undocumented)
+export const JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND = -32003;
+
 // @public
 export class Keychain {
     constructor();
@@ -734,6 +752,8 @@ export interface LogPayload {
 // @public (undocumented)
 export class MCPHttpServer<TUserConfig extends UserConfig = UserConfig, TContext = unknown> extends ExpressBasedHttpServer {
     constructor(input: MCPHttpServerConstructorArgs<TUserConfig, TContext>);
+    // (undocumented)
+    protected readonly sessionStore: ISessionStore<StreamableHTTPServerTransport>;
     // (undocumented)
     protected setupMiddlewares(): void;
     // (undocumented)

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -228,6 +228,22 @@ export abstract class ConnectionManager {
     abstract close(): Promise<void>;
 }
 
+/**
+ * Default {@link ConnectionManager} implementation used by the MongoDB MCP
+ * server.
+ *
+ * Establishes and tears down MongoDB connections via mongosh's
+ * {@link NodeDriverServiceProvider}, applying MCP-specific defaults such as
+ * the `appName` (composed from package info, device id and client name) and
+ * driver options (read/write concerns, proxy and OIDC settings).
+ *
+ * Tracks connection lifecycle as an {@link AnyConnectionState} and emits
+ * `connection-request`, `connection-success`, `connection-error`,
+ * `connection-close` and `close` events on {@link ConnectionManager.events}.
+ * For OIDC connection strings it stays in the `connecting` state until the
+ * OIDC plugin reports auth success or failure (via the shared event bus),
+ * surfacing device-flow verification URL and user code when applicable.
+ */
 export class MCPConnectionManager extends ConnectionManager {
     private deviceId: DeviceId;
     private bus: EventEmitter;

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -233,21 +233,31 @@ export abstract class ConnectionManager {
  * server.
  *
  * Establishes and tears down MongoDB connections via mongosh's
- * {@link NodeDriverServiceProvider}, applying MCP-specific defaults such as
- * the `appName` (composed from package info, device id and client name) and
- * driver options (read/write concerns, proxy and OIDC settings).
+ * NodeDriverServiceProvider, applying MCP-specific defaults such as the
+ * `appName` (composed from package info, device id and client name) and driver
+ * options (read/write concerns, proxy and OIDC settings).
  *
  * Tracks connection lifecycle as an {@link AnyConnectionState} and emits
  * `connection-request`, `connection-success`, `connection-error`,
  * `connection-close` and `close` events on {@link ConnectionManager.events}.
- * For OIDC connection strings it stays in the `connecting` state until the
- * OIDC plugin reports auth success or failure (via the shared event bus),
- * surfacing device-flow verification URL and user code when applicable.
+ * For OIDC connection strings it stays in the `connecting` state until the OIDC
+ * plugin reports auth success or failure (via the shared event bus), surfacing
+ * device-flow verification URL and user code when applicable.
  */
 export class MCPConnectionManager extends ConnectionManager {
     private deviceId: DeviceId;
     private bus: EventEmitter;
 
+    /**
+     * @param userConfig - Active user configuration; used when classifying the
+     * connection string (e.g. Atlas vs. local).
+     * @param logger - Logger used for OIDC and disconnect diagnostics.
+     * @param deviceId - Provider of the stable device identifier embedded in
+     * the connection's `appName`.
+     * @param bus - Optional event emitter shared with the OIDC plugin to
+     * receive `mongodb-oidc-plugin:auth-*` notifications. A fresh emitter is
+     * created when omitted.
+     */
     constructor(
         private userConfig: UserConfig,
         private logger: LoggerBase,
@@ -262,6 +272,17 @@ export class MCPConnectionManager extends ConnectionManager {
         this.deviceId = deviceId;
     }
 
+    /**
+     * Opens a new MongoDB connection from the supplied {@link ConnectionSettings},
+     * disconnecting any prior connection first.
+     *
+     * Resolves to a `connected` state for non-OIDC auth and to a `connecting`
+     * state for OIDC flows (which transition to `connected` once the OIDC
+     * plugin reports success on the shared event bus). On failure, transitions
+     * to an `errored` state and throws a {@link MongoDBError} with either
+     * {@link ErrorCodes.MisconfiguredConnectionString} or
+     * {@link ErrorCodes.NotConnectedToMongoDB}.
+     */
     override async connect(settings: ConnectionSettings): Promise<AnyConnectionState> {
         this._events.emit("connection-request", this.currentConnectionState);
 
@@ -357,6 +378,12 @@ export class MCPConnectionManager extends ConnectionManager {
         }
     }
 
+    /**
+     * Closes the underlying NodeDriverServiceProvider (awaiting it first when
+     * the manager is still in the `connecting` state) and emits
+     * `connection-close`. No-op when already `disconnected` or `errored`, in
+     * which case the current state is returned as-is.
+     */
     override async disconnect(): Promise<ConnectionStateDisconnected | ConnectionStateErrored> {
         if (this.currentConnectionState.tag === "disconnected" || this.currentConnectionState.tag === "errored") {
             return this.currentConnectionState;
@@ -381,6 +408,11 @@ export class MCPConnectionManager extends ConnectionManager {
         return { tag: "disconnected" };
     }
 
+    /**
+     * Permanently shuts the manager down: best-effort disconnect (errors are
+     * logged, not thrown) followed by emission of the `close` event with the
+     * final connection state.
+     */
     override async close(): Promise<void> {
         try {
             await this.disconnect();

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -61,6 +61,7 @@ export {
 } from "./transports/base.js";
 export {
     ConnectionManager,
+    MCPConnectionManager,
     ConnectionStateConnected,
     type AnyConnectionState,
     type ConnectionState,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -123,4 +123,11 @@ export {
     Histogram,
     Counter,
 } from "@mongodb-js/mcp-metrics";
-export * from "./transports/jsonRpcErrorCodes.js";
+export {
+    JSON_RPC_ERROR_CODE_PROCESSING_REQUEST_FAILED,
+    JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED,
+    JSON_RPC_ERROR_CODE_SESSION_ID_INVALID,
+    JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND,
+    JSON_RPC_ERROR_CODE_INVALID_REQUEST,
+    JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION,
+} from "./transports/jsonRpcErrorCodes.js";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -122,3 +122,4 @@ export {
     Histogram,
     Counter,
 } from "@mongodb-js/mcp-metrics";
+export * from "./transports/jsonRpcErrorCodes.js";

--- a/src/transports/jsonRpcErrorCodes.ts
+++ b/src/transports/jsonRpcErrorCodes.ts
@@ -2,11 +2,46 @@
  * JSON-RPC error codes for the MCP HTTP server.
  * These are defined in a separate module to avoid circular dependencies
  * between streamableHttp.ts and mcpHttpServer.ts.
+ *
+ * The values fall in the JSON-RPC implementation-defined server error range
+ * (`-32000` to `-32099`) and are returned in the `error.code` field of
+ * JSON-RPC responses sent over the streamable HTTP transport.
  */
 
+/**
+ * Generic failure while processing an otherwise valid JSON-RPC request
+ * (e.g. an unhandled exception thrown by the MCP server). HTTP status: 500.
+ */
 export const JSON_RPC_ERROR_CODE_PROCESSING_REQUEST_FAILED = -32000;
+
+/**
+ * Returned when a request that requires an existing session is received
+ * without an `Mcp-Session-Id` header. HTTP status: 400.
+ */
 export const JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED = -32001;
+
+/**
+ * Returned when the supplied `Mcp-Session-Id` header is malformed or otherwise
+ * not acceptable for the current request (e.g. provided on an `initialize`
+ * call that must allocate a new session). HTTP status: 400.
+ */
 export const JSON_RPC_ERROR_CODE_SESSION_ID_INVALID = -32002;
+
+/**
+ * Returned when the supplied `Mcp-Session-Id` does not match any session
+ * tracked by the server's session store. HTTP status: 404.
+ */
 export const JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND = -32003;
+
+/**
+ * The HTTP request body could not be interpreted as a valid JSON-RPC message
+ * (e.g. missing `initialize` on a session-creating request). HTTP status: 400.
+ */
 export const JSON_RPC_ERROR_CODE_INVALID_REQUEST = -32004;
+
+/**
+ * The client supplied an externally generated `Mcp-Session-Id` while the
+ * server is configured with `externallyManagedSessions` disabled. HTTP
+ * status: 400.
+ */
 export const JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION = -32005;

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -41,7 +41,7 @@ export class MCPHttpServer<
     TUserConfig extends UserConfig = UserConfig,
     TContext = unknown,
 > extends ExpressBasedHttpServer {
-    private readonly sessionStore: ISessionStore<StreamableHTTPServerTransport>;
+    protected readonly sessionStore: ISessionStore<StreamableHTTPServerTransport>;
     private readonly serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
     private readonly sessionOptions?: CustomizableSessionOptions<TUserConfig>;
     protected readonly userConfig: TUserConfig;


### PR DESCRIPTION
## Proposed changes

Making some changes to exported members on our library to support changes for Sticky Session in MMS.


Relevant MMS PRs:

- https://github.com/10gen/mms/pull/166640
- https://github.com/10gen/mms/pull/166990

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
