### PR TITLE
Add clusterId to upgrade tool telemetry event

### DIFF
--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -268,6 +268,7 @@ export type StreamsToolMetadata = AtlasMetadata & {
 export type UpgradeClusterMetadata = AtlasMetadata & {
     original_tier?: "free" | "flex";
     target_tier?: "flex" | "m10";
+    cluster_id?: string;
     provider?: string;
     region?: string;
 };

--- a/src/tools/atlas/update/upgradeCluster.ts
+++ b/src/tools/atlas/update/upgradeCluster.ts
@@ -142,6 +142,7 @@ export const UpgradeClusterOutputSchema = {
     targetTier: z.enum(["FLEX", "M10"]),
     resolvedProvider: z.string().optional(),
     resolvedRegion: z.string().optional(),
+    clusterId: z.string().optional(),
 };
 
 export class UpgradeClusterTool extends AtlasToolBase {
@@ -190,6 +191,7 @@ export class UpgradeClusterTool extends AtlasToolBase {
         );
 
         const target = args.targetTier ?? (clusterInfo.instanceType === "FREE" ? "FLEX" : "M10");
+        let clusterId: string | undefined;
         switch (clusterInfo.instanceType) {
             case "DEDICATED":
                 throw new UpgradeClusterError(
@@ -200,13 +202,19 @@ export class UpgradeClusterTool extends AtlasToolBase {
                     throw new UpgradeClusterError(`Cluster "${clusterName}" is already a Flex cluster.`);
                 }
 
-                await this.apiClient.upgradeFlexToDedicated({
+                ({ id: clusterId } = await this.apiClient.upgradeFlexToDedicated({
                     groupId: projectId,
                     body: buildM10UpgradeBody("FLEX", clusterName, clusterInfo.provider, clusterInfo.region),
-                });
+                }));
                 break;
             case "FREE":
-                await this.upgradeFreeCluster(projectId, clusterName, target, clusterInfo.provider, clusterInfo.region);
+                ({ id: clusterId } = await this.upgradeFreeCluster(
+                    projectId,
+                    clusterName,
+                    target,
+                    clusterInfo.provider,
+                    clusterInfo.region
+                ));
                 break;
         }
 
@@ -222,6 +230,7 @@ export class UpgradeClusterTool extends AtlasToolBase {
                 targetTier: target,
                 resolvedProvider: clusterInfo.provider,
                 resolvedRegion: clusterInfo.region,
+                clusterId,
             },
         };
     }
@@ -243,10 +252,10 @@ export class UpgradeClusterTool extends AtlasToolBase {
         target: "FLEX" | "M10",
         backingProviderName: string | undefined,
         regionName: string | undefined
-    ): Promise<void> {
+    ): Promise<{ id?: string }> {
         switch (target) {
             case "FLEX":
-                await this.apiClient.upgradeSharedTierCluster({
+                return await this.apiClient.upgradeSharedTierCluster({
                     groupId: projectId,
                     body: {
                         name: clusterName,
@@ -258,13 +267,11 @@ export class UpgradeClusterTool extends AtlasToolBase {
                         },
                     },
                 });
-                break;
             case "M10":
-                await this.apiClient.upgradeSharedTierCluster({
+                return await this.apiClient.upgradeSharedTierCluster({
                     groupId: projectId,
                     body: buildM10UpgradeBody("FREE", clusterName, backingProviderName, regionName),
                 });
-                break;
         }
     }
 
@@ -280,6 +287,7 @@ export class UpgradeClusterTool extends AtlasToolBase {
             ...parentMetadata,
             original_tier: UpgradeClusterTool.toLowerCase(sc?.originalTier),
             target_tier: UpgradeClusterTool.toLowerCase(sc?.targetTier),
+            cluster_id: sc?.clusterId,
             provider: sc?.resolvedProvider,
             region: sc?.resolvedRegion,
         };

--- a/tests/unit/tools/atlas/update/upgradeCluster.test.ts
+++ b/tests/unit/tools/atlas/update/upgradeCluster.test.ts
@@ -710,13 +710,14 @@ describe("UpgradeClusterTool", () => {
             expect((result.structuredContent as Record<string, unknown>)["resolvedRegion"]).toBeUndefined();
         });
 
-        it("does not include cluster IDs in structuredContent", async () => {
+        it("includes clusterId from the upgrade response", async () => {
             mockApiClient.getCluster!.mockResolvedValue(FREE_CLUSTER_RAW);
 
             const result = await exec({ projectId: "proj1", clusterName: "MyCluster" });
 
-            expect(result.structuredContent).not.toHaveProperty("originalClusterId");
-            expect(result.structuredContent).not.toHaveProperty("targetClusterId");
+            expect(result.structuredContent).toMatchObject({
+                clusterId: "upgraded-cluster-id",
+            });
         });
 
         it("successive calls return independent structuredContent", async () => {
@@ -732,7 +733,7 @@ describe("UpgradeClusterTool", () => {
     });
 
     describe("telemetry metadata", () => {
-        it("resolves originalTier and targetTier from structuredContent", async () => {
+        it("resolves originalTier, targetTier, and cluster_id from structuredContent", async () => {
             mockApiClient.getCluster!.mockResolvedValue(FREE_CLUSTER_RAW);
             const result = await exec({ projectId: "proj1", clusterName: "MyCluster" });
 
@@ -742,6 +743,7 @@ describe("UpgradeClusterTool", () => {
             );
             expect(metadata.original_tier).toBe("free");
             expect(metadata.target_tier).toBe("flex");
+            expect(metadata.cluster_id).toBe("upgraded-cluster-id");
         });
 
         it("resolves provider and region from structuredContent", async () => {
@@ -759,18 +761,6 @@ describe("UpgradeClusterTool", () => {
             );
             expect(metadata.provider).toBe("GCP");
             expect(metadata.region).toBe("CENTRAL_US");
-        });
-
-        it("does not include cluster IDs in telemetry metadata", async () => {
-            mockApiClient.getCluster!.mockResolvedValue(FREE_CLUSTER_RAW);
-            const result = await exec({ projectId: "proj1", clusterName: "MyCluster" });
-
-            const metadata = tool["resolveTelemetryMetadata"](
-                { projectId: "proj1", clusterName: "MyCluster" } as never,
-                { result: result as never }
-            );
-            expect(metadata).not.toHaveProperty("original_cluster_id");
-            expect(metadata).not.toHaveProperty("target_cluster_id");
         });
 
         it("returns empty metadata fields when result has no structuredContent (error path)", () => {


### PR DESCRIPTION
## Proposed changes
Adding clusterId (clusterId remains the same through upgrade) to telemetry event data.

Tests:

- [x] Unit
- [x] Manually
<img width="400" height="243" alt="image" src="https://github.com/user-attachments/assets/22850e19-f473-4e7a-a2c2-559875108040" />

<img width="397" height="235" alt="image" src="https://github.com/user-attachments/assets/196656f5-4906-4900-961e-e23931c42e19" />


## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
