### PR TITLE
refactor: introduce CompositeKeychain and deprecate Keychain.root (OWASP MCP10)

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -240,6 +240,17 @@ export type CommonProperties = {
     has_docker?: TelemetryBoolSet;
 } & CommonStaticProperties;
 
+// @public
+export class CompositeKeychain extends Keychain {
+    constructor(delegates: readonly Keychain[]);
+    // (undocumented)
+    get allSecrets(): Secret[];
+    // (undocumented)
+    clearAllSecrets(): void;
+    // (undocumented)
+    register(value: Secret["value"], kind: Secret["kind"]): void;
+}
+
 // @public (undocumented)
 export class CompositeLogger extends LoggerBase {
     constructor(...loggers: LoggerBase[]);
@@ -627,14 +638,13 @@ export const JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND = -32003;
 
 // @public
 export class Keychain {
-    constructor();
     // (undocumented)
     get allSecrets(): Secret[];
     // (undocumented)
     clearAllSecrets(): void;
     // (undocumented)
     register(value: Secret["value"], kind: Secret["kind"]): void;
-    // (undocumented)
+    // @deprecated (undocumented)
     static get root(): Keychain;
 }
 
@@ -807,13 +817,14 @@ export function parseUserConfig(input: {
     warnings: string[];
     parsed: UserConfig | undefined;
     error: string | undefined;
+    secrets: Keychain;
 };
 
 export { PrometheusMetrics }
 
 export { PrometheusMetricsOptions }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function registerGlobalSecretToRedact(value: Secret["value"], kind: Secret["kind"]): void;
 
 export { Registry }

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -614,14 +614,13 @@ export const jsonExportFormat: z.ZodEnum<{
 
 // @public
 export class Keychain {
-    constructor();
     // (undocumented)
     get allSecrets(): Secret[];
     // (undocumented)
     clearAllSecrets(): void;
     // (undocumented)
     register(value: Secret["value"], kind: Secret["kind"]): void;
-    // (undocumented)
+    // @deprecated (undocumented)
     static get root(): Keychain;
 }
 

--- a/src/common/config/parseUserConfig.ts
+++ b/src/common/config/parseUserConfig.ts
@@ -41,7 +41,24 @@ export function parseUserConfig({
     warnings: string[];
     parsed: UserConfig | undefined;
     error: string | undefined;
+    /**
+     * Fresh keychain populated with every secret discovered in the
+     * parsed config (Atlas credentials, connection string, TLS file
+     * paths, etc.). The caller owns this keychain and is responsible
+     * for passing it into loggers / sessions so log redaction works.
+     * Always returned — empty when parsing failed — so callers can
+     * write a uniform branch.
+     *
+     * During the transition away from the deprecated `Keychain.root`
+     * static, every secret registered here is ALSO registered into
+     * `Keychain.root` for one release so downstream code that still
+     * reads from the global keeps working. New code should consume
+     * `secrets` directly.
+     */
+    secrets: Keychain;
 } {
+    const secrets = new Keychain();
+
     const schema = overrides
         ? z.object({
               ...UserConfigSchema.shape,
@@ -52,7 +69,7 @@ export function parseUserConfig({
     const { error: parseError, warnings, parsed } = parseUserConfigSources({ args, schema, parserOptions });
 
     if (parseError) {
-        return { error: parseError, warnings, parsed: undefined };
+        return { error: parseError, warnings, parsed: undefined, secrets };
     }
 
     if (parsed.nodb) {
@@ -60,6 +77,7 @@ export function parseUserConfig({
             error: "Error: The --nodb argument is not supported in the MCP Server. Please remove it from your configuration.",
             warnings,
             parsed: undefined,
+            secrets,
         };
     }
 
@@ -81,17 +99,24 @@ export function parseUserConfig({
             error: `Invalid configuration for the following fields:\n${error.issues.map((issue) => `${issue.path.join(".")} - ${issue.message}`).join("\n")}`,
             warnings,
             parsed: undefined,
+            secrets,
         };
     }
 
     // TODO: Separate correctly parsed user config from all other valid
     // arguments relevant to mongosh's args-parser.
     const userConfig: UserConfig = { ...parsed, ...configParseResult.data };
-    registerKnownSecretsInRootKeychain(userConfig);
+
+    // Register into both the new caller-owned keychain AND the deprecated
+    // process-wide Keychain.root for one release of backward compat.
+    registerKnownSecrets(secrets, userConfig);
+    registerKnownSecrets(Keychain.root, userConfig);
+
     return {
         parsed: userConfig,
         warnings,
         error: undefined,
+        secrets,
     };
 }
 
@@ -154,9 +179,7 @@ function parseUserConfigSources<T extends typeof UserConfigSchema>({
     };
 }
 
-function registerKnownSecretsInRootKeychain(userConfig: Partial<UserConfig>): void {
-    const keychain = Keychain.root;
-
+function registerKnownSecrets(keychain: Keychain, userConfig: Partial<UserConfig>): void {
     const maybeRegister = (value: string | undefined, kind: Secret["kind"]): void => {
         if (value) {
             keychain.register(value, kind);

--- a/src/common/keychain.ts
+++ b/src/common/keychain.ts
@@ -2,24 +2,28 @@ import type { Secret } from "mongodb-redact";
 export type { Secret } from "mongodb-redact";
 
 /**
- * This class holds the secrets of a single server. Ideally, we might want to have a keychain
- * per session, but right now the loggers are set up by server and are not aware of the concept
- * of session and this would require a bigger refactor.
- *
- * Whenever we identify or create a secret (for example, Atlas login, CLI arguments...) we
- * should register them in the root Keychain (`Keychain.root.register`) or preferably
- * on the session keychain if available `this.session.keychain`.
- **/
+ * Per-owner secret store. A Keychain holds secret values that should
+ * be redacted from log output by `mongodb-redact`. Most code paths
+ * should accept a `Keychain` (or {@link CompositeKeychain}) by
+ * reference at construction time, not reach for the deprecated
+ * `Keychain.root` static.
+ */
 export class Keychain {
-    private secrets: Secret[];
-    private static rootKeychain: Keychain = new Keychain();
+    private secrets: Secret[] = [];
 
-    constructor() {
-        this.secrets = [];
-    }
-
+    /**
+     * @deprecated Will be removed in a future release. The process-wide
+     * `Keychain.root` is retained only as a backward-compat shim for
+     * code that hasn't yet been converted to receive a keychain by
+     * dependency injection — it writes to the same module-local
+     * fallback keychain that `registerGlobalSecretToRedact` writes to.
+     * New code should accept a Keychain in its constructor / options,
+     * register session-scoped secrets via `session.keychain.register`,
+     * and read parser-discovered secrets from the `secrets` field of
+     * `parseUserConfig`'s return value.
+     */
     static get root(): Keychain {
-        return Keychain.rootKeychain;
+        return defaultBootstrapKeychain;
     }
 
     register(value: Secret["value"], kind: Secret["kind"]): void {
@@ -35,6 +39,69 @@ export class Keychain {
     }
 }
 
+/**
+ * Module-local fallback keychain backing the deprecated
+ * `Keychain.root` / `registerGlobalSecretToRedact` API surface.
+ *
+ * This is intentionally *not* exported and *not* a static on the
+ * class: keeping it module-local makes it clear to readers that this
+ * is a transitional shim, not the long-term contract. New code
+ * should construct its own `Keychain` and pass it through.
+ */
+const defaultBootstrapKeychain = new Keychain();
+
+/**
+ * @deprecated Will be removed in a future release. Construct a
+ * Keychain in the caller's scope and pass it to whatever needs to
+ * register or read secrets. This helper writes to a module-local
+ * fallback keychain that `Keychain.root` also exposes.
+ */
 export function registerGlobalSecretToRedact(value: Secret["value"], kind: Secret["kind"]): void {
-    Keychain.root.register(value, kind);
+    defaultBootstrapKeychain.register(value, kind);
+}
+
+/**
+ * Read-through union of several keychains.
+ *
+ * Used when one logger needs to redact secrets from multiple
+ * ownership scopes at once — typically a bootstrap keychain
+ * (containing process-level config secrets like the Atlas API client
+ * secret) composed with a per-session keychain (containing anything
+ * the session registered at runtime). The composite exposes the same
+ * `Keychain` contract so loggers don't need to know they're holding a
+ * composite vs a single scope.
+ *
+ * `register` always lands in the FIRST delegate; the rest are
+ * read-only from the composite's perspective. This keeps ownership
+ * unambiguous: each composite has exactly one "writable" backing
+ * keychain, and the others are sources of pre-registered secrets.
+ */
+export class CompositeKeychain extends Keychain {
+    private readonly delegates: readonly Keychain[];
+
+    constructor(delegates: readonly Keychain[]) {
+        super();
+        if (delegates.length === 0) {
+            throw new Error("CompositeKeychain requires at least one delegate keychain.");
+        }
+        this.delegates = delegates;
+    }
+
+    override register(value: Secret["value"], kind: Secret["kind"]): void {
+        this.delegates[0]!.register(value, kind);
+    }
+
+    override clearAllSecrets(): void {
+        for (const delegate of this.delegates) {
+            delegate.clearAllSecrets();
+        }
+    }
+
+    override get allSecrets(): Secret[] {
+        const result: Secret[] = [];
+        for (const delegate of this.delegates) {
+            result.push(...delegate.allSecrets);
+        }
+        return result;
+    }
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -86,7 +86,7 @@ export { Telemetry } from "./telemetry/telemetry.js";
 export { type TelemetryEvent, type CommonProperties, type BaseEvent } from "./telemetry/types.js";
 export type { TelemetryEvents, TelemetryConfig } from "./telemetry/telemetry.js";
 export { EventCache } from "./telemetry/eventCache.js";
-export { Keychain, registerGlobalSecretToRedact } from "./common/keychain.js";
+export { Keychain, CompositeKeychain, registerGlobalSecretToRedact } from "./common/keychain.js";
 export type { Secret } from "./common/keychain.js";
 export { Elicitation } from "./elicitation.js";
 export { applyConfigOverrides, ConfigOverrideError } from "./common/config/configOverrides.js";

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -69,22 +69,26 @@ describe("config", () => {
     });
 
     it("should generate defaults when no config sources are populated", () => {
-        expect(parseUserConfig({ args: [] })).toStrictEqual({
+        const { secrets, ...rest } = parseUserConfig({ args: [] });
+        expect(rest).toStrictEqual({
             parsed: expectedDefaults,
             warnings: [],
             error: undefined,
         });
+        // parseUserConfig now also returns its own keychain alongside the
+        // legacy Keychain.root registration; verify it's a real Keychain.
+        expect(secrets).toBeInstanceOf(Keychain);
+        expect(secrets.allSecrets).toEqual([]);
     });
 
     it("can override defaults in the schema and those are populated instead", () => {
-        expect(
-            parseUserConfig({
-                args: [],
-                overrides: {
-                    exportTimeoutMs: UserConfigSchema.shape.exportTimeoutMs.default(123),
-                },
-            })
-        ).toStrictEqual({
+        const { secrets, ...rest } = parseUserConfig({
+            args: [],
+            overrides: {
+                exportTimeoutMs: UserConfigSchema.shape.exportTimeoutMs.default(123),
+            },
+        });
+        expect(rest).toStrictEqual({
             parsed: {
                 ...expectedDefaults,
                 exportTimeoutMs: 123,
@@ -92,6 +96,7 @@ describe("config", () => {
             warnings: [],
             error: undefined,
         });
+        expect(secrets).toBeInstanceOf(Keychain);
     });
 
     describe("env var parsing", () => {
@@ -410,15 +415,17 @@ describe("config", () => {
             }
 
             it("cannot mix --httpHeaders and --httpHeaders.fieldX", () => {
-                expect(
-                    parseUserConfig({
-                        args: ["--httpHeaders", '{"fieldA": "3", "fieldB": "4"}', "--httpHeaders.fieldA", "5"],
-                    })
-                ).toStrictEqual({
+                const { secrets, ...rest } = parseUserConfig({
+                    args: ["--httpHeaders", '{"fieldA": "3", "fieldB": "4"}', "--httpHeaders.fieldA", "5"],
+                });
+                expect(rest).toStrictEqual({
                     error: "Invalid configuration for the following fields:\nhttpHeaders - Invalid input: expected object, received array",
                     warnings: [],
                     parsed: undefined,
                 });
+                // An empty keychain is returned even on failure so callers
+                // can uniformly destructure the result.
+                expect(secrets.allSecrets).toEqual([]);
             });
         });
 

--- a/tests/unit/common/keychain.test.ts
+++ b/tests/unit/common/keychain.test.ts
@@ -1,16 +1,11 @@
-import { Keychain, registerGlobalSecretToRedact } from "../../../src/common/keychain.js";
+import { CompositeKeychain, Keychain, registerGlobalSecretToRedact } from "../../../src/common/keychain.js";
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
 
 describe("Keychain", () => {
     let keychain: Keychain;
 
     beforeEach(() => {
-        keychain = Keychain.root;
-        keychain.clearAllSecrets();
-    });
-
-    afterEach(() => {
-        keychain.clearAllSecrets();
+        keychain = new Keychain();
     });
 
     it("should register a new secret", () => {
@@ -27,10 +22,79 @@ describe("Keychain", () => {
         expect(keychain.allSecrets).toEqual([{ value: "654321", kind: "user" }]);
     });
 
-    describe("registerGlobalSecretToRedact", () => {
-        it("registers the secret in the root keychain", () => {
-            registerGlobalSecretToRedact("123456", "password");
-            expect(keychain.allSecrets).toEqual([{ value: "123456", kind: "password" }]);
+    it("each instance has its own scope (no cross-contamination)", () => {
+        const a = new Keychain();
+        const b = new Keychain();
+        a.register("only-in-a", "password");
+        b.register("only-in-b", "password");
+        expect(a.allSecrets).toEqual([{ value: "only-in-a", kind: "password" }]);
+        expect(b.allSecrets).toEqual([{ value: "only-in-b", kind: "password" }]);
+    });
+
+    // Deprecated-shim tests: Keychain.root and registerGlobalSecretToRedact
+    // remain functional for one release to ease the transition to
+    // dependency-injected keychains. These tests guard the shim contract.
+    describe("deprecated Keychain.root + registerGlobalSecretToRedact", () => {
+        beforeEach(() => {
+            Keychain.root.clearAllSecrets();
         });
+
+        afterEach(() => {
+            Keychain.root.clearAllSecrets();
+        });
+
+        it("registerGlobalSecretToRedact writes to the deprecated Keychain.root", () => {
+            registerGlobalSecretToRedact("123456", "password");
+            expect(Keychain.root.allSecrets).toEqual([{ value: "123456", kind: "password" }]);
+        });
+
+        it("Keychain.root persists across accesses (module-local fallback)", () => {
+            Keychain.root.register("persist-me", "password");
+            expect(Keychain.root.allSecrets).toEqual([{ value: "persist-me", kind: "password" }]);
+        });
+    });
+});
+
+describe("CompositeKeychain", () => {
+    it("unions secrets from every delegate when read", () => {
+        const bootstrap = new Keychain();
+        const session = new Keychain();
+        bootstrap.register("boot-secret", "password");
+        session.register("session-secret", "user");
+
+        const composite = new CompositeKeychain([session, bootstrap]);
+
+        expect(composite.allSecrets).toEqual([
+            { value: "session-secret", kind: "user" },
+            { value: "boot-secret", kind: "password" },
+        ]);
+    });
+
+    it("register() writes only to the first delegate", () => {
+        const writable = new Keychain();
+        const readOnly = new Keychain();
+        const composite = new CompositeKeychain([writable, readOnly]);
+
+        composite.register("new-secret", "password");
+
+        expect(writable.allSecrets).toEqual([{ value: "new-secret", kind: "password" }]);
+        expect(readOnly.allSecrets).toEqual([]);
+    });
+
+    it("clearAllSecrets() clears every delegate", () => {
+        const a = new Keychain();
+        const b = new Keychain();
+        a.register("a", "password");
+        b.register("b", "password");
+        const composite = new CompositeKeychain([a, b]);
+
+        composite.clearAllSecrets();
+
+        expect(a.allSecrets).toEqual([]);
+        expect(b.allSecrets).toEqual([]);
+    });
+
+    it("refuses construction with no delegates", () => {
+        expect(() => new CompositeKeychain([])).toThrow(/at least one delegate/i);
     });
 });


### PR DESCRIPTION
Per OWASP MCP Top 10 (2025) item MCP10 - Context Injection & Over-Sharing. The process-wide `Keychain.root` static encouraged implicit cross-session secret sharing in a server that can serve many MCP sessions concurrently. This change adds explicit-ownership primitives and a non-breaking deprecation path off the static.

Why this matters: the previous design let any code path register a secret on a singleton readable by every other session in the same process. Under the HTTP transport (many MCP sessions per process), this widened the blast radius of any leak. The existing JSDoc on Keychain itself flagged the static as "a bigger refactor we should do later". This PR is that refactor, staged for one-release deprecation so downstream embedders can migrate at their own pace.

src/common/keychain.ts
- New `CompositeKeychain` class: read-through union of N delegates for cases where one logger needs to redact across multiple ownership scopes at once (typically a bootstrap keychain composed with a per-session keychain). `register` writes to the FIRST delegate only; the rest are read-only sources. This keeps ownership unambiguous: each composite has exactly one writable backing keychain.
- `Keychain.root` and `registerGlobalSecretToRedact` are kept but marked `@deprecated`. They now write to a module-local fallback keychain (not a class static), making the transitional nature of the shim clear to readers. The contract for callers is unchanged
  - the old API continues to work for one release.

src/common/config/parseUserConfig.ts
- `parseUserConfig` return gains a `secrets: Keychain` field. The returned keychain is pre-populated with every secret discovered in the parsed config (Atlas credentials, connection string, TLS file paths, etc.). The caller owns it and is responsible for threading it into loggers / sessions.
- For one-release backward compat, every secret is ALSO registered into the deprecated `Keychain.root` so downstream code that still reads from the global keeps working unchanged.
- The previous private helper `registerKnownSecretsInRootKeychain` is renamed `registerKnownSecrets` and accepts the target keychain as a parameter.

src/lib.ts
- `CompositeKeychain` is added to the public exports alongside the existing `Keychain` and `registerGlobalSecretToRedact`. Nothing is removed.

Tests:
- tests/unit/common/keychain.test.ts: new CompositeKeychain test suite covers read-union, write-target-is-first-delegate, full fan-out clear, and refusal of zero-delegate constructions. A new per-instance-isolation test guards against accidental reintroduction of cross-Keychain sharing. The existing `Keychain.root` + `registerGlobalSecretToRedact` deprecated-shim tests are preserved (with cleanup before/after) to document the back-compat contract.
- tests/unit/common/config.test.ts: the two `toStrictEqual` assertions on `parseUserConfig` return values now destructure `secrets` before comparing the rest (the new field is additive but breaks deep-equality), plus assertions that the returned keychain is a real `Keychain` (and is empty when no secrets were present). One failure-path assertion gains the same destructure
  + an empty-keychain check.

api-extractor reports regenerated.

NOT breaking changes:
- `Keychain.root` and `registerGlobalSecretToRedact` keep working.
- `parseUserConfig({...})` return type gains a new `secrets` field; existing destructures that pull only `{ parsed, warnings, error }` keep working. Full-equality assertions (`toStrictEqual`) need to account for the new field — the most common case in test code, flagged here for downstream test maintenance.

A subsequent release can complete the migration by removing `Keychain.root` and `registerGlobalSecretToRedact`.

## Proposed changes

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
