### PR TITLE
chore: Grove support for accuracy tests

### DIFF
--- a/scripts/accuracy/runAccuracyTests.sh
+++ b/scripts/accuracy/runAccuracyTests.sh
@@ -3,10 +3,14 @@
 export MDB_ACCURACY_RUN_ID=$(pnpm dlx uuid v4)
 
 # For providing access tokens for different LLM providers
-# export MDB_OPEN_AI_API_KEY=""
-# export MDB_GEMINI_API_KEY=""
+# Azure OpenAI (CI default)
 # export MDB_AZURE_OPEN_AI_API_KEY=""
 # export MDB_AZURE_OPEN_AI_API_URL=""
+# Grove
+# export MDB_GROVE_API_KEY=""
+# Other providers
+# export MDB_OPEN_AI_API_KEY=""
+# export MDB_GEMINI_API_KEY=""
 
 # For providing Atlas API credentials (required for Atlas tools)
 # Set dummy values for testing (allows Atlas tools to be registered for mocking)
@@ -20,9 +24,9 @@ export MDB_MCP_API_CLIENT_SECRET=${MDB_MCP_API_CLIENT_SECRET:-"test-atlas-client
 
 # By default we run all the tests under tests/accuracy folder unless a path is
 # specified in the command line. Such as:
-# pnpm run test:accuracy -- tests/accuracy/some-test.test.ts
+# pnpm run test:accuracy tests/accuracy/some-test.test.ts
 echo "Running accuracy tests with MDB_ACCURACY_RUN_ID '$MDB_ACCURACY_RUN_ID'"
-vitest --config vitest.config.ts --project=accuracy --coverage=false --max-workers=2 --run "$@"
+vitest --config vitest.config.ts --project=accuracy --coverage=false --max-workers="${MDB_ACCURACY_MAX_WORKERS:-2}" --run "$@"
 
 # Preserving the exit code from test run to correctly notify in the CI
 # environments when the tests fail.

--- a/tests/accuracy/sdk/models.ts
+++ b/tests/accuracy/sdk/models.ts
@@ -2,6 +2,9 @@ import type { LanguageModel } from "ai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createAzure } from "@ai-sdk/azure";
 import { createOpenAI } from "@ai-sdk/openai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+
+const GROVE_BASE_URL = "https://grove-gateway-prod.azure-api.net/grove-foundry-prod";
 
 export interface Model<VercelModel extends LanguageModel = LanguageModel> {
     readonly modelName: string;
@@ -71,7 +74,60 @@ export class GeminiModel implements Model {
     }
 }
 
-const ALL_TESTABLE_MODELS: Model[] = [new AzureOpenAIModel("gpt-4o")];
+export class GroveOpenAICompatibleModel implements Model {
+    readonly provider: string;
+    readonly displayName: string;
+
+    constructor(
+        readonly modelName: string,
+        providerName: string
+    ) {
+        this.provider = `Grove/${providerName}`;
+        this.displayName = `${this.provider} - ${modelName}`;
+    }
+
+    isAvailable(): boolean {
+        return !!process.env.MDB_GROVE_API_KEY;
+    }
+
+    getModel(): LanguageModel {
+        return createOpenAI({
+            baseURL: `${GROVE_BASE_URL}/openai/v1`,
+            apiKey: process.env.MDB_GROVE_API_KEY!,
+            headers: { "api-key": process.env.MDB_GROVE_API_KEY! },
+        }).chat(this.modelName);
+    }
+}
+
+export class GroveAnthropicModel implements Model {
+    readonly provider = "Grove/Anthropic";
+    readonly displayName: string;
+
+    constructor(readonly modelName: string) {
+        this.displayName = `${this.provider} - ${modelName}`;
+    }
+
+    isAvailable(): boolean {
+        return !!process.env.MDB_GROVE_API_KEY;
+    }
+
+    getModel(): LanguageModel {
+        return createAnthropic({
+            baseURL: `${GROVE_BASE_URL}/anthropic/v1`,
+            apiKey: process.env.MDB_GROVE_API_KEY!,
+            headers: { "api-key": process.env.MDB_GROVE_API_KEY! },
+        }).languageModel(this.modelName);
+    }
+}
+
+const ALL_TESTABLE_MODELS: Model[] = [
+    new AzureOpenAIModel("gpt-4o"),
+    new GroveOpenAICompatibleModel("gpt-4o", "OpenAI"),
+    //new GroveOpenAICompatibleModel("DeepSeek-V4-Pro", "DeepSeek"),
+    //new GroveOpenAICompatibleModel("Kimi-K2.6", "Kimi"),
+    //new GroveOpenAICompatibleModel("grok-4-20-reasoning", "Grok"),
+    new GroveAnthropicModel("claude-sonnet-4-6"),
+];
 
 export function getAvailableModels(): Model[] {
     return ALL_TESTABLE_MODELS.filter((model) => model.isAvailable());


### PR DESCRIPTION
## Summary

Adds Grove support for accuracy tests, which facilitates running accuracy tests locally.

Similar approach as [#1140](https://github.com/mongodb-js/mongodb-mcp-server/pull/1140) but limited to adding Grove support only. CI is unmodified, we can update gh secrets as needed if we choose to move to Grove.
- Included the MDB_ACCURACY_MAX_WORKERS idea from the linked PR as well, useful when running against multiple models.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
