### PR TITLE
Replacing upgradeCluster w/ tenant api calls

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -179,56 +179,15 @@ export class ApiClient {
     // (undocumented)
     stopStreamProcessor(options: FetchOptions<operations["stopGroupStreamProcessor"]>): Promise<void>;
     // (undocumented)
+    tenantUpgrade(options: FetchOptions<operations["tenantGroupFlexClusterUpgrade"]>): Promise<components["schemas"]["FlexClusterDescription20241113"]>;
+    // (undocumented)
     updateStreamConnection(options: FetchOptions<operations["updateGroupStreamConnection"]>): Promise<components["schemas"]["StreamsConnection"]>;
     // (undocumented)
     updateStreamProcessor(options: FetchOptions<operations["updateGroupStreamProcessor"]>): Promise<components["schemas"]["StreamsProcessorWithStats"]>;
     // (undocumented)
     updateStreamWorkspace(options: FetchOptions<operations["updateGroupStreamWorkspace"]>): Promise<components["schemas"]["StreamsTenant"]>;
     // (undocumented)
-    upgradeFlexToDedicated(options: {
-        groupId: string;
-        body: {
-            name: string;
-            clusterType: "REPLICASET";
-            replicationSpecs: Array<{
-                regionConfigs: Array<{
-                    providerName?: string;
-                    regionName?: string;
-                    priority: number;
-                    electableSpecs: {
-                        instanceSize: string;
-                        nodeCount: number;
-                    };
-                }>;
-            }>;
-            autoScaling: {
-                compute: {
-                    enabled: boolean;
-                    scaleDownEnabled: boolean;
-                    minInstanceSize: string;
-                    maxInstanceSize: string;
-                };
-                diskGBEnabled: boolean;
-            };
-        };
-    }): Promise<{
-        id?: string;
-    }>;
-    // (undocumented)
-    upgradeSharedTierCluster(options: {
-        groupId: string;
-        body: {
-            name: string;
-            providerSettings: {
-                providerName?: string;
-                instanceSizeName: "FLEX" | "M10";
-                backingProviderName?: string;
-                regionName?: string;
-            };
-        };
-    }): Promise<{
-        id?: string;
-    }>;
+    upgradeTenantUpgrade(options: FetchOptions<operations["upgradeGroupClusterTenantUpgrade"]>): Promise<components["schemas"]["LegacyAtlasCluster"]>;
     // (undocumented)
     validateAuthConfig(): Promise<void>;
     // (undocumented)

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -163,56 +163,15 @@ export class ApiClient {
     // (undocumented)
     stopStreamProcessor(options: FetchOptions<operations["stopGroupStreamProcessor"]>): Promise<void>;
     // (undocumented)
+    tenantUpgrade(options: FetchOptions<operations["tenantGroupFlexClusterUpgrade"]>): Promise<components["schemas"]["FlexClusterDescription20241113"]>;
+    // (undocumented)
     updateStreamConnection(options: FetchOptions<operations["updateGroupStreamConnection"]>): Promise<components["schemas"]["StreamsConnection"]>;
     // (undocumented)
     updateStreamProcessor(options: FetchOptions<operations["updateGroupStreamProcessor"]>): Promise<components["schemas"]["StreamsProcessorWithStats"]>;
     // (undocumented)
     updateStreamWorkspace(options: FetchOptions<operations["updateGroupStreamWorkspace"]>): Promise<components["schemas"]["StreamsTenant"]>;
     // (undocumented)
-    upgradeFlexToDedicated(options: {
-        groupId: string;
-        body: {
-            name: string;
-            clusterType: "REPLICASET";
-            replicationSpecs: Array<{
-                regionConfigs: Array<{
-                    providerName?: string;
-                    regionName?: string;
-                    priority: number;
-                    electableSpecs: {
-                        instanceSize: string;
-                        nodeCount: number;
-                    };
-                }>;
-            }>;
-            autoScaling: {
-                compute: {
-                    enabled: boolean;
-                    scaleDownEnabled: boolean;
-                    minInstanceSize: string;
-                    maxInstanceSize: string;
-                };
-                diskGBEnabled: boolean;
-            };
-        };
-    }): Promise<{
-        id?: string;
-    }>;
-    // (undocumented)
-    upgradeSharedTierCluster(options: {
-        groupId: string;
-        body: {
-            name: string;
-            providerSettings: {
-                providerName?: string;
-                instanceSizeName: "FLEX" | "M10";
-                backingProviderName?: string;
-                regionName?: string;
-            };
-        };
-    }): Promise<{
-        id?: string;
-    }>;
+    upgradeTenantUpgrade(options: FetchOptions<operations["upgradeGroupClusterTenantUpgrade"]>): Promise<components["schemas"]["LegacyAtlasCluster"]>;
     // (undocumented)
     validateAuthConfig(): Promise<void>;
     // (undocumented)

--- a/scripts/apply.ts
+++ b/scripts/apply.ts
@@ -117,6 +117,7 @@ async function main(): Promise<void> {
             // @ts-expect-error This is a workaround for the OpenAPI types
             const operation = openapi.paths[pathKey][methodKey] as OpenAPIV3_1.OperationObject & {
                 "x-xgen-operation-id-override": string;
+                "x-accept-override"?: string;
             };
 
             if (!operation.operationId || !operation.tags?.length) {
@@ -124,10 +125,13 @@ async function main(): Promise<void> {
             }
 
             let requiredParams = !!operation.requestBody;
-            const { hasResponseBody, acceptOverride, responseBodySchemaKey } = analyzeSuccessResponse(
-                operation,
-                openapi
-            );
+            const {
+                hasResponseBody,
+                acceptOverride: detectedAcceptOverride,
+                responseBodySchemaKey,
+            } = analyzeSuccessResponse(operation, openapi);
+            // x-accept-override (set by filter.ts) takes precedence; fall back to auto-detected non-JSON types
+            const acceptOverride = operation["x-accept-override"] ?? detectedAcceptOverride;
 
             for (const param of operation.parameters || []) {
                 const paramObject = findObjectFromRef(param, openapi);

--- a/scripts/filter.ts
+++ b/scripts/filter.ts
@@ -33,6 +33,8 @@ function filterOpenapi(openapi: OpenAPIV3_1.Document): OpenAPIV3_1.Document {
         "deleteCluster",
         "deleteFlexCluster",
         "listClusterDetails",
+        "upgradeGroupClusterTenantUpgrade",
+        "tenantGroupFlexClusterUpgrade",
         "createDatabaseUser",
         "deleteDatabaseUser",
         "listDatabaseUsers",
@@ -86,6 +88,13 @@ function filterOpenapi(openapi: OpenAPIV3_1.Document): OpenAPIV3_1.Document {
         "downloadOperationalLogs",
     ];
 
+    // Operations that require a specific API version different from the client default (2025-03-12).
+    // apply.ts reads x-accept-override to set the correct Accept header on the generated method.
+    const acceptOverrides: Record<string, string> = {
+        upgradeGroupClusterTenantUpgrade: "application/vnd.atlas.2023-01-01+json",
+        tenantGroupFlexClusterUpgrade: "application/vnd.atlas.2024-11-13+json",
+    };
+
     const filteredPaths = {};
 
     for (const path in openapi.paths) {
@@ -94,12 +103,18 @@ function filterOpenapi(openapi: OpenAPIV3_1.Document): OpenAPIV3_1.Document {
         for (const [method, operation] of Object.entries(openapi.paths[path])) {
             const op = operation as OpenAPIV3_1.OperationObject & {
                 "x-xgen-operation-id-override": string;
+                "x-accept-override"?: string;
             };
             if (
                 op.operationId &&
                 (allowedOperations.includes(op.operationId) ||
                     allowedOperations.includes(op["x-xgen-operation-id-override"]))
             ) {
+                const acceptOverride =
+                    acceptOverrides[op.operationId] ?? acceptOverrides[op["x-xgen-operation-id-override"]];
+                if (acceptOverride) {
+                    op["x-accept-override"] = acceptOverride;
+                }
                 // @ts-expect-error This is a workaround for the OpenAPI types
                 filteredMethods[method] = openapi.paths[path][method] as OpenAPIV3_1.OperationObject;
             }

--- a/scripts/filter.ts
+++ b/scripts/filter.ts
@@ -88,11 +88,10 @@ function filterOpenapi(openapi: OpenAPIV3_1.Document): OpenAPIV3_1.Document {
         "downloadOperationalLogs",
     ];
 
-    // Operations that require a specific API version different from the client default (2025-03-12).
-    // apply.ts reads x-accept-override to set the correct Accept header on the generated method.
+    // upgradeGroupClusterTenantUpgrade requires 2023-01-01 — the endpoint behaves differently
+    // under 2025-03-12 (rejects direct FREE→M10, requires FLEX first).
     const acceptOverrides: Record<string, string> = {
         upgradeGroupClusterTenantUpgrade: "application/vnd.atlas.2023-01-01+json",
-        tenantGroupFlexClusterUpgrade: "application/vnd.atlas.2024-11-13+json",
     };
 
     const filteredPaths = {};

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -11,7 +11,6 @@ import type { Credentials, AuthProvider } from "./auth/authProvider.js";
 import { AuthProviderFactory } from "./auth/authProvider.js";
 
 const ATLAS_API_VERSION = "2025-03-12";
-const LEGACY_ATLAS_API_VERSION = "2023-01-01";
 const DEFAULT_SEND_TIMEOUT_MS = 5_000;
 
 /**
@@ -237,7 +236,7 @@ export class ApiClient {
     }
 
     // DO NOT EDIT. This is auto-generated code.
-    /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
     async listClusterDetails(
         options?: FetchOptions<operations["listClusterDetails"]>
     ): Promise<components["schemas"]["PaginatedOrgGroupView"]> {
@@ -337,6 +336,19 @@ export class ApiClient {
         options: FetchOptions<operations["createGroupCluster"]>
     ): Promise<components["schemas"]["ClusterDescription20240805"]> {
         const { data, error, response } = await this.client.POST("/api/atlas/v2/groups/{groupId}/clusters", options);
+        if (error) {
+            throw ApiClientError.fromError(response, error);
+        }
+        return data;
+    }
+
+    async upgradeTenantUpgrade(
+        options: FetchOptions<operations["upgradeGroupClusterTenantUpgrade"]>
+    ): Promise<components["schemas"]["LegacyAtlasCluster"]> {
+        const { data, error, response } = await this.client.POST(
+            "/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade",
+            { ...options, headers: { Accept: "application/vnd.atlas.2023-01-01+json", ...options?.headers } }
+        );
         if (error) {
             throw ApiClientError.fromError(response, error);
         }
@@ -483,6 +495,19 @@ export class ApiClient {
         const { data, error, response } = await this.client.GET(
             "/api/atlas/v2/groups/{groupId}/flexClusters/{name}",
             options
+        );
+        if (error) {
+            throw ApiClientError.fromError(response, error);
+        }
+        return data;
+    }
+
+    async tenantUpgrade(
+        options: FetchOptions<operations["tenantGroupFlexClusterUpgrade"]>
+    ): Promise<components["schemas"]["FlexClusterDescription20241113"]> {
+        const { data, error, response } = await this.client.POST(
+            "/api/atlas/v2/groups/{groupId}/flexClusters:tenantUpgrade",
+            { ...options, headers: { Accept: "application/vnd.atlas.2024-11-13+json", ...options?.headers } }
         );
         if (error) {
             throw ApiClientError.fromError(response, error);
@@ -871,80 +896,6 @@ export class ApiClient {
         }
         return data;
     }
-    /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
     // DO NOT EDIT. This is auto-generated code.
-
-    async upgradeSharedTierCluster(options: {
-        groupId: string;
-        body: {
-            name: string;
-            providerSettings: {
-                providerName?: string;
-                instanceSizeName: "FLEX" | "M10";
-                backingProviderName?: string;
-                regionName?: string;
-            };
-        };
-    }): Promise<{ id?: string }> {
-        const authHeaders = (await this.authProvider?.getAuthHeaders()) ?? {};
-        const url = new URL(`api/atlas/v2/groups/${options.groupId}/clusters/tenantUpgrade`, this.options.baseUrl);
-        const response = await this.customFetch(url.toString(), {
-            method: "POST",
-            signal: AbortSignal.timeout(DEFAULT_SEND_TIMEOUT_MS),
-            headers: {
-                ...authHeaders,
-                "Content-Type": `application/vnd.atlas.${LEGACY_ATLAS_API_VERSION}+json`,
-                Accept: `application/vnd.atlas.${LEGACY_ATLAS_API_VERSION}+json`,
-                "User-Agent": this.options.userAgent,
-            },
-            body: JSON.stringify(options.body),
-        });
-        if (!response.ok) {
-            throw await ApiClientError.fromResponse(response);
-        }
-        return (await response.json()) as { id?: string };
-    }
-
-    async upgradeFlexToDedicated(options: {
-        groupId: string;
-        body: {
-            name: string;
-            clusterType: "REPLICASET";
-            replicationSpecs: Array<{
-                regionConfigs: Array<{
-                    providerName?: string;
-                    regionName?: string;
-                    priority: number;
-                    electableSpecs: { instanceSize: string; nodeCount: number };
-                }>;
-            }>;
-            autoScaling: {
-                compute: {
-                    enabled: boolean;
-                    scaleDownEnabled: boolean;
-                    minInstanceSize: string;
-                    maxInstanceSize: string;
-                };
-                diskGBEnabled: boolean;
-            };
-        };
-    }): Promise<{ id?: string }> {
-        const authHeaders = (await this.authProvider?.getAuthHeaders()) ?? {};
-        const url = new URL(`api/atlas/v2/groups/${options.groupId}/flexClusters:tenantUpgrade`, this.options.baseUrl);
-        const response = await this.customFetch(url.toString(), {
-            method: "POST",
-            signal: AbortSignal.timeout(DEFAULT_SEND_TIMEOUT_MS),
-            headers: {
-                ...authHeaders,
-                "Content-Type": `application/vnd.atlas.${ATLAS_API_VERSION}+json`,
-                Accept: `application/vnd.atlas.${ATLAS_API_VERSION}+json`,
-                "User-Agent": this.options.userAgent,
-            },
-            body: JSON.stringify(options.body),
-        });
-        if (!response.ok) {
-            throw await ApiClientError.fromResponse(response);
-        }
-        return (await response.json()) as { id?: string };
-    }
 }

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -507,7 +507,7 @@ export class ApiClient {
     ): Promise<components["schemas"]["FlexClusterDescription20241113"]> {
         const { data, error, response } = await this.client.POST(
             "/api/atlas/v2/groups/{groupId}/flexClusters:tenantUpgrade",
-            { ...options, headers: { Accept: "application/vnd.atlas.2024-11-13+json", ...options?.headers } }
+            options
         );
         if (error) {
             throw ApiClientError.fromError(response, error);

--- a/src/common/atlas/openapi.d.ts
+++ b/src/common/atlas/openapi.d.ts
@@ -13,7 +13,7 @@ export interface paths {
         };
         /**
          * Return All Authorized Clusters in All Projects
-         * @description Returns the details for all clusters in all projects to which you have access. Clusters contain a group of hosts that maintain the same data set. The response does not include multi-cloud clusters. To use this resource, the requesting Service Account or API Key can have any cluster-level role.
+         * @description Returns the details for all clusters in all projects to which you have access. Clusters contain a group of hosts that maintain the same data set. The response does not include multi-cloud clusters.
          */
         get: operations["listClusterDetails"];
         put?: never;
@@ -33,13 +33,13 @@ export interface paths {
         };
         /**
          * Return All Projects
-         * @description Returns details about all projects. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings. To use this resource, the requesting Service Account or API Key must have the Organization Read Only role or higher.
+         * @description Returns details about all projects. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings.
          */
         get: operations["listGroups"];
         put?: never;
         /**
          * Create One Project
-         * @description Creates one project. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings. To use this resource, the requesting Service Account or API Key must have the Read Write role.
+         * @description Creates one project. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings.
          */
         post: operations["createGroup"];
         delete?: never;
@@ -57,14 +57,14 @@ export interface paths {
         };
         /**
          * Return One Project
-         * @description Returns details about the specified project. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
+         * @description Returns details about the specified project. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings.
          */
         get: operations["getGroup"];
         put?: never;
         post?: never;
         /**
          * Remove One Project
-         * @description Removes the specified project. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings. You can delete a project only if there are no Online Archives for the clusters in the project. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
+         * @description Removes the specified project. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings. You can delete a project only if there are no Online Archives for the clusters in the project.
          */
         delete: operations["deleteGroup"];
         options?: never;
@@ -81,13 +81,13 @@ export interface paths {
         };
         /**
          * Return All Project IP Access List Entries
-         * @description Returns all access list entries from the specified project's IP access list. Each entry in the project's IP access list contains either one IP address or one CIDR-notated block of IP addresses. MongoDB Cloud only allows client connections to the cluster from entries in the project's IP access list. To use this resource, the requesting Service Account or API Key must have the Project Read Only or Project Charts Admin roles. This resource replaces the whitelist resource. MongoDB Cloud removed whitelists in July 2021. Update your applications to use this new resource. The `/groups/{GROUP-ID}/accessList` endpoint manages the database IP access list. This endpoint is distinct from the `orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/accesslist` endpoint, which manages the access list for MongoDB Cloud organizations.
+         * @description Returns all access list entries from the specified project's IP access list. Each entry in the project's IP access list contains either one IP address or one CIDR-notated block of IP addresses. MongoDB Cloud only allows client connections to the cluster from entries in the project's IP access list. This resource replaces the whitelist resource. MongoDB Cloud removed whitelists in July 2021. Update your applications to use this new resource. The `/groups/{GROUP-ID}/accessList` endpoint manages the database IP access list. This endpoint is distinct from the `orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/accesslist` endpoint, which manages the access list for MongoDB Cloud organizations.
          */
         get: operations["listGroupAccessListEntries"];
         put?: never;
         /**
          * Add Entries to Project IP Access List
-         * @description Adds one or more access list entries to the specified project. MongoDB Cloud only allows client connections to the cluster from entries in the project's IP access list. Write each entry as either one IP address or one CIDR-notated block of IP addresses. To use this resource, the requesting Service Account or API Key must have the Project Owner role, Project Charts Admin role, or Project Network Access Manager role. This resource replaces the whitelist resource. MongoDB Cloud removed whitelists in July 2021. Update your applications to use this new resource. The `/groups/{GROUP-ID}/accessList` endpoint manages the database IP access list. This endpoint is distinct from the `orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/accesslist` endpoint, which manages the access list for MongoDB Cloud organizations. This endpoint doesn't support concurrent `POST` requests. You must submit multiple `POST` requests synchronously.
+         * @description Adds one or more access list entries to the specified project. MongoDB Cloud only allows client connections to the cluster from entries in the project's IP access list. Write each entry as either one IP address or one CIDR-notated block of IP addresses. This resource replaces the whitelist resource. MongoDB Cloud removed whitelists in July 2021. Update your applications to use this new resource. The `/groups/{GROUP-ID}/accessList` endpoint manages the database IP access list. This endpoint is distinct from the `orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/accesslist` endpoint, which manages the access list for MongoDB Cloud organizations. This endpoint doesn't support concurrent `POST` requests. You must submit multiple `POST` requests synchronously.
          */
         post: operations["createGroupAccessListEntry"];
         delete?: never;
@@ -108,7 +108,7 @@ export interface paths {
         post?: never;
         /**
          * Remove One Entry from One Project IP Access List
-         * @description Removes one access list entry from the specified project's IP access list. Each entry in the project's IP access list contains one IP address, one CIDR-notated block of IP addresses, or one AWS Security Group ID. MongoDB Cloud only allows client connections to the cluster from entries in the project's IP access list. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Network Access Manager role. This resource replaces the whitelist resource. MongoDB Cloud removed whitelists in July 2021. Update your applications to use this new resource. The `/groups/{GROUP-ID}/accessList` endpoint manages the database IP access list. This endpoint is distinct from the `orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/accesslist` endpoint, which manages the access list for MongoDB Cloud organizations.
+         * @description Removes one access list entry from the specified project's IP access list. Each entry in the project's IP access list contains one IP address, one CIDR-notated block of IP addresses, or one AWS Security Group ID. MongoDB Cloud only allows client connections to the cluster from entries in the project's IP access list. This resource replaces the whitelist resource. MongoDB Cloud removed whitelists in July 2021. Update your applications to use this new resource. The `/groups/{GROUP-ID}/accessList` endpoint manages the database IP access list. This endpoint is distinct from the `orgs/{ORG-ID}/apiKeys/{API-KEY-ID}/accesslist` endpoint, which manages the access list for MongoDB Cloud organizations.
          */
         delete: operations["deleteGroupAccessListEntry"];
         options?: never;
@@ -125,7 +125,7 @@ export interface paths {
         };
         /**
          * Return All Alerts from One Project
-         * @description Returns all alerts. These alerts apply to all components in one project. You receive an alert when a monitored component meets or exceeds a value you set. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
+         * @description Returns all alerts. These alerts apply to all components in one project. You receive an alert when a monitored component meets or exceeds a value you set.
          *
          *     This resource remains under revision and may change.
          */
@@ -147,7 +147,7 @@ export interface paths {
         };
         /**
          * Return All Clusters in One Project
-         * @description Returns the details for all clusters in the specific project to which you have access. Clusters contain a group of hosts that maintain the same data set. The response includes clusters with asymmetrically-sized shards. To use this resource, the requesting Service Account or API Key must have the Project Read Only role. This feature is not  available for serverless clusters.
+         * @description Returns the details for all clusters in the specific project to which you have access. Clusters contain a group of hosts that maintain the same data set. The response includes clusters with asymmetrically-sized shards. This feature is not  available for serverless clusters.
          *
          *     This endpoint can also be used on Flex clusters that were created using the [Create Cluster](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/createCluster) endpoint or former M2/M5 clusters that have been migrated to Flex clusters until January 2026. Please use the List Flex Clusters endpoint for Flex clusters instead. Deprecated versions: v2-{2023-02-01}, v2-{2023-01-01}
          */
@@ -155,11 +155,33 @@ export interface paths {
         put?: never;
         /**
          * Create One Cluster in One Project
-         * @description Creates one cluster in the specified project. Clusters contain a group of hosts that maintain the same data set. This resource can create clusters with asymmetrically-sized shards. Each project supports up to 25 database deployments. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Cluster Creator role. This feature is not available for serverless clusters.
+         * @description Creates one cluster in the specified project. Clusters contain a group of hosts that maintain the same data set. This resource can create clusters with asymmetrically-sized shards. Each project supports up to 25 database deployments. This feature is not available for serverless clusters.
          *
          *     Please note that using an `instanceSize` of M2 or M5 will create a Flex cluster instead. Support for the `instanceSize` of M2 or M5 will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward. Deprecated versions: v2-{2024-08-05}, v2-{2023-02-01}, v2-{2023-01-01}
          */
         post: operations["createGroupCluster"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upgrade One Shared-Tier Cluster
+         * @description Upgrades a shared-tier cluster to a Flex or Dedicated (M10+) cluster in the specified project. Each project supports up to 25 clusters.
+         *
+         *     This endpoint can also be used to upgrade Flex clusters that were created using the [Create Cluster](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/createCluster) API or former M2/M5 clusters that have been migrated to Flex clusters, using `instanceSizeName` to “M2” or “M5” until January 2026. This functionality will be available until January 22, 2026, after which it will only be available for M0 clusters. Please use the Upgrade Flex Cluster endpoint instead.
+         */
+        post: operations["upgradeGroupClusterTenantUpgrade"];
         delete?: never;
         options?: never;
         head?: never;
@@ -175,7 +197,7 @@ export interface paths {
         };
         /**
          * Return One Cluster from One Project
-         * @description Returns the details for one cluster in the specified project. Clusters contain a group of hosts that maintain the same data set. The response includes clusters with asymmetrically-sized shards. To use this resource, the requesting Service Account or API Key must have the Project Read Only role. This feature is not available for serverless clusters.
+         * @description Returns the details for one cluster in the specified project. Clusters contain a group of hosts that maintain the same data set. The response includes clusters with asymmetrically-sized shards. This feature is not available for serverless clusters.
          *
          *     This endpoint can also be used on Flex clusters that were created using the [Create Cluster](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/createCluster) endpoint or former M2/M5 clusters that have been migrated to Flex clusters until January 2026. Please use the Get Flex Cluster endpoint for Flex clusters instead. Deprecated versions: v2-{2023-02-01}, v2-{2023-01-01}
          */
@@ -184,7 +206,7 @@ export interface paths {
         post?: never;
         /**
          * Remove One Cluster from One Project
-         * @description Removes one cluster from the specified project. The cluster must have termination protection disabled in order to be deleted. To use this resource, the requesting Service Account or API Key must have the Project Owner role. This feature is not available for serverless clusters.
+         * @description Removes one cluster from the specified project. The cluster must have termination protection disabled in order to be deleted. This feature is not available for serverless clusters.
          *
          *     This endpoint can also be used on Flex clusters that were created using the [Create Cluster](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/createCluster) endpoint or former M2/M5 clusters that have been migrated to Flex clusters until January 2026. Please use the Delete Flex Cluster endpoint for Flex clusters instead. Deprecated versions: v2-{2023-01-01}
          */
@@ -203,7 +225,7 @@ export interface paths {
         };
         /**
          * Return All Suggested Indexes to Drop
-         * @description Returns the indexes that the Performance Advisor suggests to drop. The Performance Advisor suggests dropping unused, redundant, and hidden indexes to improve write performance and increase storage space. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
+         * @description Returns the indexes that the Performance Advisor suggests to drop. The Performance Advisor suggests dropping unused, redundant, and hidden indexes to improve write performance and increase storage space.
          */
         get: operations["listGroupClusterPerformanceAdvisorDropIndexSuggestions"];
         put?: never;
@@ -223,7 +245,7 @@ export interface paths {
         };
         /**
          * Return Schema Advice
-         * @description Returns the schema suggestions that the Performance Advisor detects. The Performance Advisor provides holistic schema recommendations for your cluster by sampling documents in your most active collections and collections with slow-running queries. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
+         * @description Returns the schema suggestions that the Performance Advisor detects. The Performance Advisor provides holistic schema recommendations for your cluster by sampling documents in your most active collections and collections with slow-running queries.
          */
         get: operations["listGroupClusterPerformanceAdvisorSchemaAdvice"];
         put?: never;
@@ -243,7 +265,7 @@ export interface paths {
         };
         /**
          * Return All Suggested Indexes
-         * @description Returns the indexes that the Performance Advisor suggests. The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
+         * @description Returns the indexes that the Performance Advisor suggests. The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance.
          */
         get: operations["listGroupClusterPerformanceAdvisorSuggestedIndexes"];
         put?: never;
@@ -263,13 +285,13 @@ export interface paths {
         };
         /**
          * Return All Database Users in One Project
-         * @description Returns all database users that belong to the specified project. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
+         * @description Returns all database users that belong to the specified project.
          */
         get: operations["listGroupDatabaseUsers"];
         put?: never;
         /**
          * Create One Database User in One Project
-         * @description Creates one database user in the specified project. This MongoDB Cloud supports a maximum of 100 database users per project. If you require more than 100 database users on a project, contact Support. To use this resource, the requesting Service Account or API Key must have the Project Owner role, the Project Charts Admin role, Project Stream Processing Owner role, or the Project Database Access Admin role.
+         * @description Creates one database user in the specified project. This MongoDB Cloud supports a maximum of 100 database users per project. If you require more than 100 database users on a project, contact Support.
          */
         post: operations["createGroupDatabaseUser"];
         delete?: never;
@@ -290,7 +312,7 @@ export interface paths {
         post?: never;
         /**
          * Remove One Database User from One Project
-         * @description Removes one database user from the specified project. To use this resource, the requesting Service Account or API Key must have the Project Owner role, the Project Stream Processing Owner role, or the Project Database Access Admin role.
+         * @description Removes one database user from the specified project.
          */
         delete: operations["deleteGroupDatabaseUser"];
         options?: never;
@@ -307,13 +329,13 @@ export interface paths {
         };
         /**
          * Return All Flex Clusters from One Project
-         * @description Returns details for all flex clusters in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
+         * @description Returns details for all flex clusters in the specified project.
          */
         get: operations["listGroupFlexClusters"];
         put?: never;
         /**
          * Create One Flex Cluster in One Project
-         * @description Creates one flex cluster in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
+         * @description Creates one flex cluster in the specified project.
          */
         post: operations["createGroupFlexCluster"];
         delete?: never;
@@ -331,16 +353,36 @@ export interface paths {
         };
         /**
          * Return One Flex Cluster from One Project
-         * @description Returns details for one flex cluster in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
+         * @description Returns details for one flex cluster in the specified project.
          */
         get: operations["getGroupFlexCluster"];
         put?: never;
         post?: never;
         /**
          * Remove One Flex Cluster from One Project
-         * @description Removes one flex cluster from the specified project. The flex cluster must have termination protection disabled in order to be deleted. To use this resource, the requesting Service Account or API Key must have the Project Owner role.
+         * @description Removes one flex cluster from the specified project. The flex cluster must have termination protection disabled in order to be deleted.
          */
         delete: operations["deleteGroupFlexCluster"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/atlas/v2/groups/{groupId}/flexClusters:tenantUpgrade": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upgrade One Flex Cluster
+         * @description Upgrades a flex cluster to a dedicated cluster (M10+) in the specified project.
+         */
+        post: operations["tenantGroupFlexClusterUpgrade"];
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -355,7 +397,7 @@ export interface paths {
         };
         /**
          * Return Slow Queries
-         * @description Returns log lines for slow queries that the Performance Advisor and Query Profiler identified. The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance. MongoDB Cloud bases the threshold for slow queries on the average time of operations on your cluster. This enables workload-relevant recommendations. To use this resource, the requesting Service Account or API Key must have any Project Data Access role or the Project Observability Viewer role.
+         * @description Returns log lines for slow queries that the Performance Advisor and Query Profiler identified. The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance. MongoDB Cloud bases the threshold for slow queries on the average time of operations on your cluster. This enables workload-relevant recommendations.
          */
         get: operations["listGroupProcessPerformanceAdvisorSlowQueryLogs"];
         put?: never;
@@ -381,7 +423,7 @@ export interface paths {
         put?: never;
         /**
          * Create One Stream Workspace
-         * @description Creates one stream workspace in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Data Access Admin role, Project Owner role or Project Stream Processing Owner role.
+         * @description Creates one stream workspace in the specified project.
          */
         post: operations["createGroupStreamWorkspace"];
         delete?: never;
@@ -419,13 +461,13 @@ export interface paths {
         };
         /**
          * Return All Private Link Connections
-         * @description Returns all Private Link connections for the specified project. To use this resource, the requesting Service Account or API Key must have the Project Read Only role, Project Data Access roles, Project Owner role or Project Stream Processing Owner role.
+         * @description Returns all Private Link connections for the specified project.
          */
         get: operations["listGroupStreamPrivateLinkConnections"];
         put?: never;
         /**
          * Create One Private Link Connection
-         * @description Creates one Private Link in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Owner or Project Stream Processing Owner role.
+         * @description Creates one Private Link in the specified project.
          */
         post: operations["createGroupStreamPrivateLinkConnection"];
         delete?: never;
@@ -443,14 +485,14 @@ export interface paths {
         };
         /**
          * Return One Private Link Connection
-         * @description Returns the details of one Private Link connection within the project. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
+         * @description Returns the details of one Private Link connection within the project.
          */
         get: operations["getGroupStreamPrivateLinkConnection"];
         put?: never;
         post?: never;
         /**
          * Delete One Private Link Connection
-         * @description Deletes one Private Link in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Owner or Project Stream Processing Owner role.
+         * @description Deletes one Private Link in the specified project.
          */
         delete: operations["deleteGroupStreamPrivateLinkConnection"];
         options?: never;
@@ -527,21 +569,21 @@ export interface paths {
         };
         /**
          * Return One Stream Workspace
-         * @description Returns the details of one stream workspace within the specified project. To use this resource, the requesting Service Account or API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.
+         * @description Returns the details of one stream workspace within the specified project.
          */
         get: operations["getGroupStreamWorkspace"];
         put?: never;
         post?: never;
         /**
          * Delete One Stream Workspace
-         * @description Delete one stream workspace in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Data Access Admin role, Project Owner role or Project Stream Processing Owner role.
+         * @description Delete one stream workspace in the specified project.
          */
         delete: operations["deleteGroupStreamWorkspace"];
         options?: never;
         head?: never;
         /**
          * Update One Stream Workspace
-         * @description Update one stream workspace in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Data Access Admin role, Project Owner role or Project Stream Processing Owner role.
+         * @description Update one stream workspace in the specified project.
          */
         patch: operations["updateGroupStreamWorkspace"];
         trace?: never;
@@ -555,7 +597,7 @@ export interface paths {
         };
         /**
          * Download Audit Logs for One Atlas Stream Processing Workspace
-         * @description Downloads the audit logs for the specified Atlas Streams Processing workspace or stream processor. By default, logs cover periods of 30 days. To use this resource, the requesting Service Account or API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role. The API does not support direct calls with the json response schema. You must request a gzip response schema using an accept header of the format: `Accept: application/vnd.atlas.YYYY-MM-DD+gzip`.
+         * @description Downloads the audit logs for the specified Atlas Streams Processing workspace or stream processor. By default, logs cover periods of 30 days. The API does not support direct calls with the json response schema. You must request a gzip response schema using an accept header of the format: `Accept: application/vnd.atlas.YYYY-MM-DD+gzip`.
          */
         get: operations["downloadGroupStreamAuditLogs"];
         put?: never;
@@ -575,13 +617,13 @@ export interface paths {
         };
         /**
          * Return All Connections of the Stream Workspaces
-         * @description Returns all connections of the stream workspace for the specified project. To use this resource, the requesting Service Account or API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.
+         * @description Returns all connections of the stream workspace for the specified project.
          */
         get: operations["listGroupStreamConnections"];
         put?: never;
         /**
          * Create One Stream Connection
-         * @description Creates one connection for a stream workspace in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Owner or Project Stream Processing Owner role.
+         * @description Creates one connection for a stream workspace in the specified project.
          */
         post: operations["createGroupStreamConnection"];
         delete?: never;
@@ -599,21 +641,21 @@ export interface paths {
         };
         /**
          * Return One Stream Connection
-         * @description Returns the details of one stream connection within the specified stream workspace. To use this resource, the requesting Service Account or API Key must have the Project Read Only role.
+         * @description Returns the details of one stream connection within the specified stream workspace.
          */
         get: operations["getGroupStreamConnection"];
         put?: never;
         post?: never;
         /**
          * Delete One Stream Connection
-         * @description Delete one connection of the specified stream workspace. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Stream Processing Owner role.
+         * @description Delete one connection of the specified stream workspace.
          */
         delete: operations["deleteGroupStreamConnection"];
         options?: never;
         head?: never;
         /**
          * Update One Stream Connection
-         * @description Update one connection for the specified stream workspace in the specified project. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Stream Processing Owner role.
+         * @description Update one connection for the specified stream workspace in the specified project.
          */
         patch: operations["updateGroupStreamConnection"];
         trace?: never;
@@ -629,7 +671,7 @@ export interface paths {
         put?: never;
         /**
          * Create One Stream Processor
-         * @description Create one Stream Processor within the specified stream workspace. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Stream Processing Owner role.
+         * @description Create one Stream Processor within the specified stream workspace.
          */
         post: operations["createGroupStreamProcessor"];
         delete?: never;
@@ -647,21 +689,21 @@ export interface paths {
         };
         /**
          * Return One Stream Processor
-         * @description Get one Stream Processor within the specified stream workspace. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Stream Processing Owner role.
+         * @description Get one Stream Processor within the specified stream workspace.
          */
         get: operations["getGroupStreamProcessor"];
         put?: never;
         post?: never;
         /**
          * Delete One Stream Processor
-         * @description Delete a Stream Processor within the specified stream workspace. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Stream Processing Owner role.
+         * @description Delete a Stream Processor within the specified stream workspace.
          */
         delete: operations["deleteGroupStreamProcessor"];
         options?: never;
         head?: never;
         /**
          * Update One Stream Processor
-         * @description Modify one existing Stream Processor within the specified stream workspace. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Stream Processing Owner role.
+         * @description Modify one existing Stream Processor within the specified stream workspace.
          */
         patch: operations["updateGroupStreamProcessor"];
         trace?: never;
@@ -677,7 +719,7 @@ export interface paths {
         put?: never;
         /**
          * Start One Stream Processor
-         * @description Start a Stream Processor within the specified stream workspace. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Stream Processing Owner role.
+         * @description Start a Stream Processor within the specified stream workspace.
          */
         post: operations["startGroupStreamProcessor"];
         delete?: never;
@@ -697,7 +739,7 @@ export interface paths {
         put?: never;
         /**
          * Start One Stream Processor With Options
-         * @description Start a Stream Processor within the specified stream workspace. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Stream Processing Owner role.
+         * @description Start a Stream Processor within the specified stream workspace.
          */
         post: operations["startGroupStreamProcessorWith"];
         delete?: never;
@@ -717,7 +759,7 @@ export interface paths {
         put?: never;
         /**
          * Stop One Stream Processor
-         * @description Stop a Stream Processor within the specified stream workspace. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Stream Processing Owner role.
+         * @description Stop a Stream Processor within the specified stream workspace.
          */
         post: operations["stopGroupStreamProcessor"];
         delete?: never;
@@ -735,7 +777,7 @@ export interface paths {
         };
         /**
          * Return All Stream Processors in One Stream Workspace
-         * @description Returns all Stream Processors within the specified stream workspace. To use this resource, the requesting Service Account or API Key must have the Project Owner role or Project Stream Processing Owner role.
+         * @description Returns all Stream Processors within the specified stream workspace.
          */
         get: operations["getGroupStreamProcessors"];
         put?: never;
@@ -755,7 +797,7 @@ export interface paths {
         };
         /**
          * Download Operational Logs for One Atlas Stream Processing Workspace
-         * @description Downloads the operational logs for the specified Atlas Streams Processing workspace or stream processor. By default, logs cover periods of 30 days. To use this resource, the requesting Service Account or API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role. The API does not support direct calls with the json response schema. You must request a gzip response schema using an accept header of the format: "Accept: application/vnd.atlas.2025-03-12+gzip".
+         * @description Downloads the operational logs for the specified Atlas Streams Processing workspace or stream processor. By default, logs cover periods of 30 days. The API does not support direct calls with the json response schema. You must request a gzip response schema using an accept header of the format: "Accept: application/vnd.atlas.2025-03-12+gzip".
          */
         get: operations["downloadGroupStreamOperationalLogs"];
         put?: never;
@@ -777,7 +819,7 @@ export interface paths {
         put?: never;
         /**
          * Create One Stream Workspace with Sample Connections
-         * @description Creates one stream workspace in the specified project with sample connections. To use this resource the requesting Service Account or API Key must have the Project Data Access Admin role, Project Owner role or Project Stream Processing Owner role.
+         * @description Creates one stream workspace in the specified project with sample connections.
          */
         post: operations["withGroupStreamSampleConnections"];
         delete?: never;
@@ -795,7 +837,7 @@ export interface paths {
         };
         /**
          * Return All Organizations
-         * @description Returns all organizations to which the requesting Service Account or API Key has access. To use this resource, the requesting Service Account or API Key must have the Organization Member role.
+         * @description Returns all organizations to which the requesting Service Account or API Key has access.
          */
         get: operations["listOrgs"];
         put?: never;
@@ -821,8 +863,6 @@ export interface paths {
          *     - Associate different MongoDB Cloud users or teams with different environments, or give different permission to MongoDB Cloud users in different environments.
          *     - Maintain separate cluster security configurations.
          *     - Create different alert settings.
-         *
-         *     To use this resource, the requesting Service Account or API Key must have the Organization Member role.
          */
         get: operations["getOrgGroups"];
         put?: never;
@@ -913,7 +953,7 @@ export interface components {
              * @description Cluster tier, with a default storage and memory capacity, that applies to all the data-bearing hosts in your cluster.
              * @enum {string}
              */
-            instanceSizeName?: "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M100" | "M140" | "M200" | "M300" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R700" | "M40_NVME" | "M50_NVME" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M400_NVME";
+            instanceSizeName?: "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M100" | "M140" | "M200" | "M300" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R700" | "M40_NVME" | "M50_NVME" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M400_NVME" | "M30_GEN_2" | "M40_GEN_2" | "M50_GEN_2" | "M60_GEN_2" | "M80_GEN_2" | "M140_GEN_2" | "M200_GEN_2" | "M300_GEN_2" | "R40_GEN_2" | "R50_GEN_2" | "R60_GEN_2" | "R80_GEN_2" | "R200_GEN_2" | "R300_GEN_2" | "R400_GEN_2" | "R700_GEN_2" | "M40_NVME_GEN_2" | "M50_NVME_GEN_2" | "M60_NVME_GEN_2" | "M80_NVME_GEN_2" | "M200_NVME_GEN_2" | "M400_NVME_GEN_2";
             /**
              * AWS Regions
              * @description Physical location where MongoDB Cloud deploys your AWS-hosted MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases. When MongoDB Cloud deploys a dedicated cluster, it checks if a VPC or VPC connection exists for that provider and region. If not, MongoDB Cloud creates them as part of the deployment. MongoDB Cloud assigns the VPC a CIDR block. To limit a new VPC peering connection to one CIDR block and region, create the connection first. Deploy the cluster after the connection starts.
@@ -948,13 +988,13 @@ export interface components {
              * @description Maximum instance size to which your cluster can automatically scale.
              * @enum {string}
              */
-            maxInstanceSize?: "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M100" | "M140" | "M200" | "M300" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R700" | "M40_NVME" | "M50_NVME" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M400_NVME";
+            maxInstanceSize?: "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M100" | "M140" | "M200" | "M300" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R700" | "M40_NVME" | "M50_NVME" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M400_NVME" | "M30_GEN_2" | "M40_GEN_2" | "M50_GEN_2" | "M60_GEN_2" | "M80_GEN_2" | "M140_GEN_2" | "M200_GEN_2" | "M300_GEN_2" | "R40_GEN_2" | "R50_GEN_2" | "R60_GEN_2" | "R80_GEN_2" | "R200_GEN_2" | "R300_GEN_2" | "R400_GEN_2" | "R700_GEN_2" | "M40_NVME_GEN_2" | "M50_NVME_GEN_2" | "M60_NVME_GEN_2" | "M80_NVME_GEN_2" | "M200_NVME_GEN_2" | "M400_NVME_GEN_2";
             /**
              * AWS Instance Sizes
              * @description Minimum instance size to which your cluster can automatically scale.
              * @enum {string}
              */
-            minInstanceSize?: "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M100" | "M140" | "M200" | "M300" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R700" | "M40_NVME" | "M50_NVME" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M400_NVME";
+            minInstanceSize?: "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M100" | "M140" | "M200" | "M300" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R700" | "M40_NVME" | "M50_NVME" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M400_NVME" | "M30_GEN_2" | "M40_GEN_2" | "M50_GEN_2" | "M60_GEN_2" | "M80_GEN_2" | "M140_GEN_2" | "M200_GEN_2" | "M300_GEN_2" | "R40_GEN_2" | "R50_GEN_2" | "R60_GEN_2" | "R80_GEN_2" | "R200_GEN_2" | "R300_GEN_2" | "R400_GEN_2" | "R700_GEN_2" | "M40_NVME_GEN_2" | "M50_NVME_GEN_2" | "M60_NVME_GEN_2" | "M80_NVME_GEN_2" | "M200_NVME_GEN_2" | "M400_NVME_GEN_2";
         };
         AWSCreateDataProcessRegionView: Omit<components["schemas"]["CreateDataProcessRegionView"], "cloudProvider"> & {
             /**
@@ -1027,6 +1067,11 @@ export interface components {
              */
             diskSizeGB?: number;
             /**
+             * Format: int32
+             * @description Target throughput desired for storage attached to this hardware. Only returned for Gen 2 instance sizes with Standard (GP3) volume type.
+             */
+            readonly diskThroughput?: number;
+            /**
              * @description Type of storage you want to attach to your AWS-provisioned cluster.
              *
              *     - `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size.
@@ -1041,7 +1086,7 @@ export interface components {
              * @description Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as "base nodes") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.
              * @enum {string}
              */
-            instanceSize?: "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M100" | "M140" | "M200" | "M300" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R700" | "M40_NVME" | "M50_NVME" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M400_NVME";
+            instanceSize?: "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M100" | "M140" | "M200" | "M300" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R700" | "M40_NVME" | "M50_NVME" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M400_NVME" | "M30_GEN_2" | "M40_GEN_2" | "M50_GEN_2" | "M60_GEN_2" | "M80_GEN_2" | "M140_GEN_2" | "M200_GEN_2" | "M300_GEN_2" | "R40_GEN_2" | "R50_GEN_2" | "R60_GEN_2" | "R80_GEN_2" | "R200_GEN_2" | "R300_GEN_2" | "R400_GEN_2" | "R700_GEN_2" | "M40_NVME_GEN_2" | "M50_NVME_GEN_2" | "M60_NVME_GEN_2" | "M80_NVME_GEN_2" | "M200_NVME_GEN_2" | "M400_NVME_GEN_2";
             /**
              * Format: int32
              * @description Number of nodes of the given type for MongoDB Cloud to deploy to the region.
@@ -1100,7 +1145,7 @@ export interface components {
             /** @description Flag that indicates whether the instance size may scale down via reactive auto-scaling. MongoDB Cloud requires this parameter if `replicationSpecs[n].regionConfigs[m].autoScaling.compute.enabled` is `true`. If you enable this option, specify a value for `replicationSpecs[n].regionConfigs[m].autoScaling.compute.minInstanceSize`. */
             scaleDownEnabled?: boolean;
         };
-        AlertViewForNdsGroup: components["schemas"]["AppServiceAlertView"] | components["schemas"]["ClusterAlertViewForNdsGroup"] | components["schemas"]["HostAlertViewForNdsGroup"] | components["schemas"]["HostMetricAlert"] | components["schemas"]["ReplicaSetAlertViewForNdsGroup"] | components["schemas"]["StreamProcessorAlertViewForNdsGroup"] | components["schemas"]["DefaultAlertViewForNdsGroup"];
+        AlertViewForNdsGroup: components["schemas"]["AppServiceAlertView"] | components["schemas"]["ClusterAlertViewForNdsGroup"] | components["schemas"]["HostAlertViewForNdsGroup"] | components["schemas"]["FlexMetricAlert"] | components["schemas"]["HostMetricAlert"] | components["schemas"]["ReplicaSetAlertViewForNdsGroup"] | components["schemas"]["StreamProcessorAlertViewForNdsGroup"] | components["schemas"]["DefaultAlertViewForNdsGroup"];
         /** @description Object that contains the identifying characteristics of the Amazon Web Services (AWS) Key Management Service (KMS). This field always returns a null value. */
         ApiAtlasCloudProviderAccessFeatureUsageFeatureIdView: Record<string, never> | null;
         /** @description Group of settings that configures a subset of the advanced configuration details. */
@@ -1180,12 +1225,12 @@ export interface components {
          * @description Atlas Streams AWS Regions.
          * @enum {string}
          */
-        ApiStreamsAWSRegionView: "SYDNEY_AUS" | "MUMBAI_IND" | "FRANKFURT_DEU" | "DUBLIN_IRL" | "LONDON_GBR" | "VIRGINIA_USA" | "OHIO_USA" | "OREGON_USA" | "SAOPAULO_BRA" | "MONTREAL_CAN" | "TOKYO_JPN" | "SINGAPORE_SGP";
+        ApiStreamsAWSRegionView: "SYDNEY_AUS" | "MUMBAI_IND" | "FRANKFURT_DEU" | "DUBLIN_IRL" | "LONDON_GBR" | "VIRGINIA_USA" | "OHIO_USA" | "OREGON_USA" | "SAOPAULO_BRA" | "MONTREAL_CAN" | "TOKYO_JPN" | "SINGAPORE_SGP" | "PARIS_FRA";
         /**
          * @description Atlas Streams Azure Regions.
          * @enum {string}
          */
-        ApiStreamsAzureRegionView: "eastus" | "westus" | "eastus2" | "westeurope";
+        ApiStreamsAzureRegionView: "eastus" | "westus" | "eastus2" | "westeurope" | "brazilsouth" | "australiaeast";
         /**
          * @description Atlas Streams GCP Regions.
          * @enum {string}
@@ -1207,7 +1252,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -1314,6 +1359,186 @@ export interface components {
             tokenizer: {
                 [key: string]: Record<string, never>;
             };
+        };
+        /**
+         * Tenant Cluster Upgrade Request
+         * @description Request containing target state of tenant cluster to be upgraded.
+         */
+        AtlasTenantClusterUpgradeRequest20240805: {
+            /**
+             * Format: date-time
+             * @description If reconfiguration is necessary to regain a primary due to a regional outage, submit this field alongside your topology reconfiguration to request a new regional outage resistant topology. Forced reconfigurations during an outage of the majority of electable nodes carry a risk of data loss if replicated writes (even majority committed writes) have not been replicated to the new primary node. MongoDB Atlas docs contain more information. To proceed with an operation which carries that risk, set `acceptDataRisksAndForceReplicaSetReconfig` to the current date. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+             */
+            acceptDataRisksAndForceReplicaSetReconfig?: string;
+            /**
+             * @description Governs adaptive capacity behavior of Azure nodes in single-cloud Azure clusters or multi-cloud clusters that include Azure nodes. Adaptive capacity enables fallback hardware selection when the primary instance family is unavailable. ``ENABLED`` means the cluster explicitly opts in to adaptive capacity. ``DISABLED`` means the cluster explicitly opts out; the cluster receives capacity errors instead of being placed on fallback hardware. ``null`` means the field is unset; Azure clusters use adaptive capacity by default when the feature is enabled at the group level. Setting this field for single-cloud AWS or GCP clusters is a no-op.
+             * @enum {string|null}
+             */
+            adaptiveCapacity?: "ENABLED" | "DISABLED" | null;
+            advancedConfiguration?: components["schemas"]["ApiAtlasClusterAdvancedConfigurationView"];
+            /**
+             * @description Flag that indicates whether the cluster can perform backups. If set to `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters. Backup uses Cloud Backups for dedicated clusters and [Shared Cluster Backups](https://docs.atlas.mongodb.com/backup/shared-tier/overview/) for tenant clusters. If set to `false`, the cluster doesn't use backups.
+             * @default false
+             */
+            backupEnabled: boolean;
+            biConnector?: components["schemas"]["BiConnector"];
+            /**
+             * @description Configuration of nodes that comprise the cluster.
+             * @enum {string}
+             */
+            clusterType?: "REPLICASET" | "SHARDED" | "GEOSHARDED";
+            /**
+             * @description Config Server Management Mode for creating or updating a sharded cluster. When configured as `ATLAS_MANAGED`, Atlas may automatically switch the cluster's config server type for optimal performance and savings. When configured as `FIXED_TO_DEDICATED`, the cluster will always use a dedicated config server.
+             * @default ATLAS_MANAGED
+             * @enum {string}
+             */
+            configServerManagementMode: "ATLAS_MANAGED" | "FIXED_TO_DEDICATED";
+            /**
+             * @description Describes a sharded cluster's config server type.
+             * @enum {string}
+             */
+            readonly configServerType?: "DEDICATED" | "EMBEDDED";
+            connectionStrings?: components["schemas"]["ClusterConnectionStrings"];
+            /**
+             * Format: date-time
+             * @description Date and time when MongoDB Cloud created this cluster. This parameter expresses its value in ISO 8601 format in UTC.
+             */
+            readonly createDate?: string;
+            /**
+             * @description Disk warming mode selection.
+             * @default FULLY_WARMED
+             * @enum {string}
+             */
+            diskWarmingMode: "FULLY_WARMED" | "VISIBLE_EARLIER";
+            /** @description List of settings that represent the actual cluster state. This is read-only and always returned in the response. It reflects the current cluster configuration, which may differ from `replicationSpecs` due to system-managed changes. */
+            readonly effectiveReplicationSpecs?: components["schemas"]["ReplicationSpec20240805"][];
+            /**
+             * @description Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster. To enable customer key management for encryption at rest, the cluster `replicationSpecs[n].regionConfigs[m].{type}Specs.instanceSize` setting must be `M10` or higher and `"backupEnabled" : false` or omitted entirely.
+             * @enum {string}
+             */
+            encryptionAtRestProvider?: "NONE" | "AWS" | "AZURE" | "GCP";
+            /** @description Feature compatibility version of the cluster. This will always appear regardless of whether FCV is pinned. */
+            readonly featureCompatibilityVersion?: string;
+            /**
+             * Format: date-time
+             * @description Feature compatibility version expiration date. Will only appear if FCV is pinned. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+             */
+            readonly featureCompatibilityVersionExpirationDate?: string;
+            /**
+             * @description Set this field to configure the Sharding Management Mode when creating a new Global Cluster.
+             *
+             *     When set to false, the management mode is set to Atlas-Managed Sharding. This mode fully manages the sharding of your Global Cluster and is built to provide a seamless deployment experience.
+             *
+             *     When set to true, the management mode is set to Self-Managed Sharding. This mode leaves the management of shards in your hands and is built to provide an advanced and flexible deployment experience.
+             *
+             *     This setting cannot be changed once the cluster is deployed.
+             */
+            globalClusterSelfManagedSharding?: boolean;
+            /**
+             * @description Unique 24-hexadecimal character string that identifies the project.
+             * @example 32b6e34b3d91647abb20e7b8
+             */
+            readonly groupId?: string;
+            /**
+             * @description Unique 24-hexadecimal digit string that identifies the cluster.
+             * @example 32b6e34b3d91647abb20e7b8
+             */
+            readonly id?: string;
+            /**
+             * @description Internal classification of the cluster's role. Possible values: `NONE` (regular user cluster), `SYSTEM_CLUSTER` (system cluster for backup), `INTERNAL_SHADOW_CLUSTER` (internal use shadow cluster for testing).
+             * @enum {string}
+             */
+            readonly internalClusterRole?: "NONE" | "SYSTEM_CLUSTER" | "INTERNAL_SHADOW_CLUSTER";
+            /**
+             * @deprecated
+             * @description Collection of key-value pairs between 1 to 255 characters in length that tag and categorize the cluster. The MongoDB Cloud console doesn't display your labels.
+             *
+             *     Cluster labels are deprecated and will be removed in a future release. We strongly recommend that you use Resource Tags instead.
+             */
+            labels?: components["schemas"]["ComponentLabel"][];
+            /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
+            readonly links?: components["schemas"]["Link"][];
+            mongoDBEmployeeAccessGrant?: components["schemas"]["EmployeeAccessGrantView"];
+            /**
+             * @description MongoDB major version of the cluster. Set to the binary major version.
+             *
+             *     On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for [project LTS versions endpoint](#tag/Projects/operation/getProjectLtsVersions).
+             *
+             *      On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version.
+             */
+            mongoDBMajorVersion?: string;
+            /** @description Version of MongoDB that the cluster runs. */
+            readonly mongoDBVersion?: string;
+            /** @description Human-readable label that identifies the cluster. */
+            name: string;
+            /** @description Flag that indicates whether the cluster is paused. */
+            paused?: boolean;
+            /** @description Flag that indicates whether the cluster uses continuous cloud backups. */
+            pitEnabled?: boolean;
+            /**
+             * @description Enable or disable log redaction.
+             *
+             *     This setting configures the ``mongod`` or ``mongos`` to redact any document field contents from a message accompanying a given log event before logging. This prevents the program from writing potentially sensitive data stored on the database to the diagnostic log. Metadata such as error or operation codes, line numbers, and source file names are still visible in the logs.
+             *
+             *     Use ``redactClientLogData`` in conjunction with Encryption at Rest and TLS/SSL (Transport Encryption) to assist compliance with regulatory requirements.
+             *
+             *     *Note*: changing this setting on a cluster will trigger a rolling restart as soon as the cluster is updated.
+             */
+            redactClientLogData?: boolean;
+            /**
+             * @description Set this field to configure the replica set scaling mode for your cluster.
+             *
+             *     By default, Atlas scales under `WORKLOAD_TYPE`. This mode allows Atlas to scale your analytics nodes in parallel to your operational nodes.
+             *
+             *     When configured as `SEQUENTIAL`, Atlas scales all nodes sequentially. This mode is intended for steady-state workloads and applications performing latency-sensitive secondary reads.
+             *
+             *     When configured as `NODE_TYPE`, Atlas scales your electable nodes in parallel with your read-only and analytics nodes. This mode is intended for large, dynamic workloads requiring frequent and timely cluster tier scaling. This is the fastest scaling strategy, but it might impact latency of workloads when performing extensive secondary reads.
+             * @default WORKLOAD_TYPE
+             * @enum {string}
+             */
+            replicaSetScalingStrategy: "SEQUENTIAL" | "WORKLOAD_TYPE" | "NODE_TYPE";
+            /** @description List of settings that configure your cluster regions. This array has one object per shard representing node configurations in each shard. For replica sets there is only one object representing node configurations. */
+            replicationSpecs?: components["schemas"]["ReplicationSpec20240805"][];
+            /**
+             * @description Flag that indicates whether the cluster retains backups.
+             * @default false
+             */
+            retainBackups: boolean;
+            /**
+             * @description Root Certificate Authority that MongoDB Atlas cluster uses. MongoDB Cloud supports Internet Security Research Group.
+             * @default ISRGROOTX1
+             * @enum {string}
+             */
+            rootCertType: "ISRGROOTX1";
+            /**
+             * @description Human-readable label that indicates any current activity being taken on this cluster by the Atlas control plane. With the exception of CREATING and DELETING states, clusters should always be available and have a Primary node even when in states indicating ongoing activity.
+             *
+             *      - `IDLE`: Atlas is making no changes to this cluster and all changes requested via the UI or API can be assumed to have been applied.
+             *      - `CREATING`: A cluster being provisioned for the very first time returns state CREATING until it is ready for connections. Ensure IP Access List and DB Users are configured before attempting to connect.
+             *      - `UPDATING`: A change requested via the UI, API, AutoScaling, or other scheduled activity is taking place.
+             *      - `DELETING`: The cluster is in the process of deletion and will soon be deleted.
+             *      - `REPAIRING`: One or more nodes in the cluster are being returned to service by the Atlas control plane. Other nodes should continue to provide service as normal.
+             * @enum {string}
+             */
+            readonly stateName?: "IDLE" | "CREATING" | "UPDATING" | "DELETING" | "REPAIRING";
+            /** @description List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. */
+            tags?: components["schemas"]["ResourceTag"][];
+            /**
+             * @description Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, MongoDB Cloud won't delete the cluster. If set to `false`, MongoDB Cloud will delete the cluster.
+             * @default false
+             */
+            terminationProtectionEnabled: boolean;
+            /**
+             * @description Flag that indicates whether AWS time-based snapshot copies will be used instead of slower standard snapshot copies during fast Atlas cross-region initial syncs. This flag is only relevant for clusters containing AWS nodes.
+             * @default false
+             */
+            useAwsTimeBasedSnapshotCopyForFastInitialSync: boolean;
+            /**
+             * @description Method by which the cluster maintains the MongoDB versions. If value is `CONTINUOUS`, you must not specify `mongoDBMajorVersion`.
+             * @default LTS
+             * @enum {string}
+             */
+            versionReleaseSystem: "LTS" | "CONTINUOUS";
         };
         AzureAccountDetails: {
             /** @description The Azure Subscription ID. */
@@ -1424,6 +1649,20 @@ export interface components {
              * @enum {string}
              */
             minInstanceSize?: "M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M90" | "M200" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M300_NVME" | "M400_NVME" | "M600_NVME";
+        };
+        /** @description Azure-specific configuration for the connection. */
+        AzureConnection: {
+            /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
+            readonly links?: components["schemas"]["Link"][];
+            /**
+             * @deprecated
+             * @description Azure region where the storage account is located.
+             */
+            region?: string;
+            /** @description Unique ID of the Azure Service Principal that has access to the storage account. */
+            servicePrincipalId?: string;
+            /** @description Name of the Azure Storage Account to connect to. */
+            storageAccountName?: string;
         };
         AzureCreateDataProcessRegionView: Omit<components["schemas"]["CreateDataProcessRegionView"], "cloudProvider"> & {
             /**
@@ -1610,7 +1849,7 @@ export interface components {
             fields?: components["schemas"]["FieldViolation"][];
         };
         /** @description Instance size boundary to which your cluster can automatically scale. */
-        BaseCloudProviderInstanceSize: ("M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M100" | "M140" | "M200" | "M300" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R700" | "M40_NVME" | "M50_NVME" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M400_NVME") | ("M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M90" | "M200" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M300_NVME" | "M400_NVME" | "M600_NVME") | ("M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M140" | "M200" | "M250" | "M300" | "M400" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R600");
+        BaseCloudProviderInstanceSize: ("M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M100" | "M140" | "M200" | "M300" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R700" | "M40_NVME" | "M50_NVME" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M400_NVME" | "M30_GEN_2" | "M40_GEN_2" | "M50_GEN_2" | "M60_GEN_2" | "M80_GEN_2" | "M140_GEN_2" | "M200_GEN_2" | "M300_GEN_2" | "R40_GEN_2" | "R50_GEN_2" | "R60_GEN_2" | "R80_GEN_2" | "R200_GEN_2" | "R300_GEN_2" | "R400_GEN_2" | "R700_GEN_2" | "M40_NVME_GEN_2" | "M50_NVME_GEN_2" | "M60_NVME_GEN_2" | "M80_NVME_GEN_2" | "M200_NVME_GEN_2" | "M400_NVME_GEN_2") | ("M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M90" | "M200" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "M60_NVME" | "M80_NVME" | "M200_NVME" | "M300_NVME" | "M400_NVME" | "M600_NVME") | ("M10" | "M20" | "M30" | "M40" | "M50" | "M60" | "M80" | "M140" | "M200" | "M250" | "M300" | "M400" | "R40" | "R50" | "R60" | "R80" | "R200" | "R300" | "R400" | "R600");
         /** @description Name of the cloud provider region hosting Atlas Stream Processing. */
         BaseStreamsRegion: components["schemas"]["ApiStreamsAWSRegionView"] | components["schemas"]["ApiStreamsAzureRegionView"] | components["schemas"]["ApiStreamsGCPRegionView"];
         BasicDBObject: {
@@ -1628,255 +1867,6 @@ export interface components {
              * @enum {string}
              */
             readPreference?: "PRIMARY" | "SECONDARY" | "ANALYTICS";
-        };
-        BillingInvoice: {
-            /**
-             * Format: int64
-             * @description Sum of services that the specified organization consumed in the period covered in this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly amountBilledCents?: number;
-            /**
-             * Format: int64
-             * @description Sum that the specified organization paid toward this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly amountPaidCents?: number;
-            /**
-             * Format: date-time
-             * @description Date and time when MongoDB Cloud created this invoice. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly created?: string;
-            /**
-             * Format: int64
-             * @description Sum that MongoDB credited the specified organization toward this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly creditsCents?: number;
-            /**
-             * Format: date-time
-             * @description Date and time when MongoDB Cloud finished the billing period that this invoice covers. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly endDate?: string;
-            /**
-             * @description Unique 24-hexadecimal digit string that identifies the invoice submitted to the specified organization. Charges typically post the next day.
-             * @example 32b6e34b3d91647abb20e7b8
-             */
-            readonly id?: string;
-            /** @description List that contains individual services included in this invoice. */
-            readonly lineItems?: components["schemas"]["InvoiceLineItem"][];
-            /** @description List that contains the invoices for organizations linked to the paying organization. */
-            readonly linkedInvoices?: components["schemas"]["BillingInvoice"][];
-            /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
-            readonly links?: components["schemas"]["Link"][];
-            /**
-             * @description Unique 24-hexadecimal digit string that identifies the organization charged for services consumed from MongoDB Cloud.
-             * @example 32b6e34b3d91647abb20e7b8
-             */
-            readonly orgId?: string;
-            /** @description List that contains funds transferred to MongoDB to cover the specified service noted in this invoice. */
-            readonly payments?: components["schemas"]["BillingPayment"][];
-            /** @description List that contains payments that MongoDB returned to the organization for this invoice. */
-            readonly refunds?: components["schemas"]["BillingRefund"][];
-            /**
-             * Format: int64
-             * @description Sum of sales tax applied to this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly salesTaxCents?: number;
-            /**
-             * Format: date-time
-             * @description Date and time when MongoDB Cloud began the billing period that this invoice covers. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly startDate?: string;
-            /**
-             * Format: int64
-             * @description Sum that the specified organization owed to MongoDB when MongoDB issued this invoice. This parameter expresses its value in US Dollars.
-             */
-            readonly startingBalanceCents?: number;
-            /**
-             * @description Phase of payment processing in which this invoice exists when you made this request. Accepted phases include:
-             *
-             *     - `CLOSED`: MongoDB finalized all charges in the billing cycle but has yet to charge the customer.
-             *     - `FAILED`: MongoDB attempted to charge the provided credit card but charge for that amount failed.
-             *     - `FORGIVEN`: Customer initiated payment which MongoDB later forgave.
-             *     - `FREE`: All charges totalled zero so the customer won't be charged.
-             *     - `INVOICED`: MongoDB handled these charges using elastic invoicing.
-             *     - `PAID`: MongoDB succeeded in charging the provided credit card.
-             *     - `PENDING`: Invoice includes charges for the current billing cycle.
-             *     - `PREPAID`: Customer has a pre-paid plan so they won't be charged.
-             * @enum {string}
-             */
-            statusName?: "PENDING" | "CLOSED" | "FORGIVEN" | "FAILED" | "PAID" | "FREE" | "PREPAID" | "INVOICED";
-            /**
-             * Format: int64
-             * @description Sum of all positive invoice line items contained in this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly subtotalCents?: number;
-            /**
-             * Format: date-time
-             * @description Date and time when MongoDB Cloud last updated the value of this payment. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly updated?: string;
-        };
-        BillingInvoiceMetadata: {
-            /**
-             * Format: int64
-             * @description Sum of services that the specified organization consumed in the period covered in this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly amountBilledCents?: number;
-            /**
-             * Format: int64
-             * @description Sum that the specified organization paid toward this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly amountPaidCents?: number;
-            /**
-             * Format: date-time
-             * @description Date and time when MongoDB Cloud created this invoice. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly created?: string;
-            /**
-             * Format: int64
-             * @description Sum that MongoDB credited the specified organization toward this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly creditsCents?: number;
-            /**
-             * Format: date-time
-             * @description Date and time when MongoDB Cloud finished the billing period that this invoice covers. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly endDate?: string;
-            /**
-             * @description Unique 24-hexadecimal digit string that identifies the invoice submitted to the specified organization. Charges typically post the next day.
-             * @example 32b6e34b3d91647abb20e7b8
-             */
-            readonly id?: string;
-            /** @description List that contains the invoices for organizations linked to the paying organization. */
-            readonly linkedInvoices?: components["schemas"]["BillingInvoiceMetadata"][];
-            /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
-            readonly links?: components["schemas"]["Link"][];
-            /**
-             * @description Unique 24-hexadecimal digit string that identifies the organization charged for services consumed from MongoDB Cloud.
-             * @example 32b6e34b3d91647abb20e7b8
-             */
-            readonly orgId?: string;
-            /**
-             * Format: int64
-             * @description Sum of sales tax applied to this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly salesTaxCents?: number;
-            /**
-             * Format: date-time
-             * @description Date and time when MongoDB Cloud began the billing period that this invoice covers. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly startDate?: string;
-            /**
-             * Format: int64
-             * @description Sum that the specified organization owed to MongoDB when MongoDB issued this invoice. This parameter expresses its value in US Dollars.
-             */
-            readonly startingBalanceCents?: number;
-            /**
-             * @description Phase of payment processing in which this invoice exists when you made this request. Accepted phases include:
-             *
-             *     - `CLOSED`: MongoDB finalized all charges in the billing cycle but has yet to charge the customer.
-             *     - `FAILED`: MongoDB attempted to charge the provided credit card but charge for that amount failed.
-             *     - `FORGIVEN`: Customer initiated payment which MongoDB later forgave.
-             *     - `FREE`: All charges totalled zero so the customer won't be charged.
-             *     - `INVOICED`: MongoDB handled these charges using elastic invoicing.
-             *     - `PAID`: MongoDB succeeded in charging the provided credit card.
-             *     - `PENDING`: Invoice includes charges for the current billing cycle.
-             *     - `PREPAID`: Customer has a pre-paid plan so they won't be charged.
-             * @enum {string}
-             */
-            statusName?: "PENDING" | "CLOSED" | "FORGIVEN" | "FAILED" | "PAID" | "FREE" | "PREPAID" | "INVOICED";
-            /**
-             * Format: int64
-             * @description Sum of all positive invoice line items contained in this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly subtotalCents?: number;
-            /**
-             * Format: date-time
-             * @description Date and time when MongoDB Cloud last updated the value of this payment. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly updated?: string;
-        };
-        /**
-         * Payment
-         * @description Funds transferred to MongoDB to cover the specified service in this invoice.
-         */
-        BillingPayment: {
-            /**
-             * Format: int64
-             * @description Sum of services that the specified organization consumed in the period covered in this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly amountBilledCents?: number;
-            /**
-             * Format: int64
-             * @description Sum that the specified organization paid toward the associated invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly amountPaidCents?: number;
-            /**
-             * Format: date-time
-             * @description Date and time when the customer made this payment attempt. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly created?: string;
-            /** @description The currency in which payment was paid. This parameter expresses its value in 3-letter ISO 4217 currency code. */
-            readonly currency?: string;
-            /**
-             * @description Unique 24-hexadecimal digit string that identifies this payment toward the associated invoice.
-             * @example 32b6e34b3d91647abb20e7b8
-             */
-            readonly id?: string;
-            /**
-             * Format: int64
-             * @description Sum of sales tax applied to this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly salesTaxCents?: number;
-            /**
-             * @description Phase of payment processing for the associated invoice when you made this request. These phases include:
-             *
-             *     - `CANCELLED`: Customer or MongoDB cancelled the payment.
-             *     - `ERROR`: Issue arose when attempting to complete payment.
-             *     - `FAILED`: MongoDB tried to charge the credit card without success.
-             *     - `FAILED_AUTHENTICATION`: Strong Customer Authentication has failed. Confirm that your payment method is authenticated.
-             *     - `FORGIVEN`: Customer initiated payment which MongoDB later forgave.
-             *     - `INVOICED`: MongoDB issued an invoice that included this line item.
-             *     - `NEW`: Customer provided a method of payment, but MongoDB hasn't tried to charge the credit card.
-             *     - `PAID`: Customer submitted a successful payment.
-             *     - `PARTIAL_PAID`: Customer paid for part of this line item.
-             * @enum {string}
-             */
-            statusName?: "NEW" | "FORGIVEN" | "FAILED" | "PAID" | "PARTIAL_PAID" | "CANCELLED" | "INVOICED" | "FAILED_AUTHENTICATION" | "PROCESSING" | "PENDING_REVERSAL" | "REFUNDED";
-            /**
-             * Format: int64
-             * @description Sum of all positive invoice line items contained in this invoice. This parameter expresses its value in cents (100ths of one US Dollar).
-             */
-            readonly subtotalCents?: number;
-            /** @description The unit price applied to `amountBilledCents` to compute total payment amount. This value is represented as a decimal string. */
-            readonly unitPrice?: string;
-            /**
-             * Format: date-time
-             * @description Date and time when the customer made an update to this payment attempt. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly updated?: string;
-        };
-        /**
-         * Refund
-         * @description One payment that MongoDB returned to the organization for this invoice.
-         */
-        BillingRefund: {
-            /**
-             * Format: int64
-             * @description Sum of the funds returned to the specified organization expressed in cents (100th of US Dollar).
-             */
-            readonly amountCents?: number;
-            /**
-             * Format: date-time
-             * @description Date and time when MongoDB Cloud created this refund. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
-             */
-            readonly created?: string;
-            /**
-             * @description Unique 24-hexadecimal digit string that identifies the payment that the organization had made.
-             * @example 32b6e34b3d91647abb20e7b8
-             */
-            readonly paymentId?: string;
-            /** @description Justification that MongoDB accepted to return funds to the organization. */
-            readonly reason?: string;
         };
         /** @description Settings that describe the clusters in each project that the API key is authorized to view. */
         CloudCluster: {
@@ -2421,7 +2411,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -2485,6 +2475,34 @@ export interface components {
             readonly updated: string;
         };
         /**
+         * Automatic Cluster Scaling Settings
+         * @description Range of instance sizes to which your cluster can scale.
+         */
+        ClusterAutoScalingSettings: {
+            compute?: components["schemas"]["ClusterComputeAutoScaling"];
+            /**
+             * @description Flag that indicates whether someone enabled disk auto-scaling for this cluster.
+             * @default false
+             */
+            diskGBEnabled: boolean;
+        };
+        /** @description Collection of settings that configures how a cluster might scale its cluster tier and whether the cluster can scale down. Cluster tier auto-scaling is unavailable for clusters using Low CPU or NVME storage classes. */
+        ClusterComputeAutoScaling: {
+            /**
+             * @description Flag that indicates whether instance size reactive auto-scaling is enabled.
+             *
+             *     - Set to `true` to enable instance size reactive auto-scaling. If enabled, you must specify a value for `providerSettings.autoScaling.compute.maxInstanceSize`.
+             *     - Set to `false` to disable instance size reactive auto-scaling.
+             * @default false
+             */
+            enabled: boolean;
+            /**
+             * @description Flag that indicates whether the cluster tier can scale down via reactive auto-scaling. This is required if `autoScaling.compute.enabled` is `true`. If you enable this option, specify a value for `providerSettings.autoScaling.compute.minInstanceSize`.
+             * @default false
+             */
+            scaleDownEnabled: boolean;
+        };
+        /**
          * Cluster Connection Strings
          * @description Collection of Uniform Resource Locators that point to the MongoDB database.
          */
@@ -2514,6 +2532,11 @@ export interface components {
              * @description If reconfiguration is necessary to regain a primary due to a regional outage, submit this field alongside your topology reconfiguration to request a new regional outage resistant topology. Forced reconfigurations during an outage of the majority of electable nodes carry a risk of data loss if replicated writes (even majority committed writes) have not been replicated to the new primary node. MongoDB Atlas docs contain more information. To proceed with an operation which carries that risk, set `acceptDataRisksAndForceReplicaSetReconfig` to the current date. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
              */
             acceptDataRisksAndForceReplicaSetReconfig?: string;
+            /**
+             * @description Governs adaptive capacity behavior of Azure nodes in single-cloud Azure clusters or multi-cloud clusters that include Azure nodes. Adaptive capacity enables fallback hardware selection when the primary instance family is unavailable. ``ENABLED`` means the cluster explicitly opts in to adaptive capacity. ``DISABLED`` means the cluster explicitly opts out; the cluster receives capacity errors instead of being placed on fallback hardware. ``null`` means the field is unset; Azure clusters use adaptive capacity by default when the feature is enabled at the group level. Setting this field for single-cloud AWS or GCP clusters is a no-op.
+             * @enum {string|null}
+             */
+            adaptiveCapacity?: "ENABLED" | "DISABLED" | null;
             advancedConfiguration?: components["schemas"]["ApiAtlasClusterAdvancedConfigurationView"];
             /**
              * @description Flag that indicates whether the cluster can perform backups. If set to `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters. Backup uses Cloud Backups for dedicated clusters and [Shared Cluster Backups](https://docs.atlas.mongodb.com/backup/shared-tier/overview/) for tenant clusters. If set to `false`, the cluster doesn't use backups.
@@ -2885,18 +2908,30 @@ export interface components {
          * AWS
          * @description Group of Private Endpoint settings.
          */
-        CreateAWSEndpointRequest: components["schemas"]["CreateEndpointRequest"] & {
+        CreateAWSEndpointRequest: Omit<components["schemas"]["CreateEndpointRequest"], "cloudProvider"> & {
             /**
              * @description Unique string that identifies the private endpoint's network interface that someone added to this private endpoint service.
              * @example vpce-3bf78b0ddee411ba1
              */
             id: string;
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            cloudProvider: "AWS";
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            cloudProvider: "AWS";
         };
         /**
          * AZURE
          * @description Group of Private Endpoint settings.
          */
-        CreateAzureEndpointRequest: components["schemas"]["CreateEndpointRequest"] & {
+        CreateAzureEndpointRequest: Omit<components["schemas"]["CreateEndpointRequest"], "cloudProvider"> & {
             /**
              * @description Unique string that identifies the private endpoint's network interface that someone added to this private endpoint service.
              * @example /subscriptions/cba6d9c6-1d3f-3c11-03cb-c705d895e636/resourcegroups/qrRTqi4TSN)7yB5YLRjVDveH3.yLzpNR7Br0D3-SGrU3j0.0/providers/Microsoft.Network/privateEndpoints/pVP(vb(XeckpxtXzP0NaOsDjeWDbOK)DX8A2j2E_vBYL2.GEYIdln
@@ -2904,6 +2939,18 @@ export interface components {
             id: string;
             /** @description IPv4 address of the private endpoint in your Azure VNet that someone added to this private endpoint service. */
             privateEndpointIPAddress: string;
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            cloudProvider: "AZURE";
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            cloudProvider: "AZURE";
         };
         /** @description Settings to configure the region where you wish to store your archived data. */
         CreateDataProcessRegionView: {
@@ -2913,12 +2960,18 @@ export interface components {
              */
             cloudProvider?: "AWS" | "AZURE" | "GCP";
         };
-        CreateEndpointRequest: components["schemas"]["CreateAWSEndpointRequest"] | components["schemas"]["CreateAzureEndpointRequest"] | components["schemas"]["CreateGCPEndpointGroupRequest"];
+        CreateEndpointRequest: {
+            /**
+             * @description Cloud service provider that manages this private endpoint.
+             * @enum {string}
+             */
+            cloudProvider?: "AWS" | "AZURE" | "GCP";
+        } & (components["schemas"]["CreateAWSEndpointRequest"] | components["schemas"]["CreateAzureEndpointRequest"] | components["schemas"]["CreateGCPEndpointGroupRequest"]);
         /**
          * GCP
          * @description Group of Private Endpoint settings.
          */
-        CreateGCPEndpointGroupRequest: components["schemas"]["CreateEndpointRequest"] & {
+        CreateGCPEndpointGroupRequest: Omit<components["schemas"]["CreateEndpointRequest"], "cloudProvider"> & {
             /** @description Human-readable label that identifies a set of endpoints. If this private endpoint belongs to a port-mapped endpoint service, this field is still required but ignored. */
             endpointGroupName: string;
             /** @description List of individual private endpoints that comprise this endpoint group. If this endpoint belongs to a port-mapped endpoint service, this field will only take in a list of one private endpoint. */
@@ -2928,6 +2981,18 @@ export interface components {
              * @example p-fdeeb3e43b8e733e5ab627b1
              */
             gcpProjectId: string;
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            cloudProvider: "GCP";
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            cloudProvider: "GCP";
         };
         /** GCP Forwarding Rules */
         CreateGCPForwardingRuleRequest: {
@@ -3003,22 +3068,22 @@ export interface components {
         DailyScheduleView: Omit<WithRequired<components["schemas"]["OnlineArchiveSchedule"], "type">, "type"> & {
             /**
              * Format: int32
-             * @description Hour of the day when the scheduled window to run one online archive ends.
+             * @description Hour of the day when the scheduled window to run one online archive ends. This field uses the UTC time zone. The window must have a duration of at least two hours. If the end time is before or equal to the start time, the window extends to the next day.
              */
             endHour?: number;
             /**
              * Format: int32
-             * @description Minute of the hour when the scheduled window to run one online archive ends.
+             * @description Minute of the hour when the scheduled window to run one online archive ends. This field uses the UTC time zone. The window must have a duration of at least two hours. If the end time is before or equal to the start time, the window extends to the next day.
              */
             endMinute?: number;
             /**
              * Format: int32
-             * @description Hour of the day when the when the scheduled window to run one online archive starts.
+             * @description Hour of the day when the scheduled window to run one online archive starts. This field uses the UTC time zone.
              */
             startHour?: number;
             /**
              * Format: int32
-             * @description Minute of the hour when the scheduled window to run one online archive starts.
+             * @description Minute of the hour when the scheduled window to run one online archive starts. This field uses the UTC time zone.
              */
             startMinute?: number;
         } & {
@@ -3304,7 +3369,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -3566,7 +3631,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -3585,7 +3650,7 @@ export interface components {
              */
             readonly created: string;
             /** @description Incident that triggered this alert. */
-            readonly eventTypeName: ("CREDIT_CARD_ABOUT_TO_EXPIRE" | "PENDING_INVOICE_OVER_THRESHOLD" | "DAILY_BILL_OVER_THRESHOLD") | ("CPS_SNAPSHOT_STARTED" | "CPS_SNAPSHOT_SUCCESSFUL" | "CPS_SNAPSHOT_FAILED" | "CPS_CONCURRENT_SNAPSHOT_FAILED_WILL_RETRY" | "CPS_SNAPSHOT_BEHIND" | "CPS_COPY_SNAPSHOT_STARTED" | "CPS_COPY_SNAPSHOT_FAILED" | "CPS_COPY_SNAPSHOT_FAILED_WILL_RETRY" | "CPS_COPY_SNAPSHOT_SUCCESSFUL" | "CPS_PREV_SNAPSHOT_OLD" | "CPS_SNAPSHOT_FALLBACK_SUCCESSFUL" | "CPS_SNAPSHOT_FALLBACK_FAILED" | "CPS_RESTORE_SUCCESSFUL" | "CPS_EXPORT_SUCCESSFUL" | "CPS_RESTORE_FAILED" | "CPS_EXPORT_FAILED" | "CPS_COLLECTION_RESTORE_SUCCESSFUL" | "CPS_COLLECTION_RESTORE_FAILED" | "CPS_COLLECTION_RESTORE_PARTIAL_SUCCESS" | "CPS_COLLECTION_RESTORE_CANCELED" | "CPS_AUTO_EXPORT_FAILED" | "CPS_SNAPSHOT_DOWNLOAD_REQUEST_FAILED" | "CPS_OPLOG_BEHIND" | "CPS_OPLOG_CAUGHT_UP") | ("AWS_ENCRYPTION_KEY_NEEDS_ROTATION" | "AZURE_ENCRYPTION_KEY_NEEDS_ROTATION" | "GCP_ENCRYPTION_KEY_NEEDS_ROTATION" | "AWS_ENCRYPTION_KEY_INVALID" | "AZURE_ENCRYPTION_KEY_INVALID" | "GCP_ENCRYPTION_KEY_INVALID") | ("FTS_INDEX_DELETION_FAILED" | "FTS_INDEX_BUILD_COMPLETE" | "FTS_INDEX_BUILD_FAILED" | "FTS_INDEX_STALE" | "FTS_INDEXES_RESTORE_FAILED" | "FTS_INDEXES_SYNONYM_MAPPING_INVALID") | ("USERS_WITHOUT_MULTI_FACTOR_AUTH" | "ENCRYPTION_AT_REST_KMS_NETWORK_ACCESS_DENIED" | "ENCRYPTION_AT_REST_CONFIG_NO_LONGER_VALID" | "GROUP_SERVICE_ACCOUNT_SECRETS_EXPIRING" | "GROUP_SERVICE_ACCOUNT_SECRETS_EXPIRED" | "ACTIVE_LEGACY_TLS_CONNECTIONS") | "MONGOTUNE_ALERT" | ("CLUSTER_INSTANCE_STOP_START" | "CLUSTER_INSTANCE_RESYNC_REQUESTED" | "CLUSTER_INSTANCE_UPDATE_REQUESTED" | "SAMPLE_DATASET_LOAD_REQUESTED" | "TENANT_UPGRADE_TO_SERVERLESS_SUCCESSFUL" | "TENANT_UPGRADE_TO_SERVERLESS_FAILED" | "NETWORK_PERMISSION_ENTRY_ADDED" | "NETWORK_PERMISSION_ENTRY_REMOVED" | "NETWORK_PERMISSION_ENTRY_UPDATED" | "CLUSTER_BLOCK_WRITE" | "CLUSTER_UNBLOCK_WRITE") | ("MAINTENANCE_IN_ADVANCED" | "MAINTENANCE_AUTO_DEFERRED" | "MAINTENANCE_STARTED" | "MAINTENANCE_COMPLETED" | "MAINTENANCE_NO_LONGER_NEEDED") | ("NDS_X509_USER_AUTHENTICATION_CUSTOMER_CA_EXPIRATION_CHECK" | "NDS_X509_USER_AUTHENTICATION_CUSTOMER_CRL_EXPIRATION_CHECK" | "NDS_X509_USER_AUTHENTICATION_MANAGED_USER_CERTS_EXPIRATION_CHECK") | ("ONLINE_ARCHIVE_INSUFFICIENT_INDEXES_CHECK" | "ONLINE_ARCHIVE_MAX_CONSECUTIVE_OFFLOAD_WINDOWS_CHECK") | "OUTSIDE_SERVERLESS_METRIC_THRESHOLD" | "OUTSIDE_FLEX_METRIC_THRESHOLD" | ("JOINED_GROUP" | "REMOVED_FROM_GROUP" | "USER_ROLES_CHANGED_AUDIT") | ("TAGS_MODIFIED" | "CLUSTER_TAGS_MODIFIED" | "GROUP_TAGS_MODIFIED") | ("STREAM_PROCESSOR_STATE_IS_FAILED" | "OUTSIDE_STREAM_PROCESSOR_METRIC_THRESHOLD") | ("COMPUTE_AUTO_SCALE_INITIATED_BASE" | "COMPUTE_AUTO_SCALE_INITIATED_ANALYTICS" | "COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_BASE" | "COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_ANALYTICS" | "COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_BASE" | "COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_ANALYTICS" | "COMPUTE_AUTO_SCALE_OPLOG_FAIL_BASE" | "COMPUTE_AUTO_SCALE_OPLOG_FAIL_ANALYTICS" | "DISK_AUTO_SCALE_INITIATED" | "DISK_AUTO_SCALE_MAX_DISK_SIZE_FAIL" | "DISK_AUTO_SCALE_OPLOG_FAIL" | "PREDICTIVE_COMPUTE_AUTO_SCALE_INITIATED_BASE" | "PREDICTIVE_COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_BASE" | "PREDICTIVE_COMPUTE_AUTO_SCALE_OPLOG_FAIL_BASE" | "CLUSTER_AUTO_SHARDING_INITIATED") | ("CPS_DATA_PROTECTION_ENABLE_REQUESTED" | "CPS_DATA_PROTECTION_ENABLED" | "CPS_DATA_PROTECTION_UPDATE_REQUESTED" | "CPS_DATA_PROTECTION_UPDATED" | "CPS_DATA_PROTECTION_DISABLE_REQUESTED" | "CPS_DATA_PROTECTION_DISABLED" | "CPS_DATA_PROTECTION_APPROVED_FOR_DISABLEMENT") | "RESOURCE_POLICY_VIOLATED" | ("HOST_DOWN" | "HOST_HAS_INDEX_SUGGESTIONS" | "HOST_MONGOT_CRASHING_OOM" | "HOST_MONGOT_STOP_REPLICATION" | "HOST_MONGOT_APPROACHING_STOP_REPLICATION" | "HOST_MONGOT_PAUSE_INITIAL_SYNC" | "HOST_SEARCH_NODE_INDEX_FAILED" | "HOST_EXTERNAL_LOG_SINK_EXPORT_DOWN" | "HOST_NOT_ENOUGH_DISK_SPACE" | "SSH_KEY_NDS_HOST_ACCESS_REQUESTED" | "SSH_KEY_NDS_HOST_ACCESS_REFRESHED" | "PUSH_BASED_LOG_EXPORT_STOPPED" | "PUSH_BASED_LOG_EXPORT_DROPPED_LOG" | "HOST_VERSION_BEHIND" | "VERSION_BEHIND" | "HOST_EXPOSED" | "HOST_SSL_CERTIFICATE_STALE" | "HOST_SECURITY_CHECKUP_NOT_MET" | "ALERT_HOST_SSH_SESSION_STARTED" | "PROFILER_CONFIGURED_TOO_WIDELY");
+            readonly eventTypeName: ("CREDIT_CARD_ABOUT_TO_EXPIRE" | "PENDING_INVOICE_OVER_THRESHOLD" | "DAILY_BILL_OVER_THRESHOLD" | "DAILY_BILLING_CHANGE_OVER_THRESHOLD" | "WEEKLY_BILLING_CHANGE_OVER_THRESHOLD" | "MONTHLY_BILLING_CHANGE_OVER_THRESHOLD") | ("CPS_SNAPSHOT_STARTED" | "CPS_SNAPSHOT_SUCCESSFUL" | "CPS_SNAPSHOT_FAILED" | "CPS_CONCURRENT_SNAPSHOT_FAILED_WILL_RETRY" | "CPS_SNAPSHOT_BEHIND" | "CPS_COPY_SNAPSHOT_STARTED" | "CPS_COPY_SNAPSHOT_FAILED" | "CPS_COPY_SNAPSHOT_FAILED_WILL_RETRY" | "CPS_COPY_SNAPSHOT_SUCCESSFUL" | "CPS_PREV_SNAPSHOT_OLD" | "CPS_SNAPSHOT_FALLBACK_SUCCESSFUL" | "CPS_SNAPSHOT_FALLBACK_FAILED" | "CPS_RESTORE_SUCCESSFUL" | "CPS_EXPORT_SUCCESSFUL" | "CPS_RESTORE_FAILED" | "CPS_EXPORT_FAILED" | "CPS_COLLECTION_RESTORE_SUCCESSFUL" | "CPS_COLLECTION_RESTORE_FAILED" | "CPS_COLLECTION_RESTORE_PARTIAL_SUCCESS" | "CPS_COLLECTION_RESTORE_CANCELED" | "CPS_AUTO_EXPORT_FAILED" | "CPS_SNAPSHOT_DOWNLOAD_REQUEST_FAILED" | "CPS_OPLOG_BEHIND" | "CPS_OPLOG_CAUGHT_UP") | ("AWS_ENCRYPTION_KEY_NEEDS_ROTATION" | "AZURE_ENCRYPTION_KEY_NEEDS_ROTATION" | "GCP_ENCRYPTION_KEY_NEEDS_ROTATION" | "AWS_ENCRYPTION_KEY_INVALID" | "AZURE_ENCRYPTION_KEY_INVALID" | "GCP_ENCRYPTION_KEY_INVALID") | ("FTS_INDEX_DELETION_FAILED" | "FTS_INDEX_BUILD_COMPLETE" | "FTS_INDEX_BUILD_FAILED" | "FTS_INDEX_CLEANED_UP" | "FTS_INDEX_STALE" | "FTS_INDEXES_RESTORE_FAILED" | "FTS_INDEXES_SYNONYM_MAPPING_INVALID") | ("USERS_WITHOUT_MULTI_FACTOR_AUTH" | "ENCRYPTION_AT_REST_KMS_NETWORK_ACCESS_DENIED" | "ENCRYPTION_AT_REST_CONFIG_NO_LONGER_VALID" | "GROUP_SERVICE_ACCOUNT_SECRETS_EXPIRING" | "GROUP_SERVICE_ACCOUNT_SECRETS_EXPIRED" | "ACTIVE_LEGACY_TLS_CONNECTIONS") | "MONGOTUNE_ALERT" | ("CLUSTER_INSTANCE_STOP_START" | "CLUSTER_INSTANCE_RESYNC_REQUESTED" | "CLUSTER_INSTANCE_UPDATE_REQUESTED" | "SAMPLE_DATASET_LOAD_REQUESTED" | "TENANT_UPGRADE_TO_SERVERLESS_SUCCESSFUL" | "TENANT_UPGRADE_TO_SERVERLESS_FAILED" | "NETWORK_PERMISSION_ENTRY_ADDED" | "NETWORK_PERMISSION_ENTRY_REMOVED" | "NETWORK_PERMISSION_ENTRY_UPDATED" | "CLUSTER_BLOCK_WRITE" | "CLUSTER_UNBLOCK_WRITE") | ("MAINTENANCE_IN_ADVANCED" | "MAINTENANCE_AUTO_DEFERRED" | "MAINTENANCE_STARTED" | "MAINTENANCE_COMPLETED" | "MAINTENANCE_NO_LONGER_NEEDED") | ("NDS_X509_USER_AUTHENTICATION_CUSTOMER_CA_EXPIRATION_CHECK" | "NDS_X509_USER_AUTHENTICATION_CUSTOMER_CRL_EXPIRATION_CHECK" | "NDS_X509_USER_AUTHENTICATION_MANAGED_USER_CERTS_EXPIRATION_CHECK") | ("ONLINE_ARCHIVE_INSUFFICIENT_INDEXES_CHECK" | "ONLINE_ARCHIVE_MAX_CONSECUTIVE_OFFLOAD_WINDOWS_CHECK") | "OUTSIDE_SERVERLESS_METRIC_THRESHOLD" | "OUTSIDE_FLEX_METRIC_THRESHOLD" | ("JOINED_GROUP" | "REMOVED_FROM_GROUP" | "USER_ROLES_CHANGED_AUDIT") | ("TAGS_MODIFIED" | "CLUSTER_TAGS_MODIFIED" | "GROUP_TAGS_MODIFIED") | ("STREAM_PROCESSOR_STATE_IS_FAILED" | "OUTSIDE_STREAM_PROCESSOR_METRIC_THRESHOLD") | ("COMPUTE_AUTO_SCALE_INITIATED_BASE" | "COMPUTE_AUTO_SCALE_INITIATED_ANALYTICS" | "COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_BASE" | "COMPUTE_AUTO_SCALE_SCALE_DOWN_FAIL_ANALYTICS" | "COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_BASE" | "COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_ANALYTICS" | "COMPUTE_AUTO_SCALE_OPLOG_FAIL_BASE" | "COMPUTE_AUTO_SCALE_OPLOG_FAIL_ANALYTICS" | "DISK_AUTO_SCALE_INITIATED" | "DISK_AUTO_SCALE_MAX_DISK_SIZE_FAIL" | "DISK_AUTO_SCALE_OPLOG_FAIL" | "PREDICTIVE_COMPUTE_AUTO_SCALE_INITIATED_BASE" | "PREDICTIVE_COMPUTE_AUTO_SCALE_MAX_INSTANCE_SIZE_FAIL_BASE" | "PREDICTIVE_COMPUTE_AUTO_SCALE_OPLOG_FAIL_BASE" | "CLUSTER_AUTO_SHARDING_INITIATED" | "CLUSTER_RESHARDING_COMPLETED" | "COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_BASE" | "COMPUTE_AUTO_SCALE_DOWNSCALE_SKIPPED_FALLBACK_ANALYTICS") | ("CPS_DATA_PROTECTION_ENABLE_REQUESTED" | "CPS_DATA_PROTECTION_ENABLED" | "CPS_DATA_PROTECTION_UPDATE_REQUESTED" | "CPS_DATA_PROTECTION_UPDATED" | "CPS_DATA_PROTECTION_DISABLE_REQUESTED" | "CPS_DATA_PROTECTION_DISABLED" | "CPS_DATA_PROTECTION_APPROVED_FOR_DISABLEMENT") | "RESOURCE_POLICY_VIOLATED" | ("HOST_DOWN" | "HOST_HAS_INDEX_SUGGESTIONS" | "HOST_MONGOT_CRASHING_OOM" | "HOST_MONGOT_STOP_REPLICATION" | "HOST_MONGOT_APPROACHING_STOP_REPLICATION" | "HOST_MONGOT_PAUSE_INITIAL_SYNC" | "HOST_SEARCH_NODE_INDEX_FAILED" | "HOST_SEARCH_PROCESS_THROTTLING" | "HOST_EXTERNAL_LOG_SINK_EXPORT_DOWN" | "HOST_NOT_ENOUGH_DISK_SPACE" | "SSH_KEY_NDS_HOST_ACCESS_REQUESTED" | "SSH_KEY_NDS_HOST_ACCESS_REFRESHED" | "PUSH_BASED_LOG_EXPORT_STOPPED" | "PUSH_BASED_LOG_EXPORT_DROPPED_LOG" | "HOST_VERSION_BEHIND" | "VERSION_BEHIND" | "HOST_EXPOSED" | "HOST_SSL_CERTIFICATE_STALE" | "HOST_SECURITY_CHECKUP_NOT_MET" | "ALERT_HOST_SSH_SESSION_STARTED" | "PROFILER_CONFIGURED_TOO_WIDELY");
             /**
              * @description Unique 24-hexadecimal digit string that identifies the project that owns this alert.
              * @example 32b6e34b3d91647abb20e7b8
@@ -4017,6 +4082,98 @@ export interface components {
             readonly standardSrv?: string;
         };
         /**
+         * Flex Metric Alerts
+         * @description Flex Metric Alert notifies about changes of measurements or metrics for a Flex cluster.
+         */
+        FlexMetricAlert: {
+            /**
+             * Format: date-time
+             * @description Date and time until which this alert has been acknowledged. This parameter expresses its value in the ISO 8601 timestamp format in UTC. The resource returns this parameter if a MongoDB User previously acknowledged this alert.
+             *
+             *     - To acknowledge this alert forever, set the parameter value to 100 years in the future.
+             *
+             *     - To unacknowledge a previously acknowledged alert, do not set this parameter value.
+             */
+            acknowledgedUntil?: string;
+            /**
+             * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
+             * @example Expiration on 3/19.  Silencing for 7 days.
+             */
+            acknowledgementComment?: string;
+            /**
+             * Format: email
+             * @description MongoDB Cloud username of the person who acknowledged the alert. The response returns this parameter if a MongoDB Cloud user previously acknowledged this alert.
+             */
+            readonly acknowledgingUsername?: string;
+            /**
+             * @description Unique 24-hexadecimal digit string that identifies the alert configuration that sets this alert.
+             * @example 32b6e34b3d91647abb20e7b8
+             */
+            readonly alertConfigId: string;
+            /**
+             * @description Human-readable label that identifies the cluster to which this alert applies.
+             * @example myFlexCluster
+             */
+            readonly clusterName: string;
+            /**
+             * Format: date-time
+             * @description Date and time when MongoDB Cloud created this alert. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+             */
+            readonly created: string;
+            currentValue?: components["schemas"]["HostMetricValue"];
+            eventTypeName: components["schemas"]["FlexMetricEventTypeViewAlertable"];
+            /**
+             * @description Unique 24-hexadecimal digit string that identifies the project that owns this alert.
+             * @example 32b6e34b3d91647abb20e7b8
+             */
+            readonly groupId?: string;
+            /**
+             * @description Unique 24-hexadecimal digit string that identifies this alert.
+             * @example 32b6e34b3d91647abb20e7b8
+             */
+            readonly id: string;
+            /**
+             * Format: date-time
+             * @description Date and time that any notifications were last sent for this alert. This parameter expresses its value in the ISO 8601 timestamp format in UTC. The resource returns this parameter if MongoDB Cloud has sent notifications for this alert.
+             */
+            readonly lastNotified?: string;
+            /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
+            readonly links?: components["schemas"]["Link"][];
+            /**
+             * @description Name of the metric against which Atlas checks the configured alert condition.
+             * @example FLEX_CONNECTIONS_PERCENT
+             */
+            readonly metricName?: string;
+            /**
+             * @description Unique 24-hexadecimal character string that identifies the organization that owns the project to which this alert applies.
+             * @example 32b6e34b3d91647abb20e7b8
+             */
+            readonly orgId?: string;
+            /**
+             * Format: date-time
+             * @description Date and time that this alert changed to `"status" : "CLOSED"`. This parameter expresses its value in the ISO 8601 timestamp format in UTC. The resource returns this parameter once `"status" : "CLOSED"`.
+             */
+            readonly resolved?: string;
+            /**
+             * @description State of this alert at the time you requested its details. TRACKING indicates the alert condition exists but has not persisted for the minimum notification delay. OPEN indicates the alert condition currently exists. CLOSED indicates the alert condition has been resolved.
+             * @example OPEN
+             * @enum {string}
+             */
+            readonly status: "CANCELLED" | "CLOSED" | "OPEN" | "TRACKING";
+            /**
+             * Format: date-time
+             * @description Date and time when someone last updated this alert. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+             */
+            readonly updated: string;
+        };
+        /**
+         * Flex Metric Event Types
+         * @description Event type that triggers an alert.
+         * @example OUTSIDE_FLEX_METRIC_THRESHOLD
+         * @enum {string}
+         */
+        FlexMetricEventTypeViewAlertable: "OUTSIDE_FLEX_METRIC_THRESHOLD";
+        /**
          * Cloud Service Provider Settings for a Flex Cluster
          * @description Group of cloud provider settings that configure the provisioned MongoDB flex cluster.
          */
@@ -4353,7 +4510,7 @@ export interface components {
             /** @description List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the project. */
             tags?: components["schemas"]["ResourceTag"][];
             /**
-             * @description Flag that indicates whether to create the project with default alert settings. This setting cannot be updated after project creation.
+             * @description Flag that indicates whether to create the project with default alert settings.
              * @default true
              */
             withDefaultAlertsSettings: boolean;
@@ -4402,14 +4559,14 @@ export interface components {
         GroupPendingUserResponse: Omit<WithRequired<components["schemas"]["GroupUserResponse"], "id" | "orgMembershipStatus" | "roles" | "username">, "orgMembershipStatus"> & {
             /**
              * Format: date-time
-             * @description Date and time when MongoDB Cloud sent the invitation. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
+             * @description Date and time when MongoDB Cloud sent the invitation. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC. This field is absent for active users.
              */
             readonly invitationCreatedAt: string;
             /**
              * Format: date-time
-             * @description Date and time when the invitation from MongoDB Cloud expires. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
+             * @description Date and time when the invitation from MongoDB Cloud expires. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC. This field is absent for active users and null for rejected invitations.
              */
-            readonly invitationExpiresAt: string;
+            readonly invitationExpiresAt?: string | null;
             /**
              * Format: email
              * @description Username of the MongoDB Cloud user who sent the invitation to join the organization.
@@ -4420,13 +4577,13 @@ export interface components {
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            orgMembershipStatus: "PENDING";
+            orgMembershipStatus: "INVITATION_EXPIRED" | "INVITATION_REJECTED" | "PENDING";
         } & {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            orgMembershipStatus: "PENDING";
+            orgMembershipStatus: "INVITATION_EXPIRED" | "INVITATION_REJECTED" | "PENDING";
         };
         GroupRoleAssignment: {
             /**
@@ -4444,10 +4601,10 @@ export interface components {
              */
             readonly id: string;
             /**
-             * @description String enum that indicates whether the MongoDB Cloud user has a pending invitation to join the organization or they are already active in the organization.
+             * @description String enum that indicates the user's organization membership status: ACTIVE (member), PENDING (invited), `INVITATION_EXPIRED` (invitation expired), or `INVITATION_REJECTED` (invitation declined).
              * @enum {string}
              */
-            readonly orgMembershipStatus: "PENDING" | "ACTIVE";
+            readonly orgMembershipStatus: "PENDING" | "ACTIVE" | "INVITATION_EXPIRED" | "INVITATION_REJECTED";
             /** @description One or more project-level roles assigned to the MongoDB Cloud user. */
             readonly roles: string[];
             /**
@@ -4506,7 +4663,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -4585,7 +4742,7 @@ export interface components {
          * @example HOST_DOWN
          * @enum {string}
          */
-        HostEventTypeViewForNdsGroupAlertable: "HOST_DOWN" | "HOST_HAS_INDEX_SUGGESTIONS" | "HOST_MONGOT_CRASHING_OOM" | "HOST_MONGOT_STOP_REPLICATION" | "HOST_MONGOT_APPROACHING_STOP_REPLICATION" | "HOST_MONGOT_PAUSE_INITIAL_SYNC" | "HOST_SEARCH_NODE_INDEX_FAILED" | "HOST_EXTERNAL_LOG_SINK_EXPORT_DOWN" | "HOST_NOT_ENOUGH_DISK_SPACE" | "SSH_KEY_NDS_HOST_ACCESS_REQUESTED" | "SSH_KEY_NDS_HOST_ACCESS_REFRESHED" | "PUSH_BASED_LOG_EXPORT_STOPPED" | "PUSH_BASED_LOG_EXPORT_DROPPED_LOG" | "HOST_VERSION_BEHIND" | "VERSION_BEHIND" | "HOST_EXPOSED" | "HOST_SSL_CERTIFICATE_STALE" | "HOST_SECURITY_CHECKUP_NOT_MET" | "ALERT_HOST_SSH_SESSION_STARTED" | "PROFILER_CONFIGURED_TOO_WIDELY";
+        HostEventTypeViewForNdsGroupAlertable: "HOST_DOWN" | "HOST_HAS_INDEX_SUGGESTIONS" | "HOST_MONGOT_CRASHING_OOM" | "HOST_MONGOT_STOP_REPLICATION" | "HOST_MONGOT_APPROACHING_STOP_REPLICATION" | "HOST_MONGOT_PAUSE_INITIAL_SYNC" | "HOST_SEARCH_NODE_INDEX_FAILED" | "HOST_SEARCH_PROCESS_THROTTLING" | "HOST_EXTERNAL_LOG_SINK_EXPORT_DOWN" | "HOST_NOT_ENOUGH_DISK_SPACE" | "SSH_KEY_NDS_HOST_ACCESS_REQUESTED" | "SSH_KEY_NDS_HOST_ACCESS_REFRESHED" | "PUSH_BASED_LOG_EXPORT_STOPPED" | "PUSH_BASED_LOG_EXPORT_DROPPED_LOG" | "HOST_VERSION_BEHIND" | "VERSION_BEHIND" | "HOST_EXPOSED" | "HOST_SSL_CERTIFICATE_STALE" | "HOST_SECURITY_CHECKUP_NOT_MET" | "ALERT_HOST_SSH_SESSION_STARTED" | "PROFILER_CONFIGURED_TOO_WIDELY";
         /**
          * Host Metric Alerts
          * @description Host Metric Alert notifies about changes of measurements or metrics for mongod host.
@@ -4602,7 +4759,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -4728,85 +4885,490 @@ export interface components {
             type?: "PERIODIC_CPS" | "ON_DEMAND_CPS";
         };
         /**
-         * Line Item
-         * @description One service included in this invoice.
+         * Cluster Description
+         * @description Group of settings that configure a MongoDB cluster.
          */
-        InvoiceLineItem: {
-            /** @description Human-readable label that identifies the cluster that incurred the charge. */
-            readonly clusterName?: string;
+        LegacyAtlasCluster: {
             /**
              * Format: date-time
-             * @description Date and time when MongoDB Cloud created this line item. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+             * @description If reconfiguration is necessary to regain a primary due to a regional outage, submit this field alongside your topology reconfiguration to request a new regional outage resistant topology. Forced reconfigurations during an outage of the majority of electable nodes carry a risk of data loss if replicated writes (even majority committed writes) have not been replicated to the new primary node. MongoDB Atlas docs contain more information. To proceed with an operation which carries that risk, set `acceptDataRisksAndForceReplicaSetReconfig` to the current date. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
              */
-            readonly created?: string;
+            acceptDataRisksAndForceReplicaSetReconfig?: string;
+            advancedConfiguration?: components["schemas"]["ApiAtlasClusterAdvancedConfigurationView"];
+            autoScaling?: components["schemas"]["ClusterAutoScalingSettings"];
+            /** @description Flag that indicates whether the cluster can perform backups. If set to `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters. Backup uses Cloud Backups for dedicated clusters and Shared Cluster Backups for tenant clusters. If set to `false`, the cluster doesn't use MongoDB Cloud backups. */
+            backupEnabled?: boolean;
+            biConnector?: components["schemas"]["BiConnector"];
             /**
-             * Format: int64
-             * @description Sum by which MongoDB discounted this line item. MongoDB Cloud expresses this value in cents (100ths of one US Dollar). The resource returns this parameter when a discount applies.
+             * @description Configuration of nodes that comprise the cluster.
+             * @enum {string}
              */
-            readonly discountCents?: number;
+            clusterType?: "REPLICASET" | "SHARDED" | "GEOSHARDED";
+            /**
+             * @description Config Server Management Mode for creating or updating a sharded cluster. When configured as `ATLAS_MANAGED`, Atlas may automatically switch the cluster's config server type for optimal performance and savings. When configured as `FIXED_TO_DEDICATED`, the cluster will always use a dedicated config server.
+             * @default ATLAS_MANAGED
+             * @enum {string}
+             */
+            configServerManagementMode: "ATLAS_MANAGED" | "FIXED_TO_DEDICATED";
+            /**
+             * @description Describes a sharded cluster's config server type.
+             * @enum {string}
+             */
+            readonly configServerType?: "DEDICATED" | "EMBEDDED";
+            connectionStrings?: components["schemas"]["ClusterConnectionStrings"];
             /**
              * Format: date-time
-             * @description Date and time when when MongoDB Cloud finished charging for this line item. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+             * @description Date and time when MongoDB Cloud created this serverless instance. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
              */
-            readonly endDate?: string;
+            readonly createDate?: string;
             /**
-             * @description Unique 24-hexadecimal digit string that identifies the project associated to this line item.
+             * Format: int32
+             * @description Number of hours after cluster creation that this cluster will be automatically deleted.
+             *
+             *     This field is used to derive `deleteAfterDate` relative to `createDate`.
+             *
+             *     When set to null or zero on cluster creation, the cluster will not be automatically deleted.
+             *
+             *     When set to a positive value on cluster creation, the cluster will be automatically deleted after the specified number of hours.
+             *
+             *     When updating this field on an existing (non-deleted) cluster, and this is set to null, then existing values are preserved for this & `deleteAfterDate`.
+             *
+             *     When updating this field on an existing (non-deleted) cluster, and this is set to zero, then `deleteAfterDate` is reset to null (disable auto deletion) regardless of previous configurations.
+             *
+             *     When updating this field on an existing (non-deleted) cluster, and this is set to a positive value, then `createDate` + `deleteAfterCreationHours` must be later than now else the field update is ignored and existing values are preserved for this & `deleteAfterDate`.
+             */
+            deleteAfterCreationHours?: number;
+            /**
+             * Format: date-time
+             * @description The date at which this cluster will be automatically deleted.
+             *
+             *     This parameter expresses its value in the ISO 8601 timestamp format in UTC and is derived based on the `createDate` + `deleteAfterCreationHours`.
+             */
+            readonly deleteAfterDate?: string;
+            /**
+             * Format: double
+             * @description Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.
+             *
+             *      This value is not configurable on M0/M2/M5 clusters.
+             *
+             *      MongoDB Cloud requires this parameter if you set `replicationSpecs`.
+             *
+             *      If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value.
+             *
+             *      Storage charge calculations depend on whether you choose the default value or a custom value.
+             *
+             *      The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.
+             */
+            diskSizeGB?: number;
+            /**
+             * @description Disk warming mode selection.
+             * @default FULLY_WARMED
+             * @enum {string}
+             */
+            diskWarmingMode: "FULLY_WARMED" | "VISIBLE_EARLIER";
+            /**
+             * @description Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster. To enable customer key management for encryption at rest, the cluster `replicationSpecs[n].regionConfigs[m].{type}Specs.instanceSize` setting must be `M10` or higher and `"backupEnabled" : false` or omitted entirely.
+             * @enum {string}
+             */
+            encryptionAtRestProvider?: "NONE" | "AWS" | "AZURE" | "GCP";
+            /** @description Feature compatibility version of the cluster. */
+            readonly featureCompatibilityVersion?: string;
+            /**
+             * Format: date-time
+             * @description Feature compatibility version expiration date. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+             */
+            readonly featureCompatibilityVersionExpirationDate?: string;
+            /**
+             * @description Set this field to configure the Sharding Management Mode when creating a new Global Cluster.
+             *
+             *     When set to false, the management mode is set to Atlas-Managed Sharding. This mode fully manages the sharding of your Global Cluster and is built to provide a seamless deployment experience.
+             *
+             *     When set to true, the management mode is set to Self-Managed Sharding. This mode leaves the management of shards in your hands and is built to provide an advanced and flexible deployment experience.
+             *
+             *     This setting cannot be changed once the cluster is deployed.
+             */
+            globalClusterSelfManagedSharding?: boolean;
+            /**
+             * @description Unique 24-hexadecimal character string that identifies the project.
              * @example 32b6e34b3d91647abb20e7b8
              */
             readonly groupId?: string;
-            /** @description Human-readable label that identifies the project. */
-            groupName?: string;
-            /** @description Comment that applies to this line item. */
-            readonly note?: string;
             /**
-             * Format: float
-             * @description Percentage by which MongoDB discounted this line item. The resource returns this parameter when a discount applies.
+             * @description Unique 24-hexadecimal digit string that identifies the cluster.
+             * @example 32b6e34b3d91647abb20e7b8
              */
-            readonly percentDiscount?: number;
+            readonly id?: string;
             /**
-             * Format: double
-             * @description Number of units included for the line item. These can be expressions of storage (GB), time (hours), or other units.
+             * @deprecated
+             * @description Collection of key-value pairs between 1 to 255 characters in length that tag and categorize the cluster. The MongoDB Cloud console doesn't display your labels.
+             *
+             *     Cluster labels are deprecated and will be removed in a future release. We strongly recommend that you use Resource Tags instead.
              */
-            readonly quantity?: number;
-            /** @description Human-readable description of the service that this line item provided. This Stock Keeping Unit (SKU) could be the instance type, a support charge, advanced security, or another service. */
-            readonly sku?: string;
+            labels?: components["schemas"]["ComponentLabel"][];
+            /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
+            readonly links?: components["schemas"]["Link"][];
+            mongoDBEmployeeAccessGrant?: components["schemas"]["EmployeeAccessGrantView"];
+            /**
+             * @description MongoDB major version of the cluster.
+             *
+             *     On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for [project LTS versions endpoint](#tag/Projects/operation/getProjectLTSVersions).
+             *
+             *      On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version.
+             * @example 5.0
+             */
+            mongoDBMajorVersion?: string;
+            /**
+             * @description Version of MongoDB that the cluster runs.
+             * @example 5.0.25
+             */
+            mongoDBVersion?: string;
+            /** @description Base connection string that you can use to connect to the cluster. MongoDB Cloud displays the string only after the cluster starts, not while it builds the cluster. */
+            readonly mongoURI?: string;
             /**
              * Format: date-time
-             * @description Date and time when MongoDB Cloud began charging for this line item. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+             * @description Date and time when someone last updated the connection string. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
              */
-            readonly startDate?: string;
-            /** @description Human-readable label that identifies the Atlas App Services application associated with this line item. */
-            readonly stitchAppName?: string;
-            /** @description A map of key-value pairs corresponding to the tags associated with the line item resource. */
-            readonly tags?: {
-                [key: string]: string[];
+            readonly mongoURIUpdated?: string;
+            /** @description Connection string that you can use to connect to the cluster including the `replicaSet`, `ssl`, and `authSource` query parameters with values appropriate for the cluster. You may need to add MongoDB database users. The response returns this parameter once the cluster can receive requests, not while it builds the cluster. */
+            readonly mongoURIWithOptions?: string;
+            /** @description Human-readable label that identifies the cluster. */
+            name?: string;
+            /**
+             * Format: int32
+             * @description Number of shards up to 50 to deploy for a sharded cluster. The resource returns `1` to indicate a replica set and values of `2` and higher to indicate a sharded cluster. The returned value equals the number of shards in the cluster.
+             * @default 1
+             */
+            numShards: number;
+            /** @description Flag that indicates whether the cluster is paused. */
+            paused?: boolean;
+            /** @description Flag that indicates whether the cluster uses continuous cloud backups. */
+            pitEnabled?: boolean;
+            /** @description Flag that indicates whether the M10 or higher cluster can perform Cloud Backups. If set to `true`, the cluster can perform backups. If this and `backupEnabled` are set to `false`, the cluster doesn't use MongoDB Cloud backups. */
+            providerBackupEnabled?: boolean;
+            providerSettings?: components["schemas"]["ClusterProviderSettings"];
+            /**
+             * @description Set this field to configure the replica set scaling mode for your cluster.
+             *
+             *     By default, Atlas scales under `WORKLOAD_TYPE`. This mode allows Atlas to scale your analytics nodes in parallel to your operational nodes.
+             *
+             *     When configured as `SEQUENTIAL`, Atlas scales all nodes sequentially. This mode is intended for steady-state workloads and applications performing latency-sensitive secondary reads.
+             *
+             *     When configured as `NODE_TYPE`, Atlas scales your electable nodes in parallel with your read-only and analytics nodes. This mode is intended for large, dynamic workloads requiring frequent and timely cluster tier scaling. This is the fastest scaling strategy, but it might impact latency of workloads when performing extensive secondary reads.
+             * @default WORKLOAD_TYPE
+             * @enum {string}
+             */
+            replicaSetScalingStrategy: "SEQUENTIAL" | "WORKLOAD_TYPE" | "NODE_TYPE";
+            /**
+             * Format: int32
+             * @deprecated
+             * @description Number of members that belong to the replica set. Each member retains a copy of your databases, providing high availability and data redundancy. Use `replicationSpecs` instead.
+             * @default 3
+             * @enum {integer}
+             */
+            replicationFactor: 3 | 5 | 7;
+            /**
+             * Region Configuration
+             * @description Physical location where MongoDB Cloud provisions cluster nodes.
+             */
+            replicationSpec?: {
+                [key: string]: components["schemas"]["RegionSpec"];
             };
             /**
-             * Format: double
-             * @description Lower bound for usage amount range in current SKU tier.
+             * @description List of settings that configure your cluster regions.
              *
-             *     **NOTE**: `lineItems[n].tierLowerBound` appears only if your `lineItems[n].sku` is tiered.
+             *     - For Global Clusters, each object in the array represents one zone where MongoDB Cloud deploys your clusters nodes.
+             *     - For non-Global sharded clusters and replica sets, the single object represents where MongoDB Cloud deploys your clusters nodes.
              */
-            readonly tierLowerBound?: number;
+            replicationSpecs?: components["schemas"]["LegacyReplicationSpec"][];
             /**
-             * Format: double
-             * @description Upper bound for usage amount range in current SKU tier.
+             * @description Root Certificate Authority that MongoDB Atlas cluster uses. MongoDB Cloud supports Internet Security Research Group.
+             * @default ISRGROOTX1
+             * @enum {string}
+             */
+            rootCertType: "ISRGROOTX1";
+            /** @description Connection string that you can use to connect to the cluster. The `+srv` modifier forces the connection to use Transport Layer Security (TLS). The `mongoURI` parameter lists additional options. */
+            readonly srvAddress?: string;
+            /**
+             * @description Human-readable label that indicates any current activity being taken on this cluster by the Atlas control plane. With the exception of CREATING and DELETING states, clusters should always be available and have a Primary node even when in states indicating ongoing activity.
              *
-             *     **NOTE**: `lineItems[n].tierUpperBound` appears only if your `lineItems[n].sku` is tiered.
+             *      - `IDLE`: Atlas is making no changes to this cluster and all changes requested via the UI or API can be assumed to have been applied.
+             *      - `CREATING`: A cluster being provisioned for the very first time returns state CREATING until it is ready for connections. Ensure IP Access List and DB Users are configured before attempting to connect.
+             *      - `UPDATING`: A change requested via the UI, API, AutoScaling, or other scheduled activity is taking place.
+             *      - `DELETING`: The cluster is in the process of deletion and will soon be deleted.
+             *      - `REPAIRING`: One or more nodes in the cluster are being returned to service by the Atlas control plane. Other nodes should continue to provide service as normal.
+             * @enum {string}
              */
-            readonly tierUpperBound?: number;
+            readonly stateName?: "IDLE" | "CREATING" | "UPDATING" | "DELETING" | "REPAIRING";
+            /** @description List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. */
+            tags?: components["schemas"]["ResourceTag"][];
             /**
-             * Format: int64
-             * @description Sum of the cost set for this line item. MongoDB Cloud expresses this value in cents (100ths of one US Dollar) and calculates this value as `unitPriceDollars` * `quantity` * 100.
+             * @description Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, MongoDB Cloud won't delete the cluster. If set to `false`, MongoDB Cloud will delete the cluster.
+             * @default false
              */
-            readonly totalPriceCents?: number;
-            /** @description Element used to express what **quantity** this line item measures. This value can be elements of time, storage capacity, and the like. */
-            readonly unit?: string;
+            terminationProtectionEnabled: boolean;
+            /**
+             * @description Method by which the cluster maintains the MongoDB versions. If value is `CONTINUOUS`, you must not specify `mongoDBMajorVersion`.
+             * @default LTS
+             * @enum {string}
+             */
+            versionReleaseSystem: "LTS" | "CONTINUOUS";
+        };
+        /**
+         * Tenant Cluster Upgrade Request
+         * @description Request containing target state of tenant cluster to be upgraded.
+         */
+        LegacyAtlasTenantClusterUpgradeRequest: {
+            /**
+             * Format: date-time
+             * @description If reconfiguration is necessary to regain a primary due to a regional outage, submit this field alongside your topology reconfiguration to request a new regional outage resistant topology. Forced reconfigurations during an outage of the majority of electable nodes carry a risk of data loss if replicated writes (even majority committed writes) have not been replicated to the new primary node. MongoDB Atlas docs contain more information. To proceed with an operation which carries that risk, set `acceptDataRisksAndForceReplicaSetReconfig` to the current date. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+             */
+            acceptDataRisksAndForceReplicaSetReconfig?: string;
+            advancedConfiguration?: components["schemas"]["ApiAtlasClusterAdvancedConfigurationView"];
+            autoScaling?: components["schemas"]["ClusterAutoScalingSettings"];
+            /** @description Flag that indicates whether the cluster can perform backups. If set to `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters. Backup uses Cloud Backups for dedicated clusters and Shared Cluster Backups for tenant clusters. If set to `false`, the cluster doesn't use MongoDB Cloud backups. */
+            backupEnabled?: boolean;
+            biConnector?: components["schemas"]["BiConnector"];
+            /**
+             * @description Configuration of nodes that comprise the cluster.
+             * @enum {string}
+             */
+            clusterType?: "REPLICASET" | "SHARDED" | "GEOSHARDED";
+            /**
+             * @description Config Server Management Mode for creating or updating a sharded cluster. When configured as `ATLAS_MANAGED`, Atlas may automatically switch the cluster's config server type for optimal performance and savings. When configured as `FIXED_TO_DEDICATED`, the cluster will always use a dedicated config server.
+             * @default ATLAS_MANAGED
+             * @enum {string}
+             */
+            configServerManagementMode: "ATLAS_MANAGED" | "FIXED_TO_DEDICATED";
+            /**
+             * @description Describes a sharded cluster's config server type.
+             * @enum {string}
+             */
+            readonly configServerType?: "DEDICATED" | "EMBEDDED";
+            connectionStrings?: components["schemas"]["ClusterConnectionStrings"];
+            /**
+             * Format: date-time
+             * @description Date and time when MongoDB Cloud created this serverless instance. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
+             */
+            readonly createDate?: string;
+            /**
+             * Format: int32
+             * @description Number of hours after cluster creation that this cluster will be automatically deleted.
+             *
+             *     This field is used to derive `deleteAfterDate` relative to `createDate`.
+             *
+             *     When set to null or zero on cluster creation, the cluster will not be automatically deleted.
+             *
+             *     When set to a positive value on cluster creation, the cluster will be automatically deleted after the specified number of hours.
+             *
+             *     When updating this field on an existing (non-deleted) cluster, and this is set to null, then existing values are preserved for this & `deleteAfterDate`.
+             *
+             *     When updating this field on an existing (non-deleted) cluster, and this is set to zero, then `deleteAfterDate` is reset to null (disable auto deletion) regardless of previous configurations.
+             *
+             *     When updating this field on an existing (non-deleted) cluster, and this is set to a positive value, then `createDate` + `deleteAfterCreationHours` must be later than now else the field update is ignored and existing values are preserved for this & `deleteAfterDate`.
+             */
+            deleteAfterCreationHours?: number;
+            /**
+             * Format: date-time
+             * @description The date at which this cluster will be automatically deleted.
+             *
+             *     This parameter expresses its value in the ISO 8601 timestamp format in UTC and is derived based on the `createDate` + `deleteAfterCreationHours`.
+             */
+            readonly deleteAfterDate?: string;
             /**
              * Format: double
-             * @description Value per **unit** for this line item expressed in US Dollars.
+             * @description Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.
+             *
+             *      This value is not configurable on M0/M2/M5 clusters.
+             *
+             *      MongoDB Cloud requires this parameter if you set `replicationSpecs`.
+             *
+             *      If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value.
+             *
+             *      Storage charge calculations depend on whether you choose the default value or a custom value.
+             *
+             *      The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.
              */
-            readonly unitPriceDollars?: number;
+            diskSizeGB?: number;
+            /**
+             * @description Disk warming mode selection.
+             * @default FULLY_WARMED
+             * @enum {string}
+             */
+            diskWarmingMode: "FULLY_WARMED" | "VISIBLE_EARLIER";
+            /**
+             * @description Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster. To enable customer key management for encryption at rest, the cluster `replicationSpecs[n].regionConfigs[m].{type}Specs.instanceSize` setting must be `M10` or higher and `"backupEnabled" : false` or omitted entirely.
+             * @enum {string}
+             */
+            encryptionAtRestProvider?: "NONE" | "AWS" | "AZURE" | "GCP";
+            /** @description Feature compatibility version of the cluster. */
+            readonly featureCompatibilityVersion?: string;
+            /**
+             * Format: date-time
+             * @description Feature compatibility version expiration date. This parameter expresses its value in the ISO 8601 timestamp format in UTC.
+             */
+            readonly featureCompatibilityVersionExpirationDate?: string;
+            /**
+             * @description Set this field to configure the Sharding Management Mode when creating a new Global Cluster.
+             *
+             *     When set to false, the management mode is set to Atlas-Managed Sharding. This mode fully manages the sharding of your Global Cluster and is built to provide a seamless deployment experience.
+             *
+             *     When set to true, the management mode is set to Self-Managed Sharding. This mode leaves the management of shards in your hands and is built to provide an advanced and flexible deployment experience.
+             *
+             *     This setting cannot be changed once the cluster is deployed.
+             */
+            globalClusterSelfManagedSharding?: boolean;
+            /**
+             * @description Unique 24-hexadecimal character string that identifies the project.
+             * @example 32b6e34b3d91647abb20e7b8
+             */
+            readonly groupId?: string;
+            /**
+             * @description Unique 24-hexadecimal digit string that identifies the cluster.
+             * @example 32b6e34b3d91647abb20e7b8
+             */
+            readonly id?: string;
+            /**
+             * @deprecated
+             * @description Collection of key-value pairs between 1 to 255 characters in length that tag and categorize the cluster. The MongoDB Cloud console doesn't display your labels.
+             *
+             *     Cluster labels are deprecated and will be removed in a future release. We strongly recommend that you use Resource Tags instead.
+             */
+            labels?: components["schemas"]["ComponentLabel"][];
+            /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
+            readonly links?: components["schemas"]["Link"][];
+            mongoDBEmployeeAccessGrant?: components["schemas"]["EmployeeAccessGrantView"];
+            /**
+             * @description MongoDB major version of the cluster.
+             *
+             *     On creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for [project LTS versions endpoint](#tag/Projects/operation/getProjectLTSVersions).
+             *
+             *      On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version.
+             * @example 5.0
+             */
+            mongoDBMajorVersion?: string;
+            /**
+             * @description Version of MongoDB that the cluster runs.
+             * @example 5.0.25
+             */
+            mongoDBVersion?: string;
+            /** @description Base connection string that you can use to connect to the cluster. MongoDB Cloud displays the string only after the cluster starts, not while it builds the cluster. */
+            readonly mongoURI?: string;
+            /**
+             * Format: date-time
+             * @description Date and time when someone last updated the connection string. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
+             */
+            readonly mongoURIUpdated?: string;
+            /** @description Connection string that you can use to connect to the cluster including the `replicaSet`, `ssl`, and `authSource` query parameters with values appropriate for the cluster. You may need to add MongoDB database users. The response returns this parameter once the cluster can receive requests, not while it builds the cluster. */
+            readonly mongoURIWithOptions?: string;
+            /** @description Human-readable label that identifies the cluster. */
+            name: string;
+            /**
+             * Format: int32
+             * @description Number of shards up to 50 to deploy for a sharded cluster. The resource returns `1` to indicate a replica set and values of `2` and higher to indicate a sharded cluster. The returned value equals the number of shards in the cluster.
+             * @default 1
+             */
+            numShards: number;
+            /** @description Flag that indicates whether the cluster is paused. */
+            paused?: boolean;
+            /** @description Flag that indicates whether the cluster uses continuous cloud backups. */
+            pitEnabled?: boolean;
+            /** @description Flag that indicates whether the M10 or higher cluster can perform Cloud Backups. If set to `true`, the cluster can perform backups. If this and `backupEnabled` are set to `false`, the cluster doesn't use MongoDB Cloud backups. */
+            providerBackupEnabled?: boolean;
+            providerSettings?: components["schemas"]["ClusterProviderSettings"];
+            /**
+             * @description Set this field to configure the replica set scaling mode for your cluster.
+             *
+             *     By default, Atlas scales under `WORKLOAD_TYPE`. This mode allows Atlas to scale your analytics nodes in parallel to your operational nodes.
+             *
+             *     When configured as `SEQUENTIAL`, Atlas scales all nodes sequentially. This mode is intended for steady-state workloads and applications performing latency-sensitive secondary reads.
+             *
+             *     When configured as `NODE_TYPE`, Atlas scales your electable nodes in parallel with your read-only and analytics nodes. This mode is intended for large, dynamic workloads requiring frequent and timely cluster tier scaling. This is the fastest scaling strategy, but it might impact latency of workloads when performing extensive secondary reads.
+             * @default WORKLOAD_TYPE
+             * @enum {string}
+             */
+            replicaSetScalingStrategy: "SEQUENTIAL" | "WORKLOAD_TYPE" | "NODE_TYPE";
+            /**
+             * Format: int32
+             * @deprecated
+             * @description Number of members that belong to the replica set. Each member retains a copy of your databases, providing high availability and data redundancy. Use `replicationSpecs` instead.
+             * @default 3
+             * @enum {integer}
+             */
+            replicationFactor: 3 | 5 | 7;
+            /**
+             * Region Configuration
+             * @description Physical location where MongoDB Cloud provisions cluster nodes.
+             */
+            replicationSpec?: {
+                [key: string]: components["schemas"]["RegionSpec"];
+            };
+            /**
+             * @description List of settings that configure your cluster regions.
+             *
+             *     - For Global Clusters, each object in the array represents one zone where MongoDB Cloud deploys your clusters nodes.
+             *     - For non-Global sharded clusters and replica sets, the single object represents where MongoDB Cloud deploys your clusters nodes.
+             */
+            replicationSpecs?: components["schemas"]["LegacyReplicationSpec"][];
+            /**
+             * @description Root Certificate Authority that MongoDB Atlas cluster uses. MongoDB Cloud supports Internet Security Research Group.
+             * @default ISRGROOTX1
+             * @enum {string}
+             */
+            rootCertType: "ISRGROOTX1";
+            /** @description Connection string that you can use to connect to the cluster. The `+srv` modifier forces the connection to use Transport Layer Security (TLS). The `mongoURI` parameter lists additional options. */
+            readonly srvAddress?: string;
+            /**
+             * @description Human-readable label that indicates any current activity being taken on this cluster by the Atlas control plane. With the exception of CREATING and DELETING states, clusters should always be available and have a Primary node even when in states indicating ongoing activity.
+             *
+             *      - `IDLE`: Atlas is making no changes to this cluster and all changes requested via the UI or API can be assumed to have been applied.
+             *      - `CREATING`: A cluster being provisioned for the very first time returns state CREATING until it is ready for connections. Ensure IP Access List and DB Users are configured before attempting to connect.
+             *      - `UPDATING`: A change requested via the UI, API, AutoScaling, or other scheduled activity is taking place.
+             *      - `DELETING`: The cluster is in the process of deletion and will soon be deleted.
+             *      - `REPAIRING`: One or more nodes in the cluster are being returned to service by the Atlas control plane. Other nodes should continue to provide service as normal.
+             * @enum {string}
+             */
+            readonly stateName?: "IDLE" | "CREATING" | "UPDATING" | "DELETING" | "REPAIRING";
+            /** @description List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. */
+            tags?: components["schemas"]["ResourceTag"][];
+            /**
+             * @description Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, MongoDB Cloud won't delete the cluster. If set to `false`, MongoDB Cloud will delete the cluster.
+             * @default false
+             */
+            terminationProtectionEnabled: boolean;
+            /**
+             * @description Method by which the cluster maintains the MongoDB versions. If value is `CONTINUOUS`, you must not specify `mongoDBMajorVersion`.
+             * @default LTS
+             * @enum {string}
+             */
+            versionReleaseSystem: "LTS" | "CONTINUOUS";
+        };
+        LegacyReplicationSpec: {
+            /**
+             * @description Unique 24-hexadecimal digit string that identifies the replication object for a zone in a Global Cluster.
+             *
+             *     - If you include existing zones in the request, you must specify this parameter.
+             *
+             *     - If you add a new zone to an existing Global Cluster, you may specify this parameter. The request deletes any existing zones in a Global Cluster that you exclude from the request.
+             * @example 32b6e34b3d91647abb20e7b8
+             */
+            id?: string;
+            /**
+             * Format: int32
+             * @description Positive integer that specifies the number of shards to deploy in each specified zone If you set this value to `1` and `clusterType` is `SHARDED`, MongoDB Cloud deploys a single-shard sharded cluster. Don't create a sharded cluster with a single shard for production environments. Single-shard sharded clusters don't provide the same benefits as multi-shard configurations.
+             *
+             *      If you are upgrading a replica set to a sharded cluster, you cannot increase the number of shards in the same update request.  You should wait until after the cluster has completed upgrading to sharded and you have reconnected all application clients to the MongoDB router before adding additional shards. Otherwise, your data might become inconsistent once MongoDB Cloud begins distributing data across shards.
+             * @default 1
+             */
+            numShards: number;
+            /**
+             * Region Configuration
+             * @description Physical location where MongoDB Cloud provisions cluster nodes.
+             */
+            regionsConfig?: {
+                [key: string]: components["schemas"]["RegionSpec"];
+            };
+            /** @description Human-readable label that identifies the zone in a Global Cluster. Provide this value only if `clusterType` is `GEOSHARDED`. */
+            zoneName?: string;
         };
         Link: {
             /**
@@ -4871,22 +5433,22 @@ export interface components {
             dayOfMonth?: number;
             /**
              * Format: int32
-             * @description Hour of the day when the scheduled window to run one online archive ends.
+             * @description Hour of the day when the scheduled window to run one online archive ends. This field uses the UTC time zone. The window must have a duration of at least two hours. If the end time is before or equal to the start time, the window extends to the next day.
              */
             endHour?: number;
             /**
              * Format: int32
-             * @description Minute of the hour when the scheduled window to run one online archive ends.
+             * @description Minute of the hour when the scheduled window to run one online archive ends. This field uses the UTC time zone. The window must have a duration of at least two hours. If the end time is before or equal to the start time, the window extends to the next day.
              */
             endMinute?: number;
             /**
              * Format: int32
-             * @description Hour of the day when the when the scheduled window to run one online archive starts.
+             * @description Hour of the day when the scheduled window to run one online archive starts. This field uses the UTC time zone.
              */
             startHour?: number;
             /**
              * Format: int32
-             * @description Minute of the hour when the scheduled window to run one online archive starts.
+             * @description Minute of the hour when the scheduled window to run one online archive starts. This field uses the UTC time zone.
              */
             startMinute?: number;
         } & {
@@ -4936,7 +5498,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -5132,14 +5694,14 @@ export interface components {
         OrgPendingUserResponse: Omit<WithRequired<components["schemas"]["OrgUserResponse"], "id" | "orgMembershipStatus" | "roles" | "username">, "orgMembershipStatus"> & {
             /**
              * Format: date-time
-             * @description Date and time when MongoDB Cloud sent the invitation. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
+             * @description Date and time when MongoDB Cloud sent the invitation. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC. This field is absent for active users.
              */
             readonly invitationCreatedAt: string;
             /**
              * Format: date-time
-             * @description Date and time when the invitation from MongoDB Cloud expires. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC.
+             * @description Date and time when the invitation from MongoDB Cloud expires. MongoDB Cloud represents this timestamp in ISO 8601 format in UTC. This field is absent for active users and null for rejected invitations.
              */
-            readonly invitationExpiresAt: string;
+            readonly invitationExpiresAt?: string | null;
             /**
              * Format: email
              * @description Username of the MongoDB Cloud user who sent the invitation to join the organization.
@@ -5150,13 +5712,13 @@ export interface components {
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            orgMembershipStatus: "PENDING";
+            orgMembershipStatus: "INVITATION_EXPIRED" | "INVITATION_REJECTED" | "PENDING";
         } & {
             /**
              * @description discriminator enum property added by openapi-typescript
              * @enum {string}
              */
-            orgMembershipStatus: "PENDING";
+            orgMembershipStatus: "INVITATION_EXPIRED" | "INVITATION_REJECTED" | "PENDING";
         };
         OrgUserResponse: {
             /**
@@ -5165,10 +5727,10 @@ export interface components {
              */
             readonly id: string;
             /**
-             * @description String enum that indicates whether the MongoDB Cloud user has a pending invitation to join the organization or they are already active in the organization.
+             * @description String enum that indicates the user's organization membership status: ACTIVE (member), PENDING (invited), `INVITATION_EXPIRED` (invitation expired), or `INVITATION_REJECTED` (invitation declined).
              * @enum {string}
              */
-            readonly orgMembershipStatus: "PENDING" | "ACTIVE";
+            readonly orgMembershipStatus: "PENDING" | "ACTIVE" | "INVITATION_EXPIRED" | "INVITATION_REJECTED";
             roles: components["schemas"]["OrgUserRolesResponse"];
             /** @description List of unique 24-hexadecimal digit strings that identifies the teams to which this MongoDB Cloud user belongs. */
             readonly teamIds?: string[];
@@ -5568,7 +6130,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -5671,6 +6233,33 @@ export interface components {
             units?: components["schemas"]["RawMetricUnits"];
         };
         /**
+         * Region Configuration
+         * @description Physical location where MongoDB Cloud provisions cluster nodes.
+         */
+        RegionSpec: {
+            /**
+             * Format: int32
+             * @description Number of analytics nodes in the region. Analytics nodes handle analytic data such as reporting queries from MongoDB Connector for Business Intelligence on MongoDB Cloud. Analytics nodes are read-only, and can never become the primary. Use `replicationSpecs[n].{region}.analyticsNodes` instead.
+             */
+            analyticsNodes?: number;
+            /**
+             * Format: int32
+             * @description Number of electable nodes to deploy in the specified region. Electable nodes can become the primary and can facilitate local reads. Use `replicationSpecs[n].{region}.electableNodes` instead.
+             * @enum {integer}
+             */
+            electableNodes?: 0 | 3 | 5 | 7;
+            /**
+             * Format: int32
+             * @description Number that indicates the election priority of the region. To identify the Preferred Region of the cluster, set this parameter to `7`. The primary node runs in the **Preferred Region**. To identify a read-only region, set this parameter to `0`.
+             */
+            priority?: number;
+            /**
+             * Format: int32
+             * @description Number of read-only nodes in the region. Read-only nodes can never become the primary member, but can facilitate local reads. Use `replicationSpecs[n].{region}.readOnlyNodes` instead.
+             */
+            readOnlyNodes?: number;
+        };
+        /**
          * ReplicaSet Alerts
          * @description Replica Set alert notifies about different activities on replica set of mongod instances.
          */
@@ -5686,7 +6275,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -5839,6 +6428,8 @@ export interface components {
              * @enum {string}
              */
             type: "S3_LOG_EXPORT";
+            /** @description When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`. */
+            useLegacyPathStructure?: boolean | null;
         } & {
             /**
              * @description discriminator enum property added by openapi-typescript
@@ -5882,6 +6473,8 @@ export interface components {
              * @enum {string}
              */
             type: "S3_LOG_EXPORT";
+            /** @description When true, uses the legacy daily-folder path structure compatible with Push-Based Log Export: `{prefix}/{cluster}/{hostname}/{logType}/{YYYY-MM-DD}/{timestamp}-{logType}.log`. When false (default), uses the flat timestamped structure: `{prefix}/{cluster}/{hostname}/{logType}/{timestamp}-{logType}.log`. */
+            useLegacyPathStructure?: boolean | null;
         } & {
             /**
              * @description discriminator enum property added by openapi-typescript
@@ -6306,7 +6899,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -6426,6 +7019,23 @@ export interface components {
              */
             type: "AWSLambda";
         };
+        /** @description The configuration for Azure Blob Storage connections. */
+        StreamsAzureBlobStorageConnection: Omit<components["schemas"]["StreamsConnection"], "type"> & {
+            azure?: components["schemas"]["AzureConnection"];
+            publicPrivateNetworking?: components["schemas"]["StreamsPublicPrivateLinkNetworking"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "AzureBlobStorage";
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "AzureBlobStorage";
+        };
         StreamsClusterConnection: Omit<components["schemas"]["StreamsConnection"], "type"> & {
             /** @description Unique 24-hexadecimal digit string that identifies the project that contains the configured cluster. Required if the ID does not match the project containing the streams workspace. You must first enable the organization setting. */
             clusterGroupId?: string;
@@ -6447,6 +7057,8 @@ export interface components {
         };
         /** @description Settings that define a connection to an external data store. */
         StreamsConnection: {
+            /** @description Unique identifier of the connection. */
+            readonly id?: string;
             /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
             readonly links?: components["schemas"]["Link"][];
             /** @description Human-readable label that identifies the stream connection. In the case of the Sample type, this is the name of the sample source. */
@@ -6462,8 +7074,8 @@ export interface components {
              * @description Type of the connection.
              * @enum {string}
              */
-            type?: "Kafka" | "Cluster" | "Sample" | "Https" | "AWSLambda" | "AWSKinesisDataStreams" | "SchemaRegistry";
-        } & (components["schemas"]["StreamsSampleConnection"] | components["schemas"]["StreamsClusterConnection"] | components["schemas"]["StreamsKafkaConnection"] | components["schemas"]["StreamsHttpsConnection"] | components["schemas"]["StreamsAWSLambdaConnection"] | components["schemas"]["StreamsS3Connection"] | components["schemas"]["StreamsAWSKinesisDataStreamsConnection"] | components["schemas"]["StreamsSchemaRegistryConnection"]);
+            type?: "Kafka" | "Cluster" | "Sample" | "Https" | "AzureBlobStorage" | "AWSLambda" | "AWSKinesisDataStreams" | "SchemaRegistry" | "GCPPubSub";
+        } & (components["schemas"]["StreamsSampleConnection"] | components["schemas"]["StreamsClusterConnection"] | components["schemas"]["StreamsKafkaConnection"] | components["schemas"]["StreamsHttpsConnection"] | components["schemas"]["StreamsAWSLambdaConnection"] | components["schemas"]["StreamsS3Connection"] | components["schemas"]["StreamsAWSKinesisDataStreamsConnection"] | components["schemas"]["StreamsSchemaRegistryConnection"] | components["schemas"]["StreamsAzureBlobStorageConnection"] | components["schemas"]["StreamsGCPPubSubConnection"]);
         /** @description Dead letter queue for the stream processor. */
         StreamsDLQ: {
             /** @description Name of the collection to use for the DLQ. */
@@ -6485,6 +7097,30 @@ export interface components {
             /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
             readonly links?: components["schemas"]["Link"][];
             region: components["schemas"]["BaseStreamsRegion"];
+        };
+        /** @description GCP-specific configuration for the connection. */
+        StreamsGCPConnectionConfig: {
+            /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
+            readonly links?: components["schemas"]["Link"][];
+            /** @description Email address of the Google Cloud Platform (GCP) service account that Atlas Streams uses to connect to the GCP Pub/Sub resources. */
+            serviceAccountId?: string;
+        };
+        /** @description The configuration for GCP Pub/Sub connections. */
+        StreamsGCPPubSubConnection: Omit<components["schemas"]["StreamsConnection"], "type"> & {
+            gcp?: components["schemas"]["StreamsGCPConnectionConfig"];
+            publicPrivateNetworking?: components["schemas"]["StreamsPublicPrivateLinkNetworking"];
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "GCPPubSub";
+        } & {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "GCPPubSub";
         };
         StreamsHttpsConnection: Omit<components["schemas"]["StreamsConnection"], "type"> & {
             /** @description A map of key-value pairs that will be passed as headers for the request. */
@@ -6663,11 +7299,11 @@ export interface components {
             readonly interfaceEndpointName?: string;
             /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
             readonly links?: components["schemas"]["Link"][];
-            /** @description Provider where the Kafka cluster is deployed. Valid values are AWS and AZURE. */
+            /** @description Cloud provider where the private endpoint's target resource is deployed. Valid values are AWS, AZURE, and GCP. */
             provider: string;
             /** @description Account ID from the cloud provider. */
             readonly providerAccountId?: string;
-            /** @description The region of the Provider’s cluster. See [AZURE](https://www.mongodb.com/docs/atlas/reference/microsoft-azure/#stream-processing-instances) and [AWS](https://www.mongodb.com/docs/atlas/reference/amazon-aws/#stream-processing-instances) supported regions. */
+            /** @description The region of the Provider’s cluster. See [AWS](https://www.mongodb.com/docs/atlas/reference/amazon-aws/#stream-processing-workspaces), [AZURE](https://www.mongodb.com/docs/atlas/reference/microsoft-azure/#stream-processing-workspaces), and [GCP](https://www.mongodb.com/docs/atlas/reference/google-gcp/#stream-processing-workspaces) supported regions. */
             region?: string;
             /** @description For AZURE EVENTHUB, this is the [namespace endpoint ID](https://learn.microsoft.com/en-us/rest/api/eventhub/namespaces/get). For AWS CONFLUENT cluster, this is the [VPC Endpoint service name](https://docs.confluent.io/cloud/current/networking/private-links/aws-privatelink.html). */
             serviceEndpointId?: string;
@@ -6676,16 +7312,18 @@ export interface components {
             /**
              * @description Vendor that manages the cloud service. The list of supported vendor values is:
              *     - AWS
-             *     -- MSK for AWS MSK Kafka clusters
-             *     -- CONFLUENT for Confluent Kafka clusters on AWS
-             *     -- KINESIS for AWS Kinesis Data Streams
+             *     -- `MSK` for AWS MSK Kafka clusters
+             *     -- `CONFLUENT` for Confluent Kafka clusters on AWS
+             *     -- `KINESIS` for AWS Kinesis Data Streams
              *
              *     - Azure
-             *     -- EVENTHUB for Azure EventHub.
-             *     -- CONFLUENT for Confluent Kafka clusters on Azure
+             *     -- `EVENTHUB` for Azure EventHub.
+             *     -- `CONFLUENT` for Confluent Kafka clusters on Azure
+             *     -- `AZURE_BLOB_STORAGE` for Azure Blob Storage
              *
              *     - GCP
-             *     -- CONFLUENT for Confluent Kafka clusters on GCP
+             *     -- `CONFLUENT` for Confluent Kafka clusters on GCP
+             *     -- `PUBSUB` for Google Cloud Pub/Sub
              *
              *     **NOTE** Omitting the vendor field will default to using the GENERIC vendor.
              */
@@ -6705,6 +7343,12 @@ export interface components {
             options?: components["schemas"]["StreamsOptions"];
             /** @description Stream aggregation pipeline you want to apply to your streaming data. */
             pipeline?: components["schemas"]["Document"][];
+            /**
+             * Stream Workspace Tier
+             * @description Selected tier for the Stream Workspace. Configures Memory / VCPU allowances.
+             * @enum {string}
+             */
+            tier?: "SP50" | "SP30" | "SP10" | "SP5" | "SP2";
         };
         /** @description An atlas stream processor with optional stats. */
         StreamsProcessorWithStats: {
@@ -6734,6 +7378,28 @@ export interface components {
              * @enum {string}
              */
             tier?: "SP50" | "SP30" | "SP10" | "SP5" | "SP2";
+        };
+        /** @description Networking configuration for connections that support `PUBLIC` and `PRIVATE_LINK` access types. For GCP connections, use `PRIVATE_LINK` for GCP Private Service Connect (PSC). */
+        StreamsPublicPrivateLinkNetworking: {
+            access?: components["schemas"]["StreamsPublicPrivateLinkNetworkingAccess"];
+            /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
+            readonly links?: components["schemas"]["Link"][];
+        };
+        /** @description Information about networking access. */
+        StreamsPublicPrivateLinkNetworkingAccess: {
+            /**
+             * @description The ID of the Private Link connection. Required for `PRIVATE_LINK` type. For GCP connections using Private Service Connect (PSC), this is the PSC connection ID.
+             * @example 32b6e34b3d91647abb20e7b8
+             */
+            connectionId?: string;
+            /** @description List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships. */
+            readonly links?: components["schemas"]["Link"][];
+            /**
+             * Networking Access Type
+             * @description Selected networking type. Either `PUBLIC` or `PRIVATE_LINK`. Defaults to `PUBLIC`. For AWS, Azure, and GCP connections, use `PRIVATE_LINK` for AWS PrivateLink, Azure Private Link, or GCP Private Service Connect (PSC) respectively.
+             * @enum {string}
+             */
+            type?: "PUBLIC" | "PRIVATE_LINK";
         };
         /** @description The configuration for S3 connections. */
         StreamsS3Connection: Omit<components["schemas"]["StreamsConnection"], "type"> & {
@@ -7086,7 +7752,7 @@ export interface components {
             acknowledgedUntil?: string;
             /**
              * @description Comment that a MongoDB Cloud user submitted when acknowledging the alert.
-             * @example Expiration on 3/19.  Silencing for 7days.
+             * @example Expiration on 3/19.  Silencing for 7 days.
              */
             acknowledgementComment?: string;
             /**
@@ -7469,22 +8135,22 @@ export interface components {
             dayOfWeek?: number;
             /**
              * Format: int32
-             * @description Hour of the day when the scheduled window to run one online archive ends.
+             * @description Hour of the day when the scheduled window to run one online archive ends. This field uses the UTC time zone. The window must have a duration of at least two hours. If the end time is before or equal to the start time, the window extends to the next day.
              */
             endHour?: number;
             /**
              * Format: int32
-             * @description Minute of the hour when the scheduled window to run one online archive ends.
+             * @description Minute of the hour when the scheduled window to run one online archive ends. This field uses the UTC time zone. The window must have a duration of at least two hours. If the end time is before or equal to the start time, the window extends to the next day.
              */
             endMinute?: number;
             /**
              * Format: int32
-             * @description Hour of the day when the when the scheduled window to run one online archive starts.
+             * @description Hour of the day when the scheduled window to run one online archive starts. This field uses the UTC time zone.
              */
             startHour?: number;
             /**
              * Format: int32
-             * @description Minute of the hour when the scheduled window to run one online archive starts.
+             * @description Minute of the hour when the scheduled window to run one online archive starts. This field uses the UTC time zone.
              */
             startMinute?: number;
         } & {
@@ -8108,10 +8774,12 @@ export type AppServiceAlertView = components['schemas']['AppServiceAlertView'];
 export type AppServiceEventTypeViewAlertable = components['schemas']['AppServiceEventTypeViewAlertable'];
 export type AtlasOrganization = components['schemas']['AtlasOrganization'];
 export type AtlasSearchAnalyzer = components['schemas']['AtlasSearchAnalyzer'];
+export type AtlasTenantClusterUpgradeRequest20240805 = components['schemas']['AtlasTenantClusterUpgradeRequest20240805'];
 export type AzureAccountDetails = components['schemas']['AzureAccountDetails'];
 export type AzureCloudProviderContainer = components['schemas']['AzureCloudProviderContainer'];
 export type AzureCloudProviderSettings = components['schemas']['AzureCloudProviderSettings'];
 export type AzureComputeAutoScalingRules = components['schemas']['AzureComputeAutoScalingRules'];
+export type AzureConnection = components['schemas']['AzureConnection'];
 export type AzureCreateDataProcessRegionView = components['schemas']['AzureCreateDataProcessRegionView'];
 export type AzureDataProcessRegionView = components['schemas']['AzureDataProcessRegionView'];
 export type AzureHardwareSpec20240805 = components['schemas']['AzureHardwareSpec20240805'];
@@ -8123,10 +8791,6 @@ export type BaseCloudProviderInstanceSize = components['schemas']['BaseCloudProv
 export type BaseStreamsRegion = components['schemas']['BaseStreamsRegion'];
 export type BasicDbObject = components['schemas']['BasicDBObject'];
 export type BiConnector = components['schemas']['BiConnector'];
-export type BillingInvoice = components['schemas']['BillingInvoice'];
-export type BillingInvoiceMetadata = components['schemas']['BillingInvoiceMetadata'];
-export type BillingPayment = components['schemas']['BillingPayment'];
-export type BillingRefund = components['schemas']['BillingRefund'];
 export type CloudCluster = components['schemas']['CloudCluster'];
 export type CloudDatabaseUser = components['schemas']['CloudDatabaseUser'];
 export type CloudGcpProviderSettings = components['schemas']['CloudGCPProviderSettings'];
@@ -8154,6 +8818,8 @@ export type CloudProviderContainer = components['schemas']['CloudProviderContain
 export type CloudProviderGcpAutoScaling = components['schemas']['CloudProviderGCPAutoScaling'];
 export type CloudRegionConfig20240805 = components['schemas']['CloudRegionConfig20240805'];
 export type ClusterAlertViewForNdsGroup = components['schemas']['ClusterAlertViewForNdsGroup'];
+export type ClusterAutoScalingSettings = components['schemas']['ClusterAutoScalingSettings'];
+export type ClusterComputeAutoScaling = components['schemas']['ClusterComputeAutoScaling'];
 export type ClusterConnectionStrings = components['schemas']['ClusterConnectionStrings'];
 export type ClusterDescription20240805 = components['schemas']['ClusterDescription20240805'];
 export type ClusterDescriptionConnectionStringsPrivateEndpoint = components['schemas']['ClusterDescriptionConnectionStringsPrivateEndpoint'];
@@ -8224,6 +8890,8 @@ export type FlexBackupSettings20241113 = components['schemas']['FlexBackupSettin
 export type FlexClusterDescription20241113 = components['schemas']['FlexClusterDescription20241113'];
 export type FlexClusterDescriptionCreate20241113 = components['schemas']['FlexClusterDescriptionCreate20241113'];
 export type FlexConnectionStrings20241113 = components['schemas']['FlexConnectionStrings20241113'];
+export type FlexMetricAlert = components['schemas']['FlexMetricAlert'];
+export type FlexMetricEventTypeViewAlertable = components['schemas']['FlexMetricEventTypeViewAlertable'];
 export type FlexProviderSettings20241113 = components['schemas']['FlexProviderSettings20241113'];
 export type FlexProviderSettingsCreate20241113 = components['schemas']['FlexProviderSettingsCreate20241113'];
 export type FreeComputeAutoScalingRules = components['schemas']['FreeComputeAutoScalingRules'];
@@ -8250,7 +8918,9 @@ export type HostMetricEventTypeViewAlertable = components['schemas']['HostMetric
 export type HostMetricValue = components['schemas']['HostMetricValue'];
 export type IngestionSink = components['schemas']['IngestionSink'];
 export type IngestionSource = components['schemas']['IngestionSource'];
-export type InvoiceLineItem = components['schemas']['InvoiceLineItem'];
+export type LegacyAtlasCluster = components['schemas']['LegacyAtlasCluster'];
+export type LegacyAtlasTenantClusterUpgradeRequest = components['schemas']['LegacyAtlasTenantClusterUpgradeRequest'];
+export type LegacyReplicationSpec = components['schemas']['LegacyReplicationSpec'];
 export type Link = components['schemas']['Link'];
 export type LogIntegrationRequest = components['schemas']['LogIntegrationRequest'];
 export type LogIntegrationResponse = components['schemas']['LogIntegrationResponse'];
@@ -8292,6 +8962,7 @@ export type PeriodicCpsSnapshotSource = components['schemas']['PeriodicCpsSnapsh
 export type RawMetricAlertView = components['schemas']['RawMetricAlertView'];
 export type RawMetricUnits = components['schemas']['RawMetricUnits'];
 export type RawMetricValueView = components['schemas']['RawMetricValueView'];
+export type RegionSpec = components['schemas']['RegionSpec'];
 export type ReplicaSetAlertViewForNdsGroup = components['schemas']['ReplicaSetAlertViewForNdsGroup'];
 export type ReplicaSetEventTypeViewForNdsGroupAlertable = components['schemas']['ReplicaSetEventTypeViewForNdsGroupAlertable'];
 export type ReplicationSpec20240805 = components['schemas']['ReplicationSpec20240805'];
@@ -8324,10 +8995,13 @@ export type StreamProcessorAlertViewForNdsGroup = components['schemas']['StreamP
 export type StreamsAwsConnectionConfig = components['schemas']['StreamsAWSConnectionConfig'];
 export type StreamsAwsKinesisDataStreamsConnection = components['schemas']['StreamsAWSKinesisDataStreamsConnection'];
 export type StreamsAwsLambdaConnection = components['schemas']['StreamsAWSLambdaConnection'];
+export type StreamsAzureBlobStorageConnection = components['schemas']['StreamsAzureBlobStorageConnection'];
 export type StreamsClusterConnection = components['schemas']['StreamsClusterConnection'];
 export type StreamsConnection = components['schemas']['StreamsConnection'];
 export type StreamsDlq = components['schemas']['StreamsDLQ'];
 export type StreamsDataProcessRegion = components['schemas']['StreamsDataProcessRegion'];
+export type StreamsGcpConnectionConfig = components['schemas']['StreamsGCPConnectionConfig'];
+export type StreamsGcpPubSubConnection = components['schemas']['StreamsGCPPubSubConnection'];
 export type StreamsHttpsConnection = components['schemas']['StreamsHttpsConnection'];
 export type StreamsKafkaAuthentication = components['schemas']['StreamsKafkaAuthentication'];
 export type StreamsKafkaConnection = components['schemas']['StreamsKafkaConnection'];
@@ -8340,6 +9014,8 @@ export type StreamsOptions = components['schemas']['StreamsOptions'];
 export type StreamsPrivateLinkConnection = components['schemas']['StreamsPrivateLinkConnection'];
 export type StreamsProcessor = components['schemas']['StreamsProcessor'];
 export type StreamsProcessorWithStats = components['schemas']['StreamsProcessorWithStats'];
+export type StreamsPublicPrivateLinkNetworking = components['schemas']['StreamsPublicPrivateLinkNetworking'];
+export type StreamsPublicPrivateLinkNetworkingAccess = components['schemas']['StreamsPublicPrivateLinkNetworkingAccess'];
 export type StreamsS3Connection = components['schemas']['StreamsS3Connection'];
 export type StreamsSampleConnection = components['schemas']['StreamsSampleConnection'];
 export type StreamsSampleConnections = components['schemas']['StreamsSampleConnections'];
@@ -8914,6 +9590,53 @@ export interface operations {
             500: components["responses"]["internalServerError"];
         };
     };
+    upgradeGroupClusterTenantUpgrade: {
+        parameters: {
+            query?: {
+                /** @description Flag that indicates whether Application wraps the response in an `envelope` JSON object. Some API clients cannot access the HTTP response headers or status code. To remediate this, set envelope=true in the query. Endpoints that return a list of results use the results object as an envelope. Application adds the status parameter to the response body. */
+                envelope?: components["parameters"]["envelope"];
+                /** @description Flag that indicates whether the response body should be in the prettyprint format. */
+                pretty?: components["parameters"]["pretty"];
+            };
+            header?: never;
+            path: {
+                /**
+                 * @description Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
+                 *
+                 *     **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
+                 */
+                groupId: components["parameters"]["groupId"];
+            };
+            cookie?: never;
+        };
+        /** @description Details of the shared-tier cluster upgrade in the specified project. */
+        requestBody: {
+            content: {
+                "application/vnd.atlas.2023-01-01+json": components["schemas"]["LegacyAtlasTenantClusterUpgradeRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "RateLimit-Limit": components["headers"]["HeaderRateLimitLimit"];
+                    "RateLimit-Remaining": components["headers"]["HeaderRateLimitRemaining"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/vnd.atlas.2023-01-01+json": components["schemas"]["LegacyAtlasCluster"];
+                };
+            };
+            400: components["responses"]["badRequest"];
+            401: components["responses"]["unauthorized"];
+            402: components["responses"]["paymentRequired"];
+            403: components["responses"]["forbidden"];
+            404: components["responses"]["notFound"];
+            409: components["responses"]["conflict"];
+            429: components["responses"]["tooManyRequests"];
+            500: components["responses"]["internalServerError"];
+        };
+    };
     getGroupCluster: {
         parameters: {
             query?: {
@@ -9456,6 +10179,53 @@ export interface operations {
             };
             400: components["responses"]["badRequest"];
             401: components["responses"]["unauthorized"];
+            403: components["responses"]["forbidden"];
+            404: components["responses"]["notFound"];
+            409: components["responses"]["conflict"];
+            429: components["responses"]["tooManyRequests"];
+            500: components["responses"]["internalServerError"];
+        };
+    };
+    tenantGroupFlexClusterUpgrade: {
+        parameters: {
+            query?: {
+                /** @description Flag that indicates whether Application wraps the response in an `envelope` JSON object. Some API clients cannot access the HTTP response headers or status code. To remediate this, set envelope=true in the query. Endpoints that return a list of results use the results object as an envelope. Application adds the status parameter to the response body. */
+                envelope?: components["parameters"]["envelope"];
+                /** @description Flag that indicates whether the response body should be in the prettyprint format. */
+                pretty?: components["parameters"]["pretty"];
+            };
+            header?: never;
+            path: {
+                /**
+                 * @description Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.
+                 *
+                 *     **NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.
+                 */
+                groupId: components["parameters"]["groupId"];
+            };
+            cookie?: never;
+        };
+        /** @description Details of the flex cluster upgrade in the specified project. */
+        requestBody: {
+            content: {
+                "application/vnd.atlas.2024-11-13+json": components["schemas"]["AtlasTenantClusterUpgradeRequest20240805"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "RateLimit-Limit": components["headers"]["HeaderRateLimitLimit"];
+                    "RateLimit-Remaining": components["headers"]["HeaderRateLimitRemaining"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/vnd.atlas.2024-11-13+json": components["schemas"]["FlexClusterDescription20241113"];
+                };
+            };
+            400: components["responses"]["badRequest"];
+            401: components["responses"]["unauthorized"];
+            402: components["responses"]["paymentRequired"];
             403: components["responses"]["forbidden"];
             404: components["responses"]["notFound"];
             409: components["responses"]["conflict"];

--- a/src/tools/atlas/update/upgradeCluster.ts
+++ b/src/tools/atlas/update/upgradeCluster.ts
@@ -202,10 +202,11 @@ export class UpgradeClusterTool extends AtlasToolBase {
                     throw new UpgradeClusterError(`Cluster "${clusterName}" is already a Flex cluster.`);
                 }
 
-                ({ id: clusterId } = await this.apiClient.upgradeFlexToDedicated({
-                    groupId: projectId,
+                // tenantUpgrade: upgrades Flex clusters to Dedicated (M10+)
+                ({ id: clusterId } = await this.apiClient.tenantUpgrade({
+                    params: { path: { groupId: projectId } },
                     body: buildM10UpgradeBody("FLEX", clusterName, clusterInfo.provider, clusterInfo.region),
-                }));
+                } as unknown as Parameters<typeof this.apiClient.tenantUpgrade>[0]));
                 break;
             case "FREE":
                 ({ id: clusterId } = await this.upgradeFreeCluster(
@@ -253,10 +254,11 @@ export class UpgradeClusterTool extends AtlasToolBase {
         backingProviderName: string | undefined,
         regionName: string | undefined
     ): Promise<{ id?: string }> {
+        // upgradeTenantUpgrade: upgrades Free (M0/shared) clusters to Flex or Dedicated (M10+)
         switch (target) {
             case "FLEX":
-                return await this.apiClient.upgradeSharedTierCluster({
-                    groupId: projectId,
+                return await this.apiClient.upgradeTenantUpgrade({
+                    params: { path: { groupId: projectId } },
                     body: {
                         name: clusterName,
                         providerSettings: {
@@ -266,12 +268,12 @@ export class UpgradeClusterTool extends AtlasToolBase {
                             ...(regionName !== undefined && { regionName }),
                         },
                     },
-                });
+                } as unknown as Parameters<typeof this.apiClient.upgradeTenantUpgrade>[0]);
             case "M10":
-                return await this.apiClient.upgradeSharedTierCluster({
-                    groupId: projectId,
+                return await this.apiClient.upgradeTenantUpgrade({
+                    params: { path: { groupId: projectId } },
                     body: buildM10UpgradeBody("FREE", clusterName, backingProviderName, regionName),
-                });
+                } as unknown as Parameters<typeof this.apiClient.upgradeTenantUpgrade>[0]);
         }
     }
 

--- a/tests/unit/common/apiClient.test.ts
+++ b/tests/unit/common/apiClient.test.ts
@@ -298,106 +298,79 @@ describe("ApiClient", () => {
         });
     });
 
-    describe("upgradeSharedTierCluster", () => {
+    describe("upgradeTenantUpgrade", () => {
+        // upgradeTenantUpgrade: upgrades Free (M0/shared) clusters to Flex or Dedicated (M10+)
         const upgradeOptions = {
-            groupId: "test-group-id",
-            body: {
-                name: "MyCluster",
-                providerSettings: {
-                    providerName: "FLEX",
-                    instanceSizeName: "FLEX" as const,
-                    backingProviderName: "AWS",
-                    regionName: "US_EAST_1",
-                },
-            },
-        };
+            params: { path: { groupId: "test-group-id" } },
+            body: { name: "MyCluster", providerSettings: { providerName: "FLEX", instanceSizeName: "FLEX" } },
+        } as unknown as Parameters<ApiClient["upgradeTenantUpgrade"]>[0];
 
-        it("should POST to the tenant upgrade endpoint with legacy API version headers", async () => {
-            const mockCustomFetch = vi
-                .spyOn(apiClient as unknown as { customFetch: typeof fetch }, "customFetch")
-                .mockResolvedValue(new Response(JSON.stringify({ id: "upgraded-cluster-id" }), { status: 200 }));
+        it("should POST to the tenant upgrade endpoint", async () => {
+            const mockResult = { id: "upgraded-cluster-id", name: "MyCluster" };
+            const mockPost = vi.fn().mockResolvedValue({ data: mockResult, error: null, response: new Response() });
+            // @ts-expect-error accessing private property for testing
+            apiClient.client.POST = mockPost;
 
-            const result = await apiClient.upgradeSharedTierCluster(upgradeOptions);
+            const result = await apiClient.upgradeTenantUpgrade(upgradeOptions);
 
-            expect(mockCustomFetch).toHaveBeenCalledWith(
-                "https://api.test.com/api/atlas/v2/groups/test-group-id/clusters/tenantUpgrade",
+            expect(mockPost).toHaveBeenCalledWith(
+                "/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade",
                 expect.objectContaining({
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/vnd.atlas.2023-01-01+json",
-                        Accept: "application/vnd.atlas.2023-01-01+json",
-                        Authorization: "Bearer mockToken",
-                        "User-Agent": "test-user-agent",
-                    },
-                    body: JSON.stringify(upgradeOptions.body),
+                    ...upgradeOptions,
+                    headers: expect.objectContaining({ Accept: "application/vnd.atlas.2023-01-01+json" }),
                 })
             );
-            expect(result).toEqual({ id: "upgraded-cluster-id" });
+            expect(result).toEqual(mockResult);
         });
 
-        it("should throw when the response is not ok", async () => {
-            vi.spyOn(apiClient as unknown as { customFetch: typeof fetch }, "customFetch").mockResolvedValue(
-                new Response(JSON.stringify({ error: "Bad Request" }), { status: 400 })
-            );
+        it("should throw when the API call fails", async () => {
+            const mockPost = vi.fn().mockResolvedValue({
+                data: null,
+                error: { reason: "Bad Request" },
+                response: new Response(),
+            });
+            // @ts-expect-error accessing private property for testing
+            apiClient.client.POST = mockPost;
 
-            await expect(apiClient.upgradeSharedTierCluster(upgradeOptions)).rejects.toThrow();
+            await expect(apiClient.upgradeTenantUpgrade(upgradeOptions)).rejects.toThrow();
         });
     });
 
-    describe("upgradeFlexToDedicated", () => {
+    describe("tenantUpgrade", () => {
+        // tenantUpgrade: upgrades Flex clusters to Dedicated (M10+)
         const upgradeOptions = {
-            groupId: "test-group-id",
-            body: {
-                name: "MyCluster",
-                clusterType: "REPLICASET" as const,
-                replicationSpecs: [
-                    {
-                        regionConfigs: [
-                            {
-                                providerName: "AWS",
-                                regionName: "US_EAST_1",
-                                priority: 7,
-                                electableSpecs: { instanceSize: "M10", nodeCount: 3 },
-                            },
-                        ],
-                    },
-                ],
-                autoScaling: {
-                    compute: { enabled: true, scaleDownEnabled: true, minInstanceSize: "M10", maxInstanceSize: "M30" },
-                    diskGBEnabled: true,
-                },
-            },
-        };
+            params: { path: { groupId: "test-group-id" } },
+            body: { name: "MyCluster", clusterType: "REPLICASET", replicationSpecs: [] },
+        } as unknown as Parameters<ApiClient["tenantUpgrade"]>[0];
 
-        it("should POST to the flex tenant upgrade endpoint with current API version headers", async () => {
-            const mockCustomFetch = vi
-                .spyOn(apiClient as unknown as { customFetch: typeof fetch }, "customFetch")
-                .mockResolvedValue(new Response(JSON.stringify({ id: "upgraded-cluster-id" }), { status: 200 }));
+        it("should POST to the flex tenant upgrade endpoint", async () => {
+            const mockResult = { id: "upgraded-cluster-id", name: "MyCluster" };
+            const mockPost = vi.fn().mockResolvedValue({ data: mockResult, error: null, response: new Response() });
+            // @ts-expect-error accessing private property for testing
+            apiClient.client.POST = mockPost;
 
-            const result = await apiClient.upgradeFlexToDedicated(upgradeOptions);
+            const result = await apiClient.tenantUpgrade(upgradeOptions);
 
-            expect(mockCustomFetch).toHaveBeenCalledWith(
-                "https://api.test.com/api/atlas/v2/groups/test-group-id/flexClusters:tenantUpgrade",
+            expect(mockPost).toHaveBeenCalledWith(
+                "/api/atlas/v2/groups/{groupId}/flexClusters:tenantUpgrade",
                 expect.objectContaining({
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/vnd.atlas.2025-03-12+json",
-                        Accept: "application/vnd.atlas.2025-03-12+json",
-                        Authorization: "Bearer mockToken",
-                        "User-Agent": "test-user-agent",
-                    },
-                    body: JSON.stringify(upgradeOptions.body),
+                    ...upgradeOptions,
+                    headers: expect.objectContaining({ Accept: "application/vnd.atlas.2024-11-13+json" }),
                 })
             );
-            expect(result).toEqual({ id: "upgraded-cluster-id" });
+            expect(result).toEqual(mockResult);
         });
 
-        it("should throw when the response is not ok", async () => {
-            vi.spyOn(apiClient as unknown as { customFetch: typeof fetch }, "customFetch").mockResolvedValue(
-                new Response(JSON.stringify({ error: "Bad Request" }), { status: 400 })
-            );
+        it("should throw when the API call fails", async () => {
+            const mockPost = vi.fn().mockResolvedValue({
+                data: null,
+                error: { reason: "Bad Request" },
+                response: new Response(),
+            });
+            // @ts-expect-error accessing private property for testing
+            apiClient.client.POST = mockPost;
 
-            await expect(apiClient.upgradeFlexToDedicated(upgradeOptions)).rejects.toThrow();
+            await expect(apiClient.tenantUpgrade(upgradeOptions)).rejects.toThrow();
         });
     });
 });

--- a/tests/unit/common/apiClient.test.ts
+++ b/tests/unit/common/apiClient.test.ts
@@ -315,11 +315,10 @@ describe("ApiClient", () => {
 
             expect(mockPost).toHaveBeenCalledWith(
                 "/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade",
-                expect.objectContaining({
-                    ...upgradeOptions,
-                    headers: expect.objectContaining({ Accept: "application/vnd.atlas.2023-01-01+json" }),
-                })
+                expect.anything()
             );
+            const [, options] = mockPost.mock.calls[0] as [string, { headers: Record<string, string> }];
+            expect(options.headers["Accept"]).toBe("application/vnd.atlas.2023-01-01+json");
             expect(result).toEqual(mockResult);
         });
 
@@ -353,10 +352,7 @@ describe("ApiClient", () => {
 
             expect(mockPost).toHaveBeenCalledWith(
                 "/api/atlas/v2/groups/{groupId}/flexClusters:tenantUpgrade",
-                expect.objectContaining({
-                    ...upgradeOptions,
-                    headers: expect.objectContaining({ Accept: "application/vnd.atlas.2024-11-13+json" }),
-                })
+                upgradeOptions
             );
             expect(result).toEqual(mockResult);
         });

--- a/tests/unit/tools/atlas/update/upgradeCluster.test.ts
+++ b/tests/unit/tools/atlas/update/upgradeCluster.test.ts
@@ -73,8 +73,8 @@ describe("UpgradeClusterTool", () => {
         mockApiClient = {
             getCluster: vi.fn(),
             getFlexCluster: vi.fn(),
-            upgradeSharedTierCluster: vi.fn().mockResolvedValue(UPGRADE_RESULT),
-            upgradeFlexToDedicated: vi.fn().mockResolvedValue(UPGRADE_RESULT),
+            upgradeTenantUpgrade: vi.fn().mockResolvedValue(UPGRADE_RESULT),
+            tenantUpgrade: vi.fn().mockResolvedValue(UPGRADE_RESULT),
         };
 
         const mockLogger = {
@@ -221,8 +221,8 @@ describe("UpgradeClusterTool", () => {
             const text = (result.content[0] as { text: string }).text;
             expect(text).toContain("FREE to FLEX");
 
-            expect(mockApiClient.upgradeSharedTierCluster).toHaveBeenCalledWith({
-                groupId: "proj1",
+            expect(mockApiClient.upgradeTenantUpgrade).toHaveBeenCalledWith({
+                params: { path: { groupId: "proj1" } },
                 body: {
                     name: "MyCluster",
                     providerSettings: {
@@ -242,8 +242,8 @@ describe("UpgradeClusterTool", () => {
             const text = (result.content[0] as { text: string }).text;
             expect(text).toContain("FREE to M10");
 
-            expect(mockApiClient.upgradeSharedTierCluster).toHaveBeenCalledWith({
-                groupId: "proj1",
+            expect(mockApiClient.upgradeTenantUpgrade).toHaveBeenCalledWith({
+                params: { path: { groupId: "proj1" } },
                 body: {
                     name: "MyCluster",
                     providerSettings: {
@@ -264,8 +264,8 @@ describe("UpgradeClusterTool", () => {
             });
 
             expect(result.isError).toBeFalsy();
-            expect(mockApiClient.upgradeSharedTierCluster).toHaveBeenCalledWith({
-                groupId: "proj1",
+            expect(mockApiClient.upgradeTenantUpgrade).toHaveBeenCalledWith({
+                params: { path: { groupId: "proj1" } },
                 body: {
                     name: "MyCluster",
                     providerSettings: {
@@ -288,8 +288,8 @@ describe("UpgradeClusterTool", () => {
             });
 
             expect(result.isError).toBeFalsy();
-            expect(mockApiClient.upgradeSharedTierCluster).toHaveBeenCalledWith({
-                groupId: "proj1",
+            expect(mockApiClient.upgradeTenantUpgrade).toHaveBeenCalledWith({
+                params: { path: { groupId: "proj1" } },
                 body: {
                     name: "MyCluster",
                     providerSettings: {
@@ -318,7 +318,7 @@ describe("UpgradeClusterTool", () => {
 
             await exec({ projectId: "proj1", clusterName: "MyCluster" });
 
-            const call = mockApiClient.upgradeSharedTierCluster!.mock.calls[0]![0] as {
+            const call = mockApiClient.upgradeTenantUpgrade!.mock.calls[0]![0] as {
                 body: { providerSettings: { regionName?: string } };
             };
             expect(call.body.providerSettings.regionName).toBeUndefined();
@@ -344,8 +344,8 @@ describe("UpgradeClusterTool", () => {
             const text = (result.content[0] as { text: string }).text;
             expect(text).toContain("FLEX to M10");
 
-            expect(mockApiClient.upgradeFlexToDedicated).toHaveBeenCalledWith({
-                groupId: "proj1",
+            expect(mockApiClient.tenantUpgrade).toHaveBeenCalledWith({
+                params: { path: { groupId: "proj1" } },
                 body: {
                     name: "MyCluster",
                     clusterType: "REPLICASET",
@@ -383,7 +383,7 @@ describe("UpgradeClusterTool", () => {
             });
 
             expect(result.isError).toBeFalsy();
-            const call = mockApiClient.upgradeFlexToDedicated!.mock.calls[0]![0] as {
+            const call = mockApiClient.tenantUpgrade!.mock.calls[0]![0] as {
                 body: {
                     replicationSpecs: Array<{ regionConfigs: Array<{ providerName?: string; regionName?: string }> }>;
                 };
@@ -397,7 +397,7 @@ describe("UpgradeClusterTool", () => {
 
             await exec({ projectId: "proj1", clusterName: "MyCluster" });
 
-            const call = mockApiClient.upgradeFlexToDedicated!.mock.calls[0]![0] as {
+            const call = mockApiClient.tenantUpgrade!.mock.calls[0]![0] as {
                 body: { replicationSpecs: Array<{ regionConfigs: Array<Record<string, unknown>> }> };
             };
             expect(call.body.replicationSpecs[0]!.regionConfigs[0]!["providerName"]).toBeUndefined();
@@ -443,26 +443,26 @@ describe("UpgradeClusterTool", () => {
             expect(mockApiClient.getFlexCluster).not.toHaveBeenCalled();
         });
 
-        it("returns error when upgradeSharedTierCluster throws (FREE to FLEX)", async () => {
+        it("returns error when upgradeTenantUpgrade throws (FREE to FLEX)", async () => {
             mockApiClient.getCluster!.mockResolvedValue(FREE_CLUSTER_RAW);
-            mockApiClient.upgradeSharedTierCluster!.mockRejectedValue(new Error("upgrade quota exceeded"));
+            mockApiClient.upgradeTenantUpgrade!.mockRejectedValue(new Error("upgrade quota exceeded"));
 
             const result = await exec({ projectId: "proj1", clusterName: "MyCluster" });
             expect(result.isError).toBe(true);
         });
 
-        it("returns error when upgradeSharedTierCluster throws (FREE to M10)", async () => {
+        it("returns error when upgradeTenantUpgrade throws (FREE to M10)", async () => {
             mockApiClient.getCluster!.mockResolvedValue(FREE_CLUSTER_RAW);
-            mockApiClient.upgradeSharedTierCluster!.mockRejectedValue(new Error("upgrade quota exceeded"));
+            mockApiClient.upgradeTenantUpgrade!.mockRejectedValue(new Error("upgrade quota exceeded"));
 
             const result = await exec({ projectId: "proj1", clusterName: "MyCluster", targetTier: "M10" });
             expect(result.isError).toBe(true);
         });
 
-        it("returns error when upgradeFlexToDedicated throws", async () => {
+        it("returns error when tenantUpgrade throws", async () => {
             mockApiClient.getCluster!.mockRejectedValue(notFoundError());
             mockApiClient.getFlexCluster!.mockResolvedValue(FLEX_CLUSTER_RAW);
-            mockApiClient.upgradeFlexToDedicated!.mockRejectedValue(new Error("upgrade quota exceeded"));
+            mockApiClient.tenantUpgrade!.mockRejectedValue(new Error("upgrade quota exceeded"));
 
             const result = await exec({ projectId: "proj1", clusterName: "MyCluster" });
             expect(result.isError).toBe(true);
@@ -493,8 +493,8 @@ describe("UpgradeClusterTool", () => {
 
             expect(mockApiClient.getCluster).not.toHaveBeenCalled();
             expect(mockApiClient.getFlexCluster).not.toHaveBeenCalled();
-            expect(mockApiClient.upgradeSharedTierCluster).toHaveBeenCalledWith({
-                groupId: "proj1",
+            expect(mockApiClient.upgradeTenantUpgrade).toHaveBeenCalledWith({
+                params: { path: { groupId: "proj1" } },
                 body: {
                     name: "MyCluster",
                     providerSettings: {
@@ -519,7 +519,7 @@ describe("UpgradeClusterTool", () => {
         it("uses session provider as default when no provider arg is given", async () => {
             await exec({ projectId: "proj1", clusterName: "MyCluster" });
 
-            const call = mockApiClient.upgradeSharedTierCluster!.mock.calls[0]![0] as {
+            const call = mockApiClient.upgradeTenantUpgrade!.mock.calls[0]![0] as {
                 body: { providerSettings: { backingProviderName: string } };
             };
             expect(call.body.providerSettings.backingProviderName).toBe("AWS");
@@ -534,7 +534,7 @@ describe("UpgradeClusterTool", () => {
 
             await exec({ projectId: "proj1", clusterName: "MyCluster" });
 
-            const call = mockApiClient.upgradeSharedTierCluster!.mock.calls[0]![0] as {
+            const call = mockApiClient.upgradeTenantUpgrade!.mock.calls[0]![0] as {
                 body: { providerSettings: { backingProviderName?: string } };
             };
             expect(call.body.providerSettings.backingProviderName).toBeUndefined();
@@ -544,8 +544,8 @@ describe("UpgradeClusterTool", () => {
             const result = await exec({});
 
             expect(result.isError).toBeFalsy();
-            expect(mockApiClient.upgradeSharedTierCluster).toHaveBeenCalledWith(
-                expect.objectContaining({ groupId: "proj1" })
+            expect(mockApiClient.upgradeTenantUpgrade).toHaveBeenCalledWith(
+                expect.objectContaining({ params: { path: { groupId: "proj1" } } })
             );
         });
     });
@@ -574,11 +574,11 @@ describe("UpgradeClusterTool", () => {
 
             expect(mockApiClient.getCluster).not.toHaveBeenCalled();
             expect(mockApiClient.getFlexCluster).not.toHaveBeenCalled();
-            const call = mockApiClient.upgradeFlexToDedicated!.mock.calls[0]![0] as {
-                groupId: string;
+            const call = mockApiClient.tenantUpgrade!.mock.calls[0]![0] as {
+                params: { path: { groupId: string } };
                 body: { name: string; clusterType: string };
             };
-            expect(call.groupId).toBe("proj1");
+            expect(call.params.path.groupId).toBe("proj1");
             expect(call.body.name).toBe("MyCluster");
             expect(call.body.clusterType).toBe("REPLICASET");
         });
@@ -586,7 +586,7 @@ describe("UpgradeClusterTool", () => {
         it("uses session provider and region when no args provided", async () => {
             await exec({ projectId: "proj1", clusterName: "MyCluster" });
 
-            const call = mockApiClient.upgradeFlexToDedicated!.mock.calls[0]![0] as {
+            const call = mockApiClient.tenantUpgrade!.mock.calls[0]![0] as {
                 body: {
                     replicationSpecs: Array<{ regionConfigs: Array<{ providerName?: string; regionName?: string }> }>;
                 };
@@ -598,7 +598,7 @@ describe("UpgradeClusterTool", () => {
         it("arg provider and region override session values", async () => {
             await exec({ projectId: "proj1", clusterName: "MyCluster", provider: "GCP", region: "CENTRAL_US" });
 
-            const call = mockApiClient.upgradeFlexToDedicated!.mock.calls[0]![0] as {
+            const call = mockApiClient.tenantUpgrade!.mock.calls[0]![0] as {
                 body: {
                     replicationSpecs: Array<{ regionConfigs: Array<{ providerName?: string; regionName?: string }> }>;
                 };
@@ -624,8 +624,8 @@ describe("UpgradeClusterTool", () => {
             const result = await exec({});
 
             expect(result.isError).toBeFalsy();
-            expect(mockApiClient.upgradeSharedTierCluster).toHaveBeenCalledWith(
-                expect.objectContaining({ groupId: "session-proj" })
+            expect(mockApiClient.upgradeTenantUpgrade).toHaveBeenCalledWith(
+                expect.objectContaining({ params: { path: { groupId: "session-proj" } } })
             );
         });
 


### PR DESCRIPTION
## Proposed changes
Adding ability to override header; for endpoint `upgradeGroupClusterTenantUpgrade` to support Free --> M10 upgrade, we have to user older version.

## Testing

- [x] Manual (tested free --> flex, free --> M10, flex --> M10)
- [x] Unit

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
