### PR TITLE
chore: Extends MongoDB test to cover all supported node versions

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [20]
+        node-version: ["20"]
         include:
           - os: ubuntu-latest
-            node-version: 22
+            node-version: "22"
           - os: ubuntu-latest
-            node-version: 24
+            node-version: "24"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,7 +53,7 @@ jobs:
           MDB_MONGOT_PASSWORD: ${{ secrets.TEST_MDB_MONGOT_PASSWORD }}
           MDB_VOYAGE_API_KEY: ${{ secrets.TEST_MDB_MCP_VOYAGE_API_KEY }}
       - name: Upload test results
-        if: always() && matrix.os == 'ubuntu-latest' && matrix.node-version == 20
+        if: always() && matrix.os == 'ubuntu-latest' && matrix.node-version == '20'
         uses: actions/upload-artifact@v7.0.1
         with:
           name: test-results

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -15,8 +15,17 @@ jobs:
     if: github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [20, 22, 24]
+        include:
+          - os: ubuntu-latest
+            node-version: 20
+          - os: ubuntu-latest
+            node-version: 22
+          - os: ubuntu-latest
+            node-version: 24
+          - os: macos-latest
+            node-version: 20
+          - os: windows-latest
+            node-version: 20
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [20, 22, 24]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -32,7 +33,7 @@ jobs:
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
-          node-version-file: package.json
+          node-version: ${{ matrix.node-version }}
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -47,7 +48,7 @@ jobs:
           MDB_MONGOT_PASSWORD: ${{ secrets.TEST_MDB_MONGOT_PASSWORD }}
           MDB_VOYAGE_API_KEY: ${{ secrets.TEST_MDB_MCP_VOYAGE_API_KEY }}
       - name: Upload test results
-        if: always() && matrix.os == 'ubuntu-latest'
+        if: always() && matrix.os == 'ubuntu-latest' && matrix.node-version == 20
         uses: actions/upload-artifact@v7.0.1
         with:
           name: test-results

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -15,17 +15,13 @@ jobs:
     if: github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [20]
         include:
-          - os: ubuntu-latest
-            node-version: 20
           - os: ubuntu-latest
             node-version: 22
           - os: ubuntu-latest
             node-version: 24
-          - os: macos-latest
-            node-version: 20
-          - os: windows-latest
-            node-version: 20
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Proposed changes

The engines field in package.json declares support for Node versions 20, 22, and 24, but CI was only testing against Node 20. 

This PR expands MongoDB test matrix on ubuntu to cover node versions 22, 24.
Further version coverage (testing other versions on other oses & on other unit tests) has not been included to avoid bloating the CI.


## Follow-up Work
* Update repo "Required" tasks to fit with new naming
  * `Run MongoDB tests (macos-latest)` -> `Run MongoDB tests (macos-latest, 20)`
  * `Run MongoDB tests (ubuntu-latest)` -> `Run MongoDB tests (ubuntu-latest, 20)`
  * `Run MongoDB tests (windows-latest)` -> `Run MongoDB tests (windows-latest, 20)`
