### PR TITLE
feat: add OIDC authentication support for atlas-connect-cluster

### DIFF
--- a/src/common/config/userConfig.ts
+++ b/src/common/config/userConfig.ts
@@ -208,6 +208,27 @@ const ServerConfigSchema = z.object({
             "Time in milliseconds that temporary database users created when connecting to MongoDB Atlas clusters will remain active before being automatically deleted."
         )
         .register(configRegistry, { overrideBehavior: onlyLowerThanBaseValueOverride() }),
+    atlasAuthMechanism: z
+        .enum(["username-password", "mongodb-oidc"])
+        .default("username-password")
+        .describe(
+            "Authentication mechanism used when connecting to Atlas clusters via the atlas-connect-cluster tool. " +
+                "'username-password' (default) creates a temporary database user. " +
+                "'mongodb-oidc' uses OIDC authentication and avoids creating temporary users — requires the Atlas project to have OIDC configured as a database user auth method (MongoDB 7.0+). " +
+                "Clusters running MongoDB older than 7.0 automatically fall back to 'username-password'. " +
+                "When using 'mongodb-oidc', ensure the OIDC database user in Atlas has appropriate cluster scopes (or no scope to allow all clusters) and database roles for the operations needed."
+        )
+        .register(configRegistry, {}),
+    atlasOidcMechanismProperties: z
+        .string()
+        .default("")
+        .describe(
+            "Additional OIDC mechanism properties appended to the connection string when atlasAuthMechanism is 'mongodb-oidc'. " +
+                "Required for workload identity federation. " +
+                "Examples: 'ENVIRONMENT:azure' (Azure Managed Identity), 'ENVIRONMENT:gcp,TOKEN_RESOURCE:<audience>' (GCP), 'ENVIRONMENT:k8s,TOKEN_RESOURCE:<audience>' (Kubernetes). " +
+                "Leave empty for workforce identity federation (human interactive browser/device-code flows)."
+        )
+        .register(configRegistry, {}),
     voyageApiKey: z
         .string()
         .default("")

--- a/src/common/connectionInfo.ts
+++ b/src/common/connectionInfo.ts
@@ -21,19 +21,29 @@ export interface ConnectionStringInfo {
     hostType: ConnectionStringHostType;
 }
 
-/**
- * Atlas cluster connection info containing details about the connected Atlas cluster.
- * When provided, indicates the connection is to an Atlas cluster.
- */
-export interface AtlasClusterConnectionInfo {
-    username: string;
+interface AtlasClusterConnectionInfoBase {
     projectId: string;
     clusterName: string;
     instanceType: "FREE" | "FLEX" | "DEDICATED";
     provider?: string;
     region?: string;
+}
+
+export interface AtlasTempUserConnectionInfo extends AtlasClusterConnectionInfoBase {
+    authType: "temp-user";
+    username: string;
     expiryDate: Date;
 }
+
+export interface AtlasOIDCConnectionInfo extends AtlasClusterConnectionInfoBase {
+    authType: "oidc";
+}
+
+/**
+ * Atlas cluster connection info containing details about the connected Atlas cluster.
+ * When provided, indicates the connection is to an Atlas cluster.
+ */
+export type AtlasClusterConnectionInfo = AtlasTempUserConnectionInfo | AtlasOIDCConnectionInfo;
 
 /**
  * Get metadata about the connection string including authentication type and host type.

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -108,7 +108,7 @@ export class Session extends EventEmitter<SessionEvents> {
 
         await this.connectionManager.close();
 
-        if (atlasCluster?.username && atlasCluster?.projectId && this.apiClient) {
+        if (atlasCluster?.authType === "temp-user" && this.apiClient) {
             void this.apiClient
                 .deleteDatabaseUser({
                     params: {

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { type OperationType, type ToolArgs } from "../../tool.js";
 import { AtlasToolBase } from "../atlasTool.js";
@@ -26,6 +27,17 @@ export const ConnectClusterArgs = {
     connectionType: AtlasArgs.connectionType().describe(
         "Type of connection (standard, private, or privateEndpoint) to an Atlas cluster"
     ),
+    authMechanism: z
+        .literal("username-password")
+        .optional()
+        .describe(
+            "Override to force temporary user creation for this connection. " +
+                "Only set this if: the server is configured for 'mongodb-oidc' AND a previous " +
+                "OIDC-authenticated connection to this cluster produced authorization errors on " +
+                "database operations, indicating the OIDC identity lacks sufficient access. " +
+                "Requires Atlas API credentials with database user management permissions. " +
+                "Do not set this preemptively."
+        ),
 };
 
 export class ConnectClusterTool extends AtlasToolBase {
@@ -116,6 +128,7 @@ export class ConnectClusterTool extends AtlasToolBase {
         });
 
         const connectedAtlasCluster = {
+            authType: "temp-user" as const,
             username,
             projectId,
             clusterName,
@@ -134,6 +147,48 @@ export class ConnectClusterTool extends AtlasToolBase {
         this.session.keychain.register(password, "password");
 
         return { connectionString: cn.toString(), atlas: connectedAtlasCluster };
+    }
+
+    private async prepareClusterConnectionOIDC(
+        projectId: string,
+        clusterName: string,
+        connectionType: "standard" | "private" | "privateEndpoint" | undefined = "standard"
+    ): Promise<{ connectionString: string; atlas: AtlasClusterConnectionInfo } | null> {
+        const cluster = await inspectCluster(this.apiClient, projectId, clusterName);
+
+        if (cluster.connectionStrings === undefined) {
+            throw new Error("Connection strings not available");
+        }
+        const connectionString = getConnectionString(cluster.connectionStrings, connectionType);
+        if (connectionString === undefined) {
+            throw new Error(
+                `Connection string for connection type "${connectionType}" is not available. Please ensure this connection type is set up in Atlas. See https://www.mongodb.com/docs/atlas/connect-to-database-deployment/#connect-to-an-atlas-cluster.`
+            );
+        }
+
+        if (cluster.mongoDBVersion) {
+            const major = parseInt(cluster.mongoDBVersion.split(".").at(0) ?? "", 10);
+            if (!isNaN(major) && major < 7) {
+                return null;
+            }
+        }
+
+        const cn = new URL(connectionString);
+        cn.searchParams.set("authMechanism", "MONGODB-OIDC");
+        if (this.config.atlasOidcMechanismProperties) {
+            cn.searchParams.set("authMechanismProperties", this.config.atlasOidcMechanismProperties);
+        }
+
+        const atlas: AtlasClusterConnectionInfo = {
+            authType: "oidc",
+            projectId,
+            clusterName,
+            instanceType: cluster.instanceType,
+            provider: cluster.provider,
+            region: cluster.region,
+        };
+
+        return { connectionString: cn.toString(), atlas };
     }
 
     private async connectToCluster(connectionString: string, atlas: AtlasClusterConnectionInfo): Promise<void> {
@@ -177,17 +232,18 @@ export class ConnectClusterTool extends AtlasToolBase {
         }
 
         if (lastError) {
+            const connectedCluster = this.session.connectedAtlasCluster;
             if (
-                this.session.connectedAtlasCluster?.projectId === atlas.projectId &&
-                this.session.connectedAtlasCluster?.clusterName === atlas.clusterName &&
-                this.session.connectedAtlasCluster?.username
+                connectedCluster?.projectId === atlas.projectId &&
+                connectedCluster?.clusterName === atlas.clusterName &&
+                connectedCluster?.authType === "temp-user"
             ) {
                 void this.apiClient
                     .deleteDatabaseUser({
                         params: {
                             path: {
-                                groupId: this.session.connectedAtlasCluster.projectId,
-                                username: this.session.connectedAtlasCluster.username,
+                                groupId: connectedCluster.projectId,
+                                username: connectedCluster.username,
                                 databaseName: "admin",
                             },
                         },
@@ -216,15 +272,43 @@ export class ConnectClusterTool extends AtlasToolBase {
         projectId,
         clusterName,
         connectionType,
+        authMechanism,
     }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
         const ipAccessListUpdated = await ensureCurrentIpInAccessList(this.apiClient, projectId);
         let createdUser = false;
+        let oidcFallbackMessage: string | undefined;
 
         const state = this.queryConnection(projectId, clusterName);
         switch (state) {
             case "connected-to-other-cluster":
             case "disconnected": {
                 await this.session.disconnect();
+
+                if (this.config.atlasAuthMechanism === "mongodb-oidc" && authMechanism !== "username-password") {
+                    const oidcResult = await this.prepareClusterConnectionOIDC(
+                        projectId,
+                        clusterName,
+                        connectionType
+                    );
+
+                    if (oidcResult !== null) {
+                        void this.session
+                            .connectToMongoDB(oidcResult)
+                            .catch((err: unknown) => {
+                                const error = err instanceof Error ? err : new Error(String(err));
+                                this.session.logger.error({
+                                    id: LogId.atlasConnectFailure,
+                                    context: "atlas-connect-cluster",
+                                    message: `error connecting to cluster via OIDC: ${error.message}`,
+                                });
+                            });
+                        break;
+                    }
+
+                    oidcFallbackMessage =
+                        `Note: OIDC authentication is not supported on this cluster's MongoDB version. ` +
+                        `Falling back to temporary user creation.`;
+                }
 
                 const { connectionString, atlas } = await this.prepareClusterConnection(
                     projectId,
@@ -254,8 +338,35 @@ export class ConnectClusterTool extends AtlasToolBase {
         }
 
         for (let i = 0; i < 60; i++) {
-            const state = this.queryConnection(projectId, clusterName);
-            switch (state) {
+            const connState = this.session.connectionManager.currentConnectionState;
+
+            // Surface OIDC device-flow info so the user can complete authentication.
+            if (
+                connState.tag === "connecting" &&
+                connState.connectedAtlasCluster?.projectId === projectId &&
+                connState.connectedAtlasCluster?.clusterName === clusterName &&
+                connState.oidcLoginUrl
+            ) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `To authenticate via OIDC, visit: ${connState.oidcLoginUrl}`,
+                        },
+                        {
+                            type: "text",
+                            text: `Enter code: ${connState.oidcUserCode}`,
+                        },
+                        {
+                            type: "text",
+                            text: `Call this tool again after authenticating to confirm the connection.`,
+                        },
+                    ],
+                };
+            }
+
+            const queryState = this.queryConnection(projectId, clusterName);
+            switch (queryState) {
                 case "connected": {
                     const content: CallToolResult["content"] = [
                         {
@@ -268,6 +379,13 @@ export class ConnectClusterTool extends AtlasToolBase {
                         content.push({
                             type: "text",
                             text: addedIpAccessListMessage,
+                        });
+                    }
+
+                    if (oidcFallbackMessage) {
+                        content.push({
+                            type: "text",
+                            text: oidcFallbackMessage,
                         });
                     }
 
@@ -307,6 +425,13 @@ export class ConnectClusterTool extends AtlasToolBase {
             content.push({
                 type: "text" as const,
                 text: addedIpAccessListMessage,
+            });
+        }
+
+        if (oidcFallbackMessage) {
+            content.push({
+                type: "text" as const,
+                text: oidcFallbackMessage,
             });
         }
 

--- a/tests/integration/common/connectionManager.test.ts
+++ b/tests/integration/common/connectionManager.test.ts
@@ -139,6 +139,7 @@ describeWithMongoDB("Connection Manager", (integration) => {
 
         describe("when fails to connect to a new atlas cluster", () => {
             const atlas = {
+                authType: "temp-user" as const,
                 username: "",
                 projectId: "",
                 clusterName: "My Atlas Cluster",

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -49,6 +49,8 @@ const expectedDefaults = {
     maxDocumentsPerQuery: 100,
     maxBytesPerQuery: 16 * 1024 * 1024, // ~16 mb
     atlasTemporaryDatabaseUserLifetimeMs: 4 * 60 * 60 * 1000, // 4 hours
+    atlasAuthMechanism: "username-password",
+    atlasOidcMechanismProperties: "",
     voyageApiKey: "",
     previewFeatures: [],
     dryRun: false,

--- a/tests/unit/common/connectionInfo.test.ts
+++ b/tests/unit/common/connectionInfo.test.ts
@@ -215,6 +215,7 @@ describe("connectionInfo", () => {
 
     describe("getConnectionStringInfo", () => {
         const atlasClusterInfo: AtlasClusterConnectionInfo = {
+            authType: "temp-user",
             username: "testuser",
             projectId: "project123",
             clusterName: "TestCluster",

--- a/tests/unit/resources/common/debug.test.ts
+++ b/tests/unit/resources/common/debug.test.ts
@@ -111,6 +111,7 @@ describe("debug resource", () => {
             },
             errorReason: "Error message from the server",
             connectedAtlasCluster: {
+                authType: "temp-user" as const,
                 clusterName: "My Test Cluster",
                 projectId: "COFFEEFABADA",
                 username: "",

--- a/tests/unit/tools/atlas/update/upgradeCluster.test.ts
+++ b/tests/unit/tools/atlas/update/upgradeCluster.test.ts
@@ -157,6 +157,7 @@ describe("UpgradeClusterTool", () => {
 
         it("returns error for DEDICATED cluster when connected", async () => {
             const connectedCluster: AtlasClusterConnectionInfo = {
+                authType: "temp-user",
                 username: "user",
                 projectId: "proj1",
                 clusterName: "MyCluster",
@@ -188,6 +189,7 @@ describe("UpgradeClusterTool", () => {
 
         it("returns error when attempting to upgrade FLEX to FLEX (connected)", async () => {
             const connectedCluster: AtlasClusterConnectionInfo = {
+                authType: "temp-user",
                 username: "user",
                 projectId: "proj1",
                 clusterName: "MyCluster",
@@ -483,6 +485,7 @@ describe("UpgradeClusterTool", () => {
 
     describe("connected — FREE cluster", () => {
         const connectedFreeCluster: AtlasClusterConnectionInfo = {
+            authType: "temp-user",
             username: "user",
             projectId: "proj1",
             clusterName: "MyCluster",
@@ -564,6 +567,7 @@ describe("UpgradeClusterTool", () => {
 
     describe("connected — FLEX cluster", () => {
         const connectedFlexCluster: AtlasClusterConnectionInfo = {
+            authType: "temp-user",
             username: "user",
             projectId: "proj1",
             clusterName: "MyCluster",
@@ -623,6 +627,7 @@ describe("UpgradeClusterTool", () => {
     describe("session resolves projectId and clusterName", () => {
         it("uses session projectId and clusterName when args are omitted", async () => {
             const connectedCluster: AtlasClusterConnectionInfo = {
+                authType: "temp-user",
                 username: "user",
                 projectId: "session-proj",
                 clusterName: "SessionCluster",
@@ -643,6 +648,7 @@ describe("UpgradeClusterTool", () => {
 
         it("returns error when session cluster exists but projectId/clusterName mismatch args", async () => {
             const connectedCluster: AtlasClusterConnectionInfo = {
+                authType: "temp-user",
                 username: "user",
                 projectId: "other-proj",
                 clusterName: "OtherCluster",


### PR DESCRIPTION
## Summary

Adds `mongodb-oidc` as an alternative authentication mechanism for `atlas-connect-cluster`, controlled by two new server-level config options:

- `MDB_MCP_ATLAS_AUTH_MECHANISM=mongodb-oidc` — opt in to OIDC instead of temporary user creation
- `MDB_MCP_ATLAS_OIDC_MECHANISM_PROPERTIES` — optional `authMechanismProperties` string for workload identity federation (e.g. `ENVIRONMENT:k8s,TOKEN_RESOURCE:<audience>`)

When OIDC is enabled, the tool skips creating a temporary Atlas database user entirely, allowing deployments with lower-privilege Atlas API credentials (no user management permissions required — `Project Read Only` + `Project IP Access List Admin` is sufficient).

Supports both:
- **Workforce identity federation**: human interactive browser/device-code flows (no `authMechanismProperties` needed)
- **Workload identity federation**: non-interactive cloud identity (Azure Managed Identity, GCP SA, Kubernetes ServiceAccount) via `MDB_MCP_ATLAS_OIDC_MECHANISM_PROPERTIES`

_Editor's note: See [here](https://gist.github.com/gmishkin/309823c33b05811daad80494ab64f189) for an acknowledgment of the limitations of the workload identity federation support._

## Design decisions and tradeoffs

**Auth mechanism is server-level config, not a tool argument.**
An earlier approach exposed `authMechanism` as a tool argument. We moved it to server config because the LLM agent has no way to know whether a given Atlas project has OIDC configured — that's deployment-specific knowledge the operator holds. A single MCP server deployment is already implicitly scoped to one Atlas org (the API credentials are org-scoped), and OIDC availability is also org/federation-scoped, so a server-level toggle is the right boundary.

`authMechanismProperties` is also server-only for the same reason: which cloud environment the server is running in (`ENVIRONMENT:azure`, `ENVIRONMENT:k8s`, etc.) is a property of the deployment, not something the agent should determine at call time.

**Tool-level `authMechanism: "username-password"` override retained as escape hatch.**
If the server is configured for OIDC but the OIDC identity lacks sufficient database access on a specific cluster (wrong cluster scope or insufficient roles), the agent's only recourse without this override would be a server restart. The tool now accepts an optional `authMechanism: "username-password"` argument that forces the temp-user path for that connection. The description is intentionally restrictive: agents are instructed only to set this after observing authorization errors on a previous OIDC-authenticated connection to the cluster.

**No preflight check for OIDC user access.**
We considered checking whether the OIDC identity has appropriate cluster scopes and roles before connecting, but there is no clean way to do this: the check would require additional Atlas API calls, and authorization errors only surface through actual database operations after the connection is established. The config description documents the requirement that operators ensure their OIDC database user in Atlas has appropriate cluster scopes and roles.

**Fallback to temp-user for pre-7.0 clusters.**
When `atlasAuthMechanism=mongodb-oidc` is set but the target cluster is detected as running MongoDB < 7.0 (which does not support OIDC), the tool automatically falls back to temporary user creation and includes a note in the response. This requires the Atlas API credentials to have user management permissions for pre-7.0 clusters in a mixed-version org.

**`AtlasClusterConnectionInfo` refactored to a discriminated union.**
_Editor's note: This one is not super interesting. Check the edit history of this description to see the details_

**IP access list check is unchanged for OIDC.**
_Editor's note: I think this should be considered for https://jira.mongodb.org/browse/MCP-334_

We briefly considered skipping `ensureCurrentIpInAccessList` in OIDC mode (since lower-privilege credentials can't write to the access list). However, reading the access list and the `api/private/ipinfo` endpoint both work with `Project IP Access List Admin`, which is a reasonable permission to grant alongside `Project Read Only` for an OIDC deployment. Skipping the check was reverted — operators should grant `Project IP Access List Admin` to their service account.

## Test plan

- [ ] `pnpm run check:types` passes
- [ ] `pnpm run test:local` passes (pre-existing failures in `exportsManager`, `dropIndex`, `collectionIndexes` are unrelated)
- [ ] Manual test: Atlas cluster with OIDC configured, `MDB_MCP_ATLAS_AUTH_MECHANISM=mongodb-oidc` — connection succeeds without creating a DB user
- [ ] Manual test: pre-7.0 cluster with OIDC config — falls back to temp user with notice in response
- [ ] Manual test: OIDC connection followed by auth error, then retry with `authMechanism: "username-password"` — switches to temp user