### PR TITLE
fix: atlas-list-clusters returns empty result instead of throwing error - MCP-530 

### DIFF
--- a/src/tools/atlas/read/listClusters.ts
+++ b/src/tools/atlas/read/listClusters.ts
@@ -67,7 +67,9 @@ export class ListClustersTool extends AtlasToolBase {
 
     private formatAllClustersTable(clusters?: PaginatedOrgGroupView): CallToolResult {
         if (!clusters?.results?.length) {
-            throw new Error("No clusters found.");
+            return {
+                content: [{ type: "text", text: "No clusters found." }],
+            };
         }
         const formattedClusters = clusters.results
             .map((result) => {
@@ -79,7 +81,9 @@ export class ListClustersTool extends AtlasToolBase {
             })
             .flat();
         if (!formattedClusters.length) {
-            throw new Error("No clusters found.");
+            return {
+                content: [{ type: "text", text: "No clusters found." }],
+            };
         }
 
         return {

--- a/tests/integration/tools/atlas/clusters.test.ts
+++ b/tests/integration/tools/atlas/clusters.test.ts
@@ -150,6 +150,17 @@ describeWithAtlas("clusters", (integration) => {
                 const content = getResponseContent(response.content);
                 expect(content).toBeDefined();
             });
+
+            it("returns a successful empty result when no clusters exist across all projects", async () => {
+                const session = integration.mcpServer().session;
+                assertApiClientIsAvailable(session);
+                vitest.spyOn(session.apiClient, "listClusterDetails").mockResolvedValue({ results: [], totalCount: 0 });
+
+                const response = await integration.mcpClient().callTool({ name: "atlas-list-clusters", arguments: {} });
+
+                expect(response.isError).toBeFalsy();
+                expect(getResponseContent(response.content)).toContain("No clusters found.");
+            });
         });
 
         describe("atlas-connect-cluster", () => {


### PR DESCRIPTION
## Proposed changes

`formatAllClustersTable` should return an empty result rather than an error. This matches the behaviour of `formatClustersTable` (which is called when projectId is provided)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
