### PR TITLE
chore: extend support for local connection type telemetry - MCP-520

### DIFF
--- a/src/common/connectionInfo.ts
+++ b/src/common/connectionInfo.ts
@@ -1,4 +1,4 @@
-import { isAtlas } from "mongodb-build-info";
+import { isAtlas, isLocalhost } from "mongodb-build-info";
 import type { MongoClientOptions } from "mongodb";
 import { ConnectionString } from "mongodb-connection-string-url";
 import type { UserConfig } from "./config/userConfig.js";
@@ -62,6 +62,11 @@ export function getHostType(connectionString: string): ConnectionStringHostType 
     if (isAtlas(connectionString)) {
         return "atlas";
     }
+
+    if (isLocalhost(connectionString)) {
+        return "local";
+    }
+
     return "unknown";
 }
 

--- a/tests/integration/common/connectionManager.test.ts
+++ b/tests/integration/common/connectionManager.test.ts
@@ -126,7 +126,7 @@ describeWithMongoDB("Connection Manager", (integration) => {
                     connectedAtlasCluster: undefined,
                     connectionStringInfo: {
                         authType: "scram",
-                        hostType: "unknown",
+                        hostType: "local",
                     },
                     errorReason: "Unable to parse localhost:xxxxx with URL",
                 });

--- a/tests/unit/common/connectionInfo.test.ts
+++ b/tests/unit/common/connectionInfo.test.ts
@@ -23,7 +23,7 @@ describe("connectionInfo", () => {
 
             const result = getHostType(localConnectionString);
 
-            expect(result).toBe("unknown");
+            expect(result).toBe("local");
         });
 
         it("should return 'unknown' for empty connection string", () => {
@@ -96,7 +96,7 @@ describe("connectionInfo", () => {
 
             const result = getHostType(localhostConnectionString);
 
-            expect(result).toBe("unknown");
+            expect(result).toBe("local");
         });
 
         it("should handle connection strings with IP addresses", () => {
@@ -230,7 +230,7 @@ describe("connectionInfo", () => {
 
             expect(result).toEqual({
                 authType: "scram",
-                hostType: "unknown",
+                hostType: "local",
             });
         });
 
@@ -266,7 +266,7 @@ describe("connectionInfo", () => {
 
             expect(result).toEqual({
                 authType: "scram",
-                hostType: "unknown",
+                hostType: "local",
             });
         });
 
@@ -312,7 +312,7 @@ describe("connectionInfo", () => {
 
             expect(result).toEqual({
                 authType: "ldap",
-                hostType: "unknown",
+                hostType: "local",
             });
         });
 


### PR DESCRIPTION
## Proposed changes
Adds support to expand telemetry and detect Local connection strings.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
