### PR TITLE
fix: don't block aggregates when getSearchIndexes fails MCP-497

### DIFF
--- a/src/common/logging/loggingDefinitions.ts
+++ b/src/common/logging/loggingDefinitions.ts
@@ -41,6 +41,7 @@ export const LogId = {
     mongodbCursorCloseError: mongoLogId(1_004_004),
     mongodbIndexCheckFailure: mongoLogId(1_004_005),
     searchCapabilityProbe: mongoLogId(1_004_006),
+    mongodbGetSearchIndexesFailure: mongoLogId(1_004_007),
 
     toolUpdateFailure: mongoLogId(1_005_001),
     resourceUpdateFailure: mongoLogId(1_005_002),

--- a/src/tools/mongodb/read/aggregate.ts
+++ b/src/tools/mongodb/read/aggregate.ts
@@ -70,11 +70,22 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
             const provider = await this.ensureConnected();
             await this.assertOnlyUsesPermittedStages(pipeline);
             if (await this.session.isSearchSupported()) {
-                assertVectorSearchFilterFieldsAreIndexed({
-                    searchIndexes: (await provider.getSearchIndexes(database, collection)) as SearchIndex[],
-                    pipeline,
-                    logger: this.session.logger,
-                });
+                try {
+                    assertVectorSearchFilterFieldsAreIndexed({
+                        searchIndexes: (await provider.getSearchIndexes(database, collection)) as SearchIndex[],
+                        pipeline,
+                        logger: this.session.logger,
+                    });
+                } catch (error) {
+                    if (error instanceof MongoDBError) {
+                        throw error;
+                    }
+                    this.session.logger.debug({
+                        id: LogId.mongodbGetSearchIndexesFailure,
+                        context: "aggregate tool",
+                        message: `Failed to fetch search indexes for pre-filter validation, skipping check: ${error instanceof Error ? error.message : String(error)}`,
+                    });
+                }
             }
 
             // Check if aggregate operation uses an index if enabled
@@ -298,8 +309,17 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
         let indexExists = false;
         if (isSearchSupported) {
             const provider = await this.ensureConnected();
-            const indexes = await provider.getSearchIndexes(database, collection, indexName);
-            indexExists = indexes.length >= 1;
+            try {
+                const indexes = await provider.getSearchIndexes(database, collection, indexName);
+                indexExists = indexes.length >= 1;
+            } catch (error) {
+                this.session.logger.debug({
+                    id: LogId.mongodbGetSearchIndexesFailure,
+                    context: "aggregate tool",
+                    message: `Failed to fetch search indexes for vector search index check, skipping check: ${error instanceof Error ? error.message : String(error)}`,
+                });
+                return ["valid-index", indexName];
+            }
         }
 
         return [indexExists ? "valid-index" : "non-existent-index", indexName];

--- a/src/tools/mongodb/read/aggregate.ts
+++ b/src/tools/mongodb/read/aggregate.ts
@@ -70,20 +70,21 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
             const provider = await this.ensureConnected();
             await this.assertOnlyUsesPermittedStages(pipeline);
             if (await this.session.isSearchSupported()) {
+                let searchIndexes: SearchIndex[] | undefined;
                 try {
-                    assertVectorSearchFilterFieldsAreIndexed({
-                        searchIndexes: (await provider.getSearchIndexes(database, collection)) as SearchIndex[],
-                        pipeline,
-                        logger: this.session.logger,
-                    });
+                    searchIndexes = (await provider.getSearchIndexes(database, collection)) as SearchIndex[];
                 } catch (error) {
-                    if (error instanceof MongoDBError) {
-                        throw error;
-                    }
                     this.session.logger.debug({
                         id: LogId.mongodbGetSearchIndexesFailure,
                         context: "aggregate tool",
                         message: `Failed to fetch search indexes for pre-filter validation, skipping check: ${error instanceof Error ? error.message : String(error)}`,
+                    });
+                }
+                if (searchIndexes !== undefined) {
+                    assertVectorSearchFilterFieldsAreIndexed({
+                        searchIndexes,
+                        pipeline,
+                        logger: this.session.logger,
                     });
                 }
             }

--- a/tests/integration/tools/mongodb/read/aggregate.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregate.test.ts
@@ -22,7 +22,7 @@ import { DOCUMENT_EMBEDDINGS } from "./vyai/embeddings.js";
 import type { ToolEvent } from "../../../../../src/telemetry/types.js";
 import type { Client } from "@modelcontextprotocol/sdk/client";
 import { pipelineDescriptionWithVectorSearch } from "../../../../../src/tools/mongodb/read/aggregate.js";
-import type { Collection } from "mongodb";
+import { MongoServerError, type Collection } from "mongodb";
 
 describeWithMongoDB("aggregate tool", (integration) => {
     afterEach(() => {
@@ -300,6 +300,81 @@ describeWithMongoDB("aggregate tool", (integration) => {
             );
         });
     }
+
+    it("should succeed when getSearchIndexes throws for real collections but search probe succeeded via #mongodb-mcp fallback", async () => {
+        // Regression test for: probeSearchCapability() succeeds (logs "Atlas Search capability
+        // probe succeeded") because the #mongodb-mcp fallback returns [] - but getSearchIndexes
+        // throws for real db/collection combos. Non-search aggregations should not be affected.
+        await integration
+            .mongoClient()
+            .db(integration.randomDbName())
+            .collection("people")
+            .insertMany([{ name: "Alice" }, { name: "Bob" }]);
+
+        await integration.connectMcpClient();
+
+        vi.spyOn(integration.mcpServer().session.serviceProvider, "getSearchIndexes").mockImplementation(
+            async (dbName: string, collectionName: string) => {
+                if (dbName === "#mongodb-mcp" && collectionName === "test") {
+                    return [];
+                }
+                throw new MongoServerError({ message: "Error connecting to Search Index Management service" });
+            }
+        );
+
+        const response = await integration.mcpClient().callTool({
+            name: "aggregate",
+            arguments: {
+                database: integration.randomDbName(),
+                collection: "people",
+                pipeline: [{ $match: { name: "Alice" } }],
+            },
+        });
+
+        const content = getResponseContent(response);
+        expect(content).toContain("The aggregation resulted in 1 documents");
+        const docs = getDocsFromUntrustedContent<{ name: string }>(content);
+        expect(docs[0]?.name).toBe("Alice");
+    });
+
+    it("should not apply pre-filter validation when getSearchIndexes throws during $vectorSearch aggregate", async () => {
+        // When getSearchIndexes throws (e.g. Search Index Management service unreachable), we have
+        // no definitive answer about which filter fields are indexed, so the check is skipped and
+        // the server is allowed to decide whether the query is valid.
+        await integration.connectMcpClient();
+
+        vi.spyOn(integration.mcpServer().session.serviceProvider, "getSearchIndexes").mockImplementation(
+            async (dbName: string, collectionName: string) => {
+                if (dbName === "#mongodb-mcp" && collectionName === "test") {
+                    return [];
+                }
+                throw new MongoServerError({ message: "Error connecting to Search Index Management service" });
+            }
+        );
+
+        const response = await integration.mcpClient().callTool({
+            name: "aggregate",
+            arguments: {
+                database: integration.randomDbName(),
+                collection: "people",
+                pipeline: [
+                    {
+                        $vectorSearch: {
+                            index: "myIndex",
+                            path: "embedding",
+                            queryVector: [1, 2, 3],
+                            numCandidates: 10,
+                            limit: 5,
+                            filter: { category: "electronics" },
+                        },
+                    },
+                ],
+            },
+        });
+
+        const content = getResponseContent(response);
+        expect(content).not.toContain("Vector search stage contains filter on fields that are not indexed");
+    });
 
     validateAutoConnectBehavior(integration, "aggregate", () => {
         return {

--- a/tests/integration/tools/mongodb/read/aggregate.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregate.test.ts
@@ -301,79 +301,71 @@ describeWithMongoDB("aggregate tool", (integration) => {
         });
     }
 
-    it("should succeed when getSearchIndexes throws for real collections but search probe succeeded via #mongodb-mcp fallback", async () => {
-        // Regression test for: probeSearchCapability() succeeds (logs "Atlas Search capability
-        // probe succeeded") because the #mongodb-mcp fallback returns [] - but getSearchIndexes
-        // throws for real db/collection combos. Non-search aggregations should not be affected.
-        await integration
-            .mongoClient()
-            .db(integration.randomDbName())
-            .collection("people")
-            .insertMany([{ name: "Alice" }, { name: "Bob" }]);
-
-        await integration.connectMcpClient();
-
-        vi.spyOn(integration.mcpServer().session.serviceProvider, "getSearchIndexes").mockImplementation(
-            async (dbName: string, collectionName: string) => {
-                if (dbName === "#mongodb-mcp" && collectionName === "test") {
-                    return [];
-                }
-                throw new MongoServerError({ message: "Error connecting to Search Index Management service" });
-            }
-        );
-
-        const response = await integration.mcpClient().callTool({
-            name: "aggregate",
-            arguments: {
-                database: integration.randomDbName(),
-                collection: "people",
-                pipeline: [{ $match: { name: "Alice" } }],
-            },
+    describe("when getSearchIndexes throws after a successful search capability probe", () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
         });
 
-        const content = getResponseContent(response);
-        expect(content).toContain("The aggregation resulted in 1 documents");
-        const docs = getDocsFromUntrustedContent<{ name: string }>(content);
-        expect(docs[0]?.name).toBe("Alice");
-    });
+        it("should succeed for non-search aggregations", async () => {
+            await integration
+                .mongoClient()
+                .db(integration.randomDbName())
+                .collection("people")
+                .insertMany([{ name: "Alice" }, { name: "Bob" }]);
 
-    it("should not apply pre-filter validation when getSearchIndexes throws during $vectorSearch aggregate", async () => {
-        // When getSearchIndexes throws (e.g. Search Index Management service unreachable), we have
-        // no definitive answer about which filter fields are indexed, so the check is skipped and
-        // the server is allowed to decide whether the query is valid.
-        await integration.connectMcpClient();
+            await integration.connectMcpClient();
 
-        vi.spyOn(integration.mcpServer().session.serviceProvider, "getSearchIndexes").mockImplementation(
-            async (dbName: string, collectionName: string) => {
-                if (dbName === "#mongodb-mcp" && collectionName === "test") {
-                    return [];
-                }
-                throw new MongoServerError({ message: "Error connecting to Search Index Management service" });
-            }
-        );
+            vi.spyOn(integration.mcpServer().session, "isSearchSupported").mockResolvedValue(true);
+            vi.spyOn(integration.mcpServer().session.serviceProvider, "getSearchIndexes").mockRejectedValue(
+                new MongoServerError({ message: "Error connecting to Search Index Management service" })
+            );
 
-        const response = await integration.mcpClient().callTool({
-            name: "aggregate",
-            arguments: {
-                database: integration.randomDbName(),
-                collection: "people",
-                pipeline: [
-                    {
-                        $vectorSearch: {
-                            index: "myIndex",
-                            path: "embedding",
-                            queryVector: [1, 2, 3],
-                            numCandidates: 10,
-                            limit: 5,
-                            filter: { category: "electronics" },
+            const response = await integration.mcpClient().callTool({
+                name: "aggregate",
+                arguments: {
+                    database: integration.randomDbName(),
+                    collection: "people",
+                    pipeline: [{ $match: { name: "Alice" } }],
+                },
+            });
+
+            const content = getResponseContent(response);
+            expect(content).toContain("The aggregation resulted in 1 documents");
+            const docs = getDocsFromUntrustedContent<{ name: string }>(content);
+            expect(docs[0]?.name).toBe("Alice");
+        });
+
+        it("should skip pre-filter validation and let the server decide for $vectorSearch aggregations", async () => {
+            await integration.connectMcpClient();
+
+            vi.spyOn(integration.mcpServer().session, "isSearchSupported").mockResolvedValue(true);
+            vi.spyOn(integration.mcpServer().session.serviceProvider, "getSearchIndexes").mockRejectedValue(
+                new MongoServerError({ message: "Error connecting to Search Index Management service" })
+            );
+
+            const response = await integration.mcpClient().callTool({
+                name: "aggregate",
+                arguments: {
+                    database: integration.randomDbName(),
+                    collection: "people",
+                    pipeline: [
+                        {
+                            $vectorSearch: {
+                                index: "myIndex",
+                                path: "embedding",
+                                queryVector: [1, 2, 3],
+                                numCandidates: 10,
+                                limit: 5,
+                                filter: { category: "electronics" },
+                            },
                         },
-                    },
-                ],
-            },
-        });
+                    ],
+                },
+            });
 
-        const content = getResponseContent(response);
-        expect(content).not.toContain("Vector search stage contains filter on fields that are not indexed");
+            const content = getResponseContent(response);
+            expect(content).not.toContain("Vector search stage contains filter on fields that are not indexed");
+        });
     });
 
     validateAutoConnectBehavior(integration, "aggregate", () => {


### PR DESCRIPTION
## Proposed changes

On some environments, getSearchIndexes will succeed with the test collection/database, but fail when called with existing ones. This would cause false negatives when we try and validate index usage in `aggregate`. This PR makes it so we skip the checks when this happens and instead rely on the server to accept/reject the aggregation.