### PR TITLE
Fix resource update crash after client disconnect

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -276,8 +276,16 @@ export class Server<
             message: `Resource updated: ${uri}`,
         });
 
-        if (this.subscriptions.has(uri)) {
-            void this.mcpServer.server.sendResourceUpdated({ uri });
+        if (this.subscriptions.has(uri) && this.mcpServer.isConnected()) {
+            void this.mcpServer.server.sendResourceUpdated({ uri }).catch((error: unknown) => {
+                this.session.logger.warning({
+                    id: LogId.resourceUpdateFailure,
+                    context: "resources",
+                    message: `Could not send resource update to client: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                });
+            });
         }
     }
 

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Server } from "../../src/server.js";
+import type { Session } from "../../src/common/session.js";
+import { connectionErrorHandler } from "../../src/common/connectionErrorHandler.js";
+import { LogId, type LoggerBase } from "../../src/common/logging/index.js";
+import type { Telemetry } from "../../src/telemetry/telemetry.js";
+import type { Elicitation } from "../../src/elicitation.js";
+import { defaultTestConfig } from "../integration/helpers.js";
+import { MockMetrics } from "./mocks/metrics.js";
+
+function createServerWithSubscription({
+    isConnected = true,
+    sendResourceUpdated = vi.fn().mockResolvedValue(undefined),
+}: {
+    isConnected?: boolean;
+    sendResourceUpdated?: ReturnType<typeof vi.fn>;
+} = {}): {
+    server: Server;
+    sendResourceUpdated: ReturnType<typeof vi.fn>;
+    warning: ReturnType<typeof vi.fn>;
+} {
+    const warning = vi.fn();
+    const logger = {
+        info: vi.fn(),
+        debug: vi.fn(),
+        warning,
+        error: vi.fn(),
+    } as unknown as LoggerBase;
+    const mcpServer = {
+        isConnected: vi.fn().mockReturnValue(isConnected),
+        server: { sendResourceUpdated },
+    } as unknown as McpServer;
+    const server = new Server({
+        session: { logger } as unknown as Session,
+        userConfig: defaultTestConfig,
+        mcpServer,
+        telemetry: {
+            close: vi.fn(),
+            emitEvents: vi.fn(),
+        } as unknown as Telemetry,
+        elicitation: {} as unknown as Elicitation,
+        connectionErrorHandler,
+        metrics: new MockMetrics(),
+    });
+
+    (server as unknown as { subscriptions: Set<string> }).subscriptions.add("debug://mongodb");
+
+    return { server, sendResourceUpdated, warning };
+}
+
+describe("Server resource updates", () => {
+    it("does not send resource update notifications after the MCP server disconnects", () => {
+        const { server, sendResourceUpdated } = createServerWithSubscription({ isConnected: false });
+
+        server.sendResourceUpdated("debug://mongodb");
+
+        expect(sendResourceUpdated).not.toHaveBeenCalled();
+    });
+
+    it("logs resource update notification failures instead of leaving rejections unhandled", async () => {
+        const sendResourceUpdated = vi.fn().mockRejectedValue(new Error("Not connected"));
+        const { server, warning } = createServerWithSubscription({ sendResourceUpdated });
+
+        server.sendResourceUpdated("debug://mongodb");
+        await Promise.resolve();
+
+        expect(sendResourceUpdated).toHaveBeenCalledWith({ uri: "debug://mongodb" });
+        expect(warning).toHaveBeenCalledWith({
+            id: LogId.resourceUpdateFailure,
+            context: "resources",
+            message: "Could not send resource update to client: Not connected",
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Skip resource update notifications once the MCP server transport is disconnected.
- Catch/log resource update notification failures so a late subscription update cannot become an unhandled rejection.
- Add unit coverage for disconnected and late-failing resource update paths.

## Context

When a Streamable HTTP client subscribes to `debug://mongodb`, lets the session go idle, and the session closes, reactive resources can still emit `sendResourceUpdated`. In that state the MCP SDK throws `Error: Not connected`; because the promise was intentionally discarded, the rejection can terminate Node and restart hosted services.

Observed stack shape:

```text
Error: Not connected
    at Server.notification (.../@modelcontextprotocol/sdk/dist/esm/shared/protocol.js:791:19)
    at Server.sendResourceUpdated (.../@modelcontextprotocol/sdk/dist/esm/server/index.js:423:21)
    at Server.sendResourceUpdated (.../mongodb-mcp-server/dist/esm/server.js:121:40)
    at DebugResource.triggerUpdate (.../mongodb-mcp-server/dist/esm/resources/resource.js:38:26)
```

## Validation

- `npx --yes prettier@3.8.1 --check src/server.ts tests/unit/server.test.ts`
- Secret scan of changed snippets: no secrets found
