### PR TITLE
feat: require OAuth/OIDC bearer auth on HTTP transport (OWASP MCP07)

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -29,11 +29,15 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { MetricDefinitions } from '@mongodb-js/mcp-metrics';
 import { Metrics } from '@mongodb-js/mcp-metrics';
 import type { MongoLogId } from 'mongodb-log-writer';
+import type { NextFunction } from 'express';
 import { NodeDriverServiceProvider } from '@mongosh/service-provider-node-driver';
+import * as oauth from 'oauth4webapi';
 import type { operations } from './openapi.js';
 import { PrometheusMetrics } from '@mongodb-js/mcp-metrics';
 import { PrometheusMetricsOptions } from '@mongodb-js/mcp-metrics';
 import { Registry } from '@mongodb-js/mcp-metrics';
+import type { Request as Request_2 } from 'express';
+import type { Response as Response_2 } from 'express';
 import { Secret } from 'mongodb-redact';
 import type { SessionCloseReason } from '@mongodb-js/mcp-types';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -210,6 +214,14 @@ export function applyConfigOverrides<TUserConfig extends UserConfig = UserConfig
     baseConfig: TUserConfig;
     request?: RequestContext_2;
 }): TUserConfig;
+
+// @public
+export interface AuthContext {
+    audience: string[];
+    issuer: string;
+    scopes: string[];
+    sub: string;
+}
 
 // @public
 export interface AuthProvider {
@@ -425,6 +437,9 @@ export type CreateMcpHttpServerFn<TUserConfig extends UserConfig = UserConfig, T
 export type CreateMonitoringServerFn<TMetrics extends DefaultMetrics = DefaultMetrics> = (args: MonitoringServerConstructorArgs<TMetrics>) => MonitoringServer<TMetrics> | undefined;
 
 // @public
+export function createOAuthMiddleware(input: OAuthMiddlewareOptions): (req: Request_2, res: Response_2, next: NextFunction) => Promise<void>;
+
+// @public
 export type CreateSessionConfigFn<TUserConfig extends UserConfig = UserConfig> = (context: {
     userConfig: TUserConfig;
     request?: TransportRequestContext;
@@ -586,6 +601,9 @@ export class ExportsManager extends EventEmitter<ExportsManagerEvents> {
 
 export { Gauge }
 
+// @public
+export function getAuthContext(req: Request_2): AuthContext | undefined;
+
 export { Histogram }
 
 // @public
@@ -624,6 +642,16 @@ export const JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED = -32001;
 
 // @public
 export const JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND = -32003;
+
+// @public
+export class JwksCache {
+    constructor(input: {
+        ttlMs: number;
+        logger: LoggerBase;
+    });
+    clear(): void;
+    getAuthorizationServer(issuer: string): Promise<oauth.AuthorizationServer>;
+}
 
 // @public
 export class Keychain {
@@ -783,6 +811,14 @@ export class NullLogger extends LoggerBase {
     protected logCore(): void;
     // (undocumented)
     protected type?: LoggerType;
+}
+
+// @public (undocumented)
+export interface OAuthMiddlewareOptions {
+    audience: string;
+    issuer: string;
+    jwksCache: JwksCache;
+    logger: LoggerBase;
 }
 
 // @public (undocumented)
@@ -1213,6 +1249,9 @@ export const UserConfigSchema: z.ZodObject<{
     httpHost: z.ZodDefault<z.ZodString>;
     httpHeaders: z.ZodDefault<z.ZodObject<{}, z.core.$loose>>;
     httpBodyLimit: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
+    oauthIssuer: z.ZodOptional<z.ZodString>;
+    oauthAudience: z.ZodOptional<z.ZodString>;
+    oauthJwksCacheTtlMs: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
     idleTimeoutMs: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
     notificationTimeoutMs: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
     maxBytesPerQuery: z.ZodDefault<z.ZodCoercedNumber<unknown>>;

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -22,8 +22,12 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { MetricDefinitions } from '@mongodb-js/mcp-metrics';
 import { Metrics } from '@mongodb-js/mcp-metrics';
 import type { MongoLogId } from 'mongodb-log-writer';
+import type { NextFunction } from 'express';
 import { NodeDriverServiceProvider } from '@mongosh/service-provider-node-driver';
+import * as oauth from 'oauth4webapi';
 import type { operations } from './openapi.js';
+import type { Request as Request_2 } from 'express';
+import type { Response as Response_2 } from 'express';
 import { Secret } from 'mongodb-redact';
 import type { TelemetryEvents } from '@mongodb-js/mcp-types';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
@@ -227,6 +231,14 @@ export type AtlasMetadata = {
     project_id?: string;
     org_id?: string;
 };
+
+// @public
+export interface AuthContext {
+    audience: string[];
+    issuer: string;
+    scopes: string[];
+    sub: string;
+}
 
 // @public
 export interface AuthProvider {
@@ -454,6 +466,9 @@ export type ConnectionTag = "connected" | "connecting" | "disconnected" | "error
 export { createDefaultMetrics }
 
 // @public
+export function createOAuthMiddleware(input: OAuthMiddlewareOptions): (req: Request_2, res: Response_2, next: NextFunction) => Promise<void>;
+
+// @public
 export type CreateSessionConfigFn<TUserConfig extends UserConfig = UserConfig> = (context: {
     userConfig: TUserConfig;
     request?: TransportRequestContext;
@@ -595,6 +610,9 @@ export type ExportsManagerEvents = {
 };
 
 // @public
+export function getAuthContext(req: Request_2): AuthContext | undefined;
+
+// @public
 export function getRandomUUID(): string;
 
 // @public (undocumented)
@@ -611,6 +629,16 @@ export const jsonExportFormat: z.ZodEnum<{
     relaxed: "relaxed";
     canonical: "canonical";
 }>;
+
+// @public
+export class JwksCache {
+    constructor(input: {
+        ttlMs: number;
+        logger: LoggerBase;
+    });
+    clear(): void;
+    getAuthorizationServer(issuer: string): Promise<oauth.AuthorizationServer>;
+}
 
 // @public
 export class Keychain {
@@ -689,6 +717,14 @@ export class MongoDBError<ErrorCode extends ErrorCodes = ErrorCodes> extends Err
     constructor(code: ErrorCode, message: string);
     // (undocumented)
     code: ErrorCode;
+}
+
+// @public (undocumented)
+export interface OAuthMiddlewareOptions {
+    audience: string;
+    issuer: string;
+    jwksCache: JwksCache;
+    logger: LoggerBase;
 }
 
 // @public (undocumented)
@@ -1132,6 +1168,9 @@ export const UserConfigSchema: z.ZodObject<{
     httpHost: z.ZodDefault<z.ZodString>;
     httpHeaders: z.ZodDefault<z.ZodObject<{}, z.core.$loose>>;
     httpBodyLimit: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
+    oauthIssuer: z.ZodOptional<z.ZodString>;
+    oauthAudience: z.ZodOptional<z.ZodString>;
+    oauthJwksCacheTtlMs: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
     idleTimeoutMs: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
     notificationTimeoutMs: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
     maxBytesPerQuery: z.ZodDefault<z.ZodCoercedNumber<unknown>>;

--- a/src/common/config/userConfig.ts
+++ b/src/common/config/userConfig.ts
@@ -153,6 +153,30 @@ const ServerConfigSchema = z.object({
             "Maximum size of the HTTP request body in bytes (only used when transport is 'http'). This value is passed as the optional limit parameter to the Express.js json() middleware."
         )
         .register(configRegistry, { overrideBehavior: "not-allowed" }),
+    oauthIssuer: z
+        .string()
+        .url()
+        .optional()
+        .describe(
+            "OAuth/OIDC issuer URL. When set, the HTTP transport requires Authorization: Bearer <jwt> on every request; the token must be issued by this issuer and have the configured oauthAudience claim. Required if httpHost is non-loopback."
+        )
+        .register(configRegistry, { overrideBehavior: "not-allowed" }),
+    oauthAudience: z
+        .string()
+        .optional()
+        .describe(
+            "Expected `aud` claim on incoming bearer tokens. Required when oauthIssuer is set. Tokens whose `aud` does not include this value are rejected with 401."
+        )
+        .register(configRegistry, { overrideBehavior: "not-allowed" }),
+    oauthJwksCacheTtlMs: z.coerce
+        .number()
+        .int()
+        .min(1_000, "Invalid oauthJwksCacheTtlMs: must be at least 1000")
+        .default(600_000)
+        .describe(
+            "How long (in ms) to cache the OIDC issuer's JWKS before re-fetching. Default 10 minutes. Lower values reduce key-rotation latency at the cost of more outbound requests to the issuer."
+        )
+        .register(configRegistry, { overrideBehavior: "not-allowed" }),
     idleTimeoutMs: z.coerce
         .number()
         .default(600_000)

--- a/src/common/logging/loggingDefinitions.ts
+++ b/src/common/logging/loggingDefinitions.ts
@@ -36,6 +36,13 @@ export const LogId = {
     toolDisabled: mongoLogId(1_003_003),
     toolMetadataChange: mongoLogId(1_003_004),
 
+    httpOAuthDisabled: mongoLogId(1_006_200),
+    httpOAuthEnabled: mongoLogId(1_006_201),
+    httpOAuthMissingToken: mongoLogId(1_006_202),
+    httpOAuthInvalidToken: mongoLogId(1_006_203),
+    httpOAuthJwksFetchFailure: mongoLogId(1_006_204),
+    httpOAuthDiscoveryFailure: mongoLogId(1_006_205),
+
     mongodbConnectFailure: mongoLogId(1_004_001),
     mongodbDisconnectFailure: mongoLogId(1_004_002),
     mongodbConnectTry: mongoLogId(1_004_003),

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -89,6 +89,13 @@ export { EventCache } from "./telemetry/eventCache.js";
 export { Keychain, registerGlobalSecretToRedact } from "./common/keychain.js";
 export type { Secret } from "./common/keychain.js";
 export { Elicitation } from "./elicitation.js";
+export {
+    JwksCache,
+    createOAuthMiddleware,
+    getAuthContext,
+    type AuthContext,
+    type OAuthMiddlewareOptions,
+} from "./transports/auth/index.js";
 export { applyConfigOverrides, ConfigOverrideError } from "./common/config/configOverrides.js";
 export {
     SessionStore,

--- a/src/transports/auth/index.ts
+++ b/src/transports/auth/index.ts
@@ -1,0 +1,7 @@
+export { JwksCache } from "./jwksCache.js";
+export {
+    createOAuthMiddleware,
+    getAuthContext,
+    type AuthContext,
+    type OAuthMiddlewareOptions,
+} from "./oauthMiddleware.js";

--- a/src/transports/auth/jwksCache.ts
+++ b/src/transports/auth/jwksCache.ts
@@ -1,0 +1,76 @@
+import { LRUCache } from "lru-cache";
+import * as oauth from "oauth4webapi";
+import { createFetch } from "@mongodb-js/devtools-proxy-support";
+import type { LoggerBase } from "../../common/logging/index.js";
+import { LogId } from "../../common/logging/index.js";
+
+/**
+ * A small wrapper around oauth4webapi's discovery + JWKS fetch that caches
+ * the resolved AuthorizationServer metadata for a configurable TTL.
+ *
+ * The OIDC discovery document and the JWKS itself rarely change between
+ * key-rotation events, so caching them per-issuer trades small amounts of
+ * staleness for a large reduction in outbound traffic and per-request
+ * latency on every authenticated MCP call.
+ *
+ * The cache key is the issuer URL. Failures are NOT cached; an issuer
+ * temporarily unreachable will be retried on the next request.
+ */
+export class JwksCache {
+    private readonly cache: LRUCache<string, oauth.AuthorizationServer>;
+    private readonly customFetch: typeof fetch;
+    private readonly logger: LoggerBase;
+
+    constructor({ ttlMs, logger }: { ttlMs: number; logger: LoggerBase }) {
+        this.cache = new LRUCache({ max: 8, ttl: ttlMs });
+        this.logger = logger;
+        this.customFetch = createFetch({ useEnvironmentVariableProxies: true }) as unknown as typeof fetch;
+    }
+
+    /**
+     * Resolve the AuthorizationServer metadata for the given issuer URL,
+     * fetching the discovery document on cache miss. Returned object is
+     * suitable for passing to oauth4webapi's verification helpers.
+     */
+    public async getAuthorizationServer(issuer: string): Promise<oauth.AuthorizationServer> {
+        const cached = this.cache.get(issuer);
+        if (cached) {
+            return cached;
+        }
+
+        const issuerUrl = new URL(issuer);
+        let response: Response;
+        try {
+            response = await oauth.discoveryRequest(issuerUrl, {
+                [oauth.customFetch]: this.customFetch,
+            });
+        } catch (cause) {
+            this.logger.error({
+                id: LogId.httpOAuthDiscoveryFailure,
+                context: "oauthMiddleware",
+                message: `Failed to fetch OIDC discovery document from ${issuer}: ${(cause as Error).message}`,
+            });
+            throw cause;
+        }
+
+        let server: oauth.AuthorizationServer;
+        try {
+            server = await oauth.processDiscoveryResponse(issuerUrl, response);
+        } catch (cause) {
+            this.logger.error({
+                id: LogId.httpOAuthDiscoveryFailure,
+                context: "oauthMiddleware",
+                message: `Invalid OIDC discovery document from ${issuer}: ${(cause as Error).message}`,
+            });
+            throw cause;
+        }
+
+        this.cache.set(issuer, server);
+        return server;
+    }
+
+    /** Clear all cached issuer metadata. Useful after key-rotation alarms. */
+    public clear(): void {
+        this.cache.clear();
+    }
+}

--- a/src/transports/auth/oauthMiddleware.ts
+++ b/src/transports/auth/oauthMiddleware.ts
@@ -1,0 +1,168 @@
+import type { NextFunction, Request, Response } from "express";
+import * as oauth from "oauth4webapi";
+import type { LoggerBase } from "../../common/logging/index.js";
+import { LogId } from "../../common/logging/index.js";
+import { JwksCache } from "./jwksCache.js";
+
+/**
+ * Authentication context attached to an Express request by the OAuth
+ * middleware. Tools and downstream middleware can read it via
+ * {@link getAuthContext} to find out who is making the call. The shape
+ * is intentionally narrow: we surface only the subject, audience,
+ * issuer, and granted scopes; the raw token is never exposed past the
+ * middleware so it cannot accidentally land in logs or telemetry.
+ */
+export interface AuthContext {
+    /** RFC 7519 `sub` claim — stable principal identifier from the IdP. */
+    sub: string;
+    /** Parsed RFC 8693 `scope` claim (space-delimited string → array). Accepts Azure-style `scp` array too. */
+    scopes: string[];
+    /** RFC 7519 `aud` claim, normalised to an array. */
+    audience: string[];
+    /** Issuer that minted the token. */
+    issuer: string;
+}
+
+/**
+ * Read the AuthContext attached by the middleware. Returns undefined
+ * when OAuth is disabled (loopback bind without `oauthIssuer`).
+ *
+ * Express's Request type is not globally augmented (that would require
+ * @types/express-serve-static-core, which this package does not ship
+ * as a direct dependency), so reads go through this typed accessor.
+ */
+export function getAuthContext(req: Request): AuthContext | undefined {
+    return (req as Request & { auth?: AuthContext }).auth;
+}
+
+export interface OAuthMiddlewareOptions {
+    /** Issuer URL — must exactly match the `iss` claim in incoming tokens. */
+    issuer: string;
+    /** Expected `aud` claim. Tokens whose `aud` does not include this are rejected. */
+    audience: string;
+    /** Shared JWKS / discovery cache. */
+    jwksCache: JwksCache;
+    /** Logger for audit + diagnostic events. */
+    logger: LoggerBase;
+}
+
+/**
+ * 401 helper that emits a spec-compliant `WWW-Authenticate: Bearer ...`
+ * header. The `error` and `error_description` parameters follow
+ * RFC 6750 §3 so well-behaved clients can react programmatically (and
+ * so security scanners can grade us correctly).
+ */
+function send401(
+    res: Response,
+    error: "invalid_request" | "invalid_token",
+    description: string,
+    issuer: string
+): void {
+    const params = [`realm="${issuer}"`, `error="${error}"`, `error_description="${description.replace(/"/g, "'")}"`];
+    res.setHeader("WWW-Authenticate", `Bearer ${params.join(", ")}`);
+    res.status(401).json({
+        jsonrpc: "2.0",
+        error: {
+            code: -32000,
+            message: description,
+        },
+    });
+}
+
+/**
+ * Build an Express middleware that requires a valid OAuth/OIDC bearer
+ * token on every request. Returns 401 with a proper `WWW-Authenticate`
+ * header on missing or invalid tokens.
+ *
+ * Token validation:
+ *   - signature against the issuer's JWKS (fetched via OIDC discovery,
+ *     cached by {@link JwksCache})
+ *   - `iss` claim equals the configured issuer
+ *   - `aud` claim contains the configured audience
+ *   - `exp` not in the past, `nbf` not in the future
+ *
+ * Per RFC 9068, the token's JOSE header must declare `typ: at+jwt`.
+ * Most modern enterprise IdPs (Azure AD v2, Auth0, Okta) issue this
+ * format; configure your IdP accordingly.
+ *
+ * No introspection (RFC 7662) is performed — we trust the issuer's
+ * signature and the token's own claims. Add introspection in a v2 if
+ * revocation-before-expiry is a requirement.
+ */
+export function createOAuthMiddleware({ issuer, audience, jwksCache, logger }: OAuthMiddlewareOptions) {
+    const issuerForReporting = issuer;
+    return async function oauthMiddleware(req: Request, res: Response, next: NextFunction): Promise<void> {
+        const header = req.headers.authorization;
+        if (!header || typeof header !== "string" || !header.toLowerCase().startsWith("bearer ")) {
+            logger.debug({
+                id: LogId.httpOAuthMissingToken,
+                context: "oauthMiddleware",
+                message: `Refused request to ${req.method} ${req.path}: missing or malformed Authorization header.`,
+                noRedaction: true,
+            });
+            send401(res, "invalid_request", "Authorization: Bearer <token> header is required.", issuerForReporting);
+            return;
+        }
+
+        let as: oauth.AuthorizationServer;
+        try {
+            as = await jwksCache.getAuthorizationServer(issuer);
+        } catch (cause) {
+            // Discovery failure was already logged at error level inside
+            // the cache. Surface 503 because the *server* couldn't reach
+            // the issuer — this is not a client error and clients should
+            // retry.
+            res.status(503).json({
+                jsonrpc: "2.0",
+                error: {
+                    code: -32001,
+                    message: `OAuth issuer ${issuerForReporting} is unreachable: ${(cause as Error).message}`,
+                },
+            });
+            return;
+        }
+
+        // oauth4webapi.validateJwtAccessToken takes a Request object so it
+        // can inspect the Authorization header itself. Construct a
+        // minimal Request wrapping just the header to avoid forwarding
+        // the full Express body.
+        const proxyRequest = new Request("https://internal.invalid/", {
+            headers: { authorization: header },
+        });
+
+        let claims: oauth.JWTAccessTokenClaims;
+        try {
+            claims = await oauth.validateJwtAccessToken(as, proxyRequest, audience);
+        } catch (cause) {
+            logger.warning({
+                id: LogId.httpOAuthInvalidToken,
+                context: "oauthMiddleware",
+                message: `Rejected bearer token: ${(cause as Error).message}`,
+                noRedaction: true,
+            });
+            send401(res, "invalid_token", (cause as Error).message, issuerForReporting);
+            return;
+        }
+
+        // RFC 8693 `scope` claim is a space-delimited string. Some IdPs
+        // (Azure AD) use the `scp` array form; accept both.
+        const rawScopes = (claims as Record<string, unknown>).scope ?? (claims as Record<string, unknown>).scp ?? "";
+        const scopes = Array.isArray(rawScopes)
+            ? rawScopes.filter((s): s is string => typeof s === "string")
+            : typeof rawScopes === "string"
+              ? rawScopes.split(/\s+/).filter(Boolean)
+              : [];
+
+        const audClaim = claims.aud;
+        const audArray = Array.isArray(audClaim) ? audClaim : [audClaim];
+
+        (req as Request & { auth?: AuthContext }).auth = {
+            sub: claims.sub,
+            scopes,
+            audience: audArray,
+            issuer: claims.iss,
+        };
+
+        next();
+    };
+}

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -22,6 +22,7 @@ import {
     JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION,
     JSON_RPC_ERROR_CODE_PROCESSING_REQUEST_FAILED,
 } from "./jsonRpcErrorCodes.js";
+import { createOAuthMiddleware, JwksCache } from "./auth/index.js";
 
 export type MCPHttpServerConstructorArgs<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = {
     userConfig: TUserConfig;
@@ -305,6 +306,41 @@ export class MCPHttpServer<
 
     protected setupMiddlewares(): void {
         this.app.use(express.json({ limit: this.userConfig.httpBodyLimit }));
+
+        // OAuth/OIDC bearer-token authentication. Mounted before any
+        // MCP-routing middleware so unauthenticated requests cannot reach
+        // session state. Active when oauthIssuer is configured; when it
+        // isn't, the server only accepts traffic on loopback (enforced
+        // at startup by StreamableHttpRunner.validateConfig).
+        if (this.userConfig.oauthIssuer && this.userConfig.oauthAudience) {
+            const jwksCache = new JwksCache({
+                ttlMs: this.userConfig.oauthJwksCacheTtlMs,
+                logger: this.logger,
+            });
+            this.app.use(
+                createOAuthMiddleware({
+                    issuer: this.userConfig.oauthIssuer,
+                    audience: this.userConfig.oauthAudience,
+                    jwksCache,
+                    logger: this.logger,
+                })
+            );
+            this.logger.info({
+                id: LogId.httpOAuthEnabled,
+                context: "mcpHttpServer",
+                message: `OAuth bearer-token authentication enabled (issuer=${this.userConfig.oauthIssuer}, audience=${this.userConfig.oauthAudience}).`,
+                noRedaction: true,
+            });
+        } else {
+            this.logger.info({
+                id: LogId.httpOAuthDisabled,
+                context: "mcpHttpServer",
+                message:
+                    "OAuth bearer-token authentication is NOT enabled. The HTTP transport accepts unauthenticated connections; this is only safe on a loopback bind.",
+                noRedaction: true,
+            });
+        }
+
         this.app.use((req, res, next) => {
             for (const [key, value] of Object.entries(this.userConfig.httpHeaders)) {
                 const header = req.headers[key.toLowerCase()];

--- a/src/transports/streamableHttp.ts
+++ b/src/transports/streamableHttp.ts
@@ -240,12 +240,36 @@ export class StreamableHttpRunner<
         }
 
         if (this.shouldWarnAboutHttpHost(this.userConfig.httpHost)) {
+            if (!this.userConfig.oauthIssuer || !this.userConfig.oauthAudience) {
+                // OWASP MCP07: a non-loopback bind without authentication is
+                // an open back door into the MCP server (and through it,
+                // the configured MongoDB cluster). Refuse to start rather
+                // than log a warning and continue.
+                throw new Error(
+                    `Refusing to start: httpHost=${this.userConfig.httpHost} is non-loopback and OAuth authentication is not configured. ` +
+                        `Set oauthIssuer + oauthAudience (and configure your OIDC provider) to enable bearer-token auth, ` +
+                        `or bind to 127.0.0.1 / localhost / ::1 for local-only access.`
+                );
+            }
+
             this.logger.warning({
                 id: LogId.streamableHttpTransportHttpHostWarning,
                 context: "streamableHttpTransport",
-                message: `Binding to ${this.userConfig.httpHost} can expose the MCP Server to the entire local network, which allows other devices on the same network to potentially access the MCP Server. This is a security risk and could allow unauthorized access to your database context.`,
+                message: `Binding to ${this.userConfig.httpHost}. OAuth bearer-token authentication is enabled (issuer=${this.userConfig.oauthIssuer}).`,
                 noRedaction: true,
             });
+        }
+
+        // Config-shape rule: oauthIssuer and oauthAudience must be set
+        // together. Specifying one without the other is almost certainly
+        // a misconfiguration; fail loudly instead of silently disabling
+        // auth.
+        if (Boolean(this.userConfig.oauthIssuer) !== Boolean(this.userConfig.oauthAudience)) {
+            throw new Error(
+                "oauthIssuer and oauthAudience must be configured together. " +
+                    `Got oauthIssuer=${this.userConfig.oauthIssuer ?? "<unset>"}, ` +
+                    `oauthAudience=${this.userConfig.oauthAudience ?? "<unset>"}.`
+            );
         }
     }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -36,6 +36,13 @@ export type {
     ConnectionErrorHandlerContext,
 } from "./common/connectionErrorHandler.js";
 export { Elicitation, type ElicitedInputResult } from "./elicitation.js";
+export {
+    JwksCache,
+    createOAuthMiddleware,
+    getAuthContext,
+    type AuthContext,
+    type OAuthMiddlewareOptions,
+} from "./transports/auth/index.js";
 export type {
     ConnectionStateConnecting,
     ConnectionSettings,

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -46,6 +46,8 @@ const expectedDefaults = {
     notificationTimeoutMs: 9 * 60 * 1000, // 9 minutes
     httpHeaders: {},
     httpBodyLimit: TRANSPORT_PAYLOAD_LIMITS.http,
+    oauthJwksCacheTtlMs: 10 * 60 * 1000, // 10 minutes
+
     maxDocumentsPerQuery: 100,
     maxBytesPerQuery: 16 * 1024 * 1024, // ~16 mb
     atlasTemporaryDatabaseUserLifetimeMs: 4 * 60 * 60 * 1000, // 4 hours

--- a/tests/unit/transports/auth/jwksCache.test.ts
+++ b/tests/unit/transports/auth/jwksCache.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { JwksCache } from "../../../../src/transports/auth/jwksCache.js";
+import type { LoggerBase } from "../../../../src/common/logging/index.js";
+
+// Mock oauth4webapi so we control the discovery response without doing
+// real network I/O. Each test below shapes the mock for the scenario
+// it cares about (success / failed network / malformed response).
+vi.mock("oauth4webapi", async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>;
+    return {
+        ...actual,
+        discoveryRequest: vi.fn(),
+        processDiscoveryResponse: vi.fn(),
+    };
+});
+
+vi.mock("@mongodb-js/devtools-proxy-support", () => ({
+    createFetch: vi.fn(() => globalThis.fetch),
+}));
+
+import * as oauth from "oauth4webapi";
+
+const discoveryRequest = oauth.discoveryRequest as unknown as ReturnType<typeof vi.fn>;
+const processDiscoveryResponse = oauth.processDiscoveryResponse as unknown as ReturnType<typeof vi.fn>;
+
+const ISSUER = "https://issuer.example.com";
+
+describe("JwksCache", () => {
+    let logger: LoggerBase;
+
+    beforeEach(() => {
+        discoveryRequest.mockReset();
+        processDiscoveryResponse.mockReset();
+        logger = {
+            info: vi.fn(),
+            debug: vi.fn(),
+            warning: vi.fn(),
+            error: vi.fn(),
+        } as unknown as LoggerBase;
+    });
+
+    it("fetches the discovery document on cache miss", async () => {
+        const cache = new JwksCache({ ttlMs: 60_000, logger });
+        const fakeResponse = new Response("{}");
+        discoveryRequest.mockResolvedValueOnce(fakeResponse);
+        processDiscoveryResponse.mockResolvedValueOnce({ issuer: ISSUER });
+
+        const result = await cache.getAuthorizationServer(ISSUER);
+
+        expect(result).toEqual({ issuer: ISSUER });
+        expect(discoveryRequest).toHaveBeenCalledTimes(1);
+        expect(processDiscoveryResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns the cached value on subsequent calls (single fetch)", async () => {
+        const cache = new JwksCache({ ttlMs: 60_000, logger });
+        discoveryRequest.mockResolvedValue(new Response("{}"));
+        processDiscoveryResponse.mockResolvedValue({ issuer: ISSUER });
+
+        await cache.getAuthorizationServer(ISSUER);
+        await cache.getAuthorizationServer(ISSUER);
+        await cache.getAuthorizationServer(ISSUER);
+
+        // Three calls, exactly one network fetch.
+        expect(discoveryRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not cache failures - the next call retries the network", async () => {
+        const cache = new JwksCache({ ttlMs: 60_000, logger });
+        discoveryRequest.mockRejectedValueOnce(new Error("ECONNREFUSED")).mockResolvedValueOnce(new Response("{}"));
+        processDiscoveryResponse.mockResolvedValueOnce({ issuer: ISSUER });
+
+        await expect(cache.getAuthorizationServer(ISSUER)).rejects.toThrow("ECONNREFUSED");
+        await expect(cache.getAuthorizationServer(ISSUER)).resolves.toEqual({ issuer: ISSUER });
+        expect(discoveryRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it("logs an error when discovery fails", async () => {
+        const cache = new JwksCache({ ttlMs: 60_000, logger });
+        discoveryRequest.mockRejectedValueOnce(new Error("DNS failure"));
+
+        await expect(cache.getAuthorizationServer(ISSUER)).rejects.toThrow("DNS failure");
+        expect(logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining("DNS failure") as unknown,
+            })
+        );
+    });
+
+    it("logs an error when discovery returns an invalid response", async () => {
+        const cache = new JwksCache({ ttlMs: 60_000, logger });
+        discoveryRequest.mockResolvedValueOnce(new Response("not json"));
+        processDiscoveryResponse.mockRejectedValueOnce(new Error("not a valid OIDC discovery doc"));
+
+        await expect(cache.getAuthorizationServer(ISSUER)).rejects.toThrow("not a valid OIDC discovery doc");
+        expect(logger.error).toHaveBeenCalled();
+    });
+
+    it("clear() evicts cached entries", async () => {
+        const cache = new JwksCache({ ttlMs: 60_000, logger });
+        discoveryRequest.mockResolvedValue(new Response("{}"));
+        processDiscoveryResponse.mockResolvedValue({ issuer: ISSUER });
+
+        await cache.getAuthorizationServer(ISSUER);
+        cache.clear();
+        await cache.getAuthorizationServer(ISSUER);
+
+        expect(discoveryRequest).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tests/unit/transports/auth/oauthMiddleware.test.ts
+++ b/tests/unit/transports/auth/oauthMiddleware.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextFunction, Request, Response } from "express";
+import type { JwksCache } from "../../../../src/transports/auth/jwksCache.js";
+import { createOAuthMiddleware, getAuthContext } from "../../../../src/transports/auth/oauthMiddleware.js";
+
+// Mock oauth4webapi so the middleware can be unit-tested without real
+// JWTs, real JWKS, or real network access. Each test below drives the
+// mock to the outcome it wants to verify (signature OK, signature bad,
+// etc.).
+vi.mock("oauth4webapi", async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>;
+    return {
+        ...actual,
+        validateJwtAccessToken: vi.fn(),
+    };
+});
+
+import * as oauth from "oauth4webapi";
+
+const validateJwt = oauth.validateJwtAccessToken as unknown as ReturnType<typeof vi.fn>;
+
+const ISSUER = "https://issuer.example.com";
+const AUDIENCE = "mcp-test-audience";
+
+function buildReqRes(authHeader?: string): {
+    req: Request;
+    res: Response;
+    next: ReturnType<typeof vi.fn>;
+    setHeaderSpy: ReturnType<typeof vi.fn>;
+    statusSpy: ReturnType<typeof vi.fn>;
+    jsonSpy: ReturnType<typeof vi.fn>;
+} {
+    const setHeaderSpy = vi.fn();
+    const statusSpy = vi.fn();
+    const jsonSpy = vi.fn();
+    statusSpy.mockReturnValue({ json: jsonSpy });
+
+    const req = {
+        method: "POST",
+        path: "/mcp",
+        headers: authHeader ? { authorization: authHeader } : {},
+    } as unknown as Request;
+
+    const res = {
+        setHeader: setHeaderSpy,
+        status: statusSpy,
+    } as unknown as Response;
+
+    const next = vi.fn();
+    return { req, res, next, setHeaderSpy, statusSpy, jsonSpy };
+}
+
+function buildMiddleware(jwksCacheBehavior: "ok" | "throw" = "ok"): ReturnType<typeof createOAuthMiddleware> {
+    const fakeJwksCache: JwksCache = {
+        getAuthorizationServer:
+            jwksCacheBehavior === "ok"
+                ? vi.fn().mockResolvedValue({ issuer: ISSUER })
+                : vi.fn().mockRejectedValue(new Error("issuer unreachable")),
+        clear: vi.fn(),
+    } as unknown as JwksCache;
+
+    const logger = {
+        info: vi.fn(),
+        debug: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+    } as unknown as Parameters<typeof createOAuthMiddleware>[0]["logger"];
+
+    return createOAuthMiddleware({
+        issuer: ISSUER,
+        audience: AUDIENCE,
+        jwksCache: fakeJwksCache,
+        logger,
+    });
+}
+
+describe("createOAuthMiddleware", () => {
+    beforeEach(() => {
+        validateJwt.mockReset();
+    });
+
+    it("returns 401 with WWW-Authenticate when Authorization header is missing", async () => {
+        const { req, res, next, setHeaderSpy, statusSpy, jsonSpy } = buildReqRes();
+        const mw = buildMiddleware("ok");
+
+        await mw(req, res, next as unknown as NextFunction);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(statusSpy).toHaveBeenCalledWith(401);
+        expect(setHeaderSpy).toHaveBeenCalledWith(
+            "WWW-Authenticate",
+            expect.stringMatching(/^Bearer .*realm="https:\/\/issuer\.example\.com".*error="invalid_request"/)
+        );
+        expect(jsonSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ error: expect.objectContaining({ code: -32000 }) as unknown })
+        );
+    });
+
+    it("returns 401 when Authorization header is not a Bearer scheme", async () => {
+        const { req, res, next, statusSpy, setHeaderSpy } = buildReqRes("Basic Zm9vOmJhcg==");
+        const mw = buildMiddleware("ok");
+
+        await mw(req, res, next as unknown as NextFunction);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(statusSpy).toHaveBeenCalledWith(401);
+        expect(setHeaderSpy).toHaveBeenCalledWith(
+            "WWW-Authenticate",
+            expect.stringContaining('error="invalid_request"')
+        );
+    });
+
+    it("returns 503 when the JWKS cache cannot reach the issuer", async () => {
+        const { req, res, next, statusSpy, jsonSpy } = buildReqRes("Bearer dummy.token.here");
+        const mw = buildMiddleware("throw");
+
+        await mw(req, res, next as unknown as NextFunction);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(statusSpy).toHaveBeenCalledWith(503);
+        expect(jsonSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                error: expect.objectContaining({
+                    code: -32001,
+                    message: expect.stringContaining("issuer unreachable") as unknown,
+                }) as unknown,
+            })
+        );
+    });
+
+    it("returns 401 with invalid_token when oauth4webapi rejects the token", async () => {
+        const { req, res, next, statusSpy, setHeaderSpy, jsonSpy } = buildReqRes("Bearer expired.token.here");
+        const mw = buildMiddleware("ok");
+        validateJwt.mockRejectedValueOnce(new Error("token has expired"));
+
+        await mw(req, res, next as unknown as NextFunction);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(statusSpy).toHaveBeenCalledWith(401);
+        expect(setHeaderSpy).toHaveBeenCalledWith(
+            "WWW-Authenticate",
+            expect.stringContaining('error="invalid_token"')
+        );
+        expect(jsonSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                error: expect.objectContaining({ message: "token has expired" }) as unknown,
+            })
+        );
+    });
+
+    it("calls next() and sets req.auth on success (RFC 8693 `scope` claim)", async () => {
+        const { req, res, next } = buildReqRes("Bearer valid.token.here");
+        const mw = buildMiddleware("ok");
+        validateJwt.mockResolvedValueOnce({
+            sub: "alice@example.com",
+            iss: ISSUER,
+            aud: AUDIENCE,
+            scope: "mcp:read mcp:metadata",
+        });
+
+        await mw(req, res, next as unknown as NextFunction);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(getAuthContext(req)).toEqual({
+            sub: "alice@example.com",
+            issuer: ISSUER,
+            audience: [AUDIENCE],
+            scopes: ["mcp:read", "mcp:metadata"],
+        });
+    });
+
+    it("accepts Azure-style `scp` array scope claim", async () => {
+        const { req, res, next } = buildReqRes("Bearer azure.token.here");
+        const mw = buildMiddleware("ok");
+        validateJwt.mockResolvedValueOnce({
+            sub: "svc-account-1",
+            iss: ISSUER,
+            aud: [AUDIENCE, "other-aud"],
+            scp: ["mcp:read", "mcp:create"],
+        });
+
+        await mw(req, res, next as unknown as NextFunction);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(getAuthContext(req)?.scopes).toEqual(["mcp:read", "mcp:create"]);
+        expect(getAuthContext(req)?.audience).toEqual([AUDIENCE, "other-aud"]);
+    });
+
+    it("defaults scopes to [] when neither scope nor scp is present", async () => {
+        const { req, res, next } = buildReqRes("Bearer scopeless.token");
+        const mw = buildMiddleware("ok");
+        validateJwt.mockResolvedValueOnce({
+            sub: "u",
+            iss: ISSUER,
+            aud: AUDIENCE,
+        });
+
+        await mw(req, res, next as unknown as NextFunction);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(getAuthContext(req)?.scopes).toEqual([]);
+    });
+});

--- a/tests/unit/transports/streamableHttp.test.ts
+++ b/tests/unit/transports/streamableHttp.test.ts
@@ -265,6 +265,59 @@ function getSessionStore(runner: StreamableHttpRunner<any>): ISessionStore<Strea
         .sessionStore;
 }
 
+// OAuth + non-loopback bind config validation. The runner runs the
+// check inside start(); validation failures throw before any socket
+// is opened so each test is cheap.
+describe("StreamableHttpRunner: OAuth config validation", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let runner: StreamableHttpRunner<any> | undefined;
+
+    afterEach(async () => {
+        await runner?.close();
+        runner = undefined;
+    });
+
+    it("refuses to start on non-loopback httpHost when oauthIssuer is not set", async () => {
+        runner = new StreamableHttpRunner({
+            userConfig: { ...defaultTestConfig, httpHost: "0.0.0.0", httpPort: 0 },
+        });
+        await expect(runner.start()).rejects.toThrow(
+            /Refusing to start.*non-loopback.*OAuth authentication is not configured/
+        );
+    });
+
+    it("refuses to start when oauthIssuer is set but oauthAudience is missing", async () => {
+        runner = new StreamableHttpRunner({
+            userConfig: {
+                ...defaultTestConfig,
+                httpHost: "127.0.0.1",
+                httpPort: 0,
+                oauthIssuer: "https://issuer.example.com",
+            },
+        });
+        await expect(runner.start()).rejects.toThrow(/oauthIssuer and oauthAudience must be configured together/);
+    });
+
+    it("refuses to start when oauthAudience is set but oauthIssuer is missing", async () => {
+        runner = new StreamableHttpRunner({
+            userConfig: {
+                ...defaultTestConfig,
+                httpHost: "127.0.0.1",
+                httpPort: 0,
+                oauthAudience: "mcp-test",
+            },
+        });
+        await expect(runner.start()).rejects.toThrow(/oauthIssuer and oauthAudience must be configured together/);
+    });
+
+    it("permits loopback bind without OAuth (default test config)", async () => {
+        runner = new StreamableHttpRunner({
+            userConfig: { ...defaultTestConfig, httpHost: "127.0.0.1", httpPort: 0 },
+        });
+        await expect(runner.start()).resolves.toBeUndefined();
+    });
+});
+
 class CustomMonitoringServer extends MonitoringServer {
     constructor(args: MonitoringServerConstructorArgs<DefaultMetrics>) {
         super(args);


### PR DESCRIPTION
Per OWASP MCP Top 10 (2025) item MCP07 - Insufficient Authentication & Authorization. The HTTP transport now refuses to serve any request without a valid OAuth/OIDC bearer token when `oauthIssuer` is configured, and refuses to start at all when bound to a non-loopback host without authentication.

This closes the "open HTTP backdoor" gap: previously, running `mongodb-mcp-server --transport http --httpHost 0.0.0.0` exposed every configured MongoDB tool to anyone who could reach the port. Now such deployments must (a) bind only to loopback, or (b) configure an OIDC issuer whose bearer tokens are validated on every request. Loopback dev workflows are unaffected.

Scope (intentional v1):
- AuthN only. Per-tool scope mapping (e.g. mcp:read scope required for read tools) is conceptually separate and tracked as a follow-up; the middleware exposes the parsed `scope`/`scp` claim on the auth context so a v2 can add scope checks without restructuring.
- Bearer-token validation only. RFC 7662 introspection (which would give revoke-before-expiry) is not implemented; we trust signature + exp + iss + aud.

New module: src/transports/auth/jwksCache.ts
    LRUCache-backed wrapper around oauth4webapi's discovery + JWKS fetch. Caches AuthorizationServer metadata per issuer for a configurable TTL (default 10 minutes); failures are NOT cached so transient issuer unavailability self-heals.

  oauthMiddleware.ts
    Express middleware. Validates `Authorization: Bearer <jwt>` via oauth4webapi.validateJwtAccessToken (RFC 9068). Verifies signature against the issuer's JWKS, checks `iss`/`aud`/`exp`/`nbf`. On failure returns 401 with a spec-compliant `WWW-Authenticate: Bearer realm=... error=...` header. On success sets a typed AuthContext ({ sub, scopes, audience, issuer }) on the request, accessible via the exported getAuthContext() helper. Accepts both RFC 8693 `scope` (space-delimited string) and Azure-style `scp` (array). The raw token is never stored past the middleware to keep it out of logs/telemetry.

  index.ts
    Public surface: JwksCache, createOAuthMiddleware, getAuthContext, AuthContext, OAuthMiddlewareOptions. Re-exported from both `mongodb-mcp-server` (lib.ts) and `mongodb-mcp-server/web` (web.ts) so embedders building custom HTTP servers can layer auth on top.

New config fields (userConfig.ts):
- oauthIssuer       OIDC issuer URL. Validated as a URL at parse time.
- oauthAudience     Expected `aud` claim. Required when oauthIssuer
                    is set; mismatched pairs fail at startup with a
                    clear error.
- oauthJwksCacheTtlMs   How long to cache the issuer's metadata.
                    Default 600_000 (10 minutes); minimum 1_000.

All three are `overrideBehavior: "not-allowed"` so per-session overrides cannot disable auth.

Wiring:
- MCPHttpServer.setupMiddlewares mounts createOAuthMiddleware before any MCP-routing middleware when oauthIssuer + oauthAudience are set, so unauthenticated requests cannot reach session state. Mounts the shared JwksCache so all requests share one cache.
- StreamableHttpRunner.validateConfig refuses to start in two cases: (a) httpHost is non-loopback AND oauthIssuer/oauthAudience are not set together  -> "Refusing to start: ... non-loopback ... OAuth authentication is not configured" (b) exactly one of oauthIssuer / oauthAudience is set  -> "must be configured together". Misconfigured pairs are almost always a mistake; fail loudly.

LogIds (1_006_200 - 1_006_205):
- httpOAuthDisabled / httpOAuthEnabled  (startup audit)
- httpOAuthMissingToken                 (debug; 401)
- httpOAuthInvalidToken                 (warning; 401 with token error)
- httpOAuthJwksFetchFailure             (error)
- httpOAuthDiscoveryFailure             (error)

Tests:
- 7 unit tests for createOAuthMiddleware: missing/non-Bearer header -> 401 invalid_request, issuer unreachable -> 503, oauth4webapi rejection -> 401 invalid_token, RFC 8693 / Azure / missing scope claim shapes, audience normalisation.
- 6 unit tests for JwksCache: cache hit, cache miss + fetch, failure non-caching, error logging paths, clear().
- 4 unit tests for StreamableHttpRunner.validateConfig: refuses on non-loopback without OAuth, refuses on half-configured OAuth pair (issuer-only and audience-only), accepts loopback without OAuth.
- tests/unit/common/config.test.ts expectedDefaults includes the new oauthJwksCacheTtlMs default.

api-extractor reports regenerated.

BREAKING CHANGE: HTTP transport deployments that bind to a non-loopback interface (httpHost != "127.0.0.1"/"localhost"/"::1") now require OAuth configuration (oauthIssuer + oauthAudience) and the server refuses to start without it. Deployments bound to loopback are unaffected.

## Proposed changes

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
