### PR TITLE
chore: Add fields to atlas-create-cluster response content

### DIFF
--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -357,9 +357,9 @@ export class CreateClusterTool extends AtlasToolBase {
             LATEST: "LATEST";
         }>>;
         backup: z.ZodDefault<z.ZodEnum<{
-            CONTINUOUS: "CONTINUOUS";
             OFF: "OFF";
             SNAPSHOT: "SNAPSHOT";
+            CONTINUOUS: "CONTINUOUS";
         }>>;
         terminationProtectionEnabled: z.ZodDefault<z.ZodBoolean>;
     };
@@ -399,9 +399,9 @@ export class CreateClusterTool extends AtlasToolBase {
             LATEST: "LATEST";
         }>;
         backup: z.ZodEnum<{
-            CONTINUOUS: "CONTINUOUS";
             OFF: "OFF";
             SNAPSHOT: "SNAPSHOT";
+            CONTINUOUS: "CONTINUOUS";
         }>;
         computeAutoScaling: z.ZodBoolean;
         terminationProtectionEnabled: z.ZodBoolean;

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -290,8 +290,8 @@ export type CreateClusterMetadata = AtlasMetadata & {
     provider?: string;
     region?: string;
     instance_size?: string;
-    cluster_type?: string;
-    backup?: string;
+    cluster_type?: "REPLICASET" | "SHARDED";
+    backup?: "OFF" | "SNAPSHOT" | "CONTINUOUS";
     compute_auto_scaling?: TelemetryBoolSet;
     termination_protection?: TelemetryBoolSet;
     disk_size_gb?: number;

--- a/src/tools/atlas/create/createCluster.ts
+++ b/src/tools/atlas/create/createCluster.ts
@@ -16,22 +16,22 @@ Default recommendation: AWS US_EAST_1.
 User-specified regions not present in the mapping MUST be respected, rely on the tool to surface errors if a region is not supported.
 `;
 
-const INSTANCE_SIZES = ["M10", "M20", "M30", "M40", "M50", "M60", "M80"] as const;
-const CLOUD_PROVIDERS = ["AWS", "GCP", "AZURE"] as const;
-const CLUSTER_TYPES = ["REPLICASET", "SHARDED"] as const;
-const MONGODB_VERSIONS = ["7.0", "8.0", "LATEST"] as const;
-const BACKUP_OPTIONS = ["OFF", "SNAPSHOT", "CONTINUOUS"] as const;
+const instanceSizeEnum = z.enum(["M10", "M20", "M30", "M40", "M50", "M60", "M80"]);
+const cloudProviderEnum = z.enum(["AWS", "GCP", "AZURE"]);
+const clusterTypeEnum = z.enum(["REPLICASET", "SHARDED"]);
+const mongoDBVersionEnum = z.enum(["7.0", "8.0", "LATEST"]);
+const backupEnum = z.enum(["OFF", "SNAPSHOT", "CONTINUOUS"]);
 
-type InstanceSize = (typeof INSTANCE_SIZES)[number];
-type CloudProvider = (typeof CLOUD_PROVIDERS)[number];
-type MongoDBVersion = (typeof MONGODB_VERSIONS)[number];
-type Backup = (typeof BACKUP_OPTIONS)[number];
+type InstanceSize = z.infer<typeof instanceSizeEnum>;
+type CloudProvider = z.infer<typeof cloudProviderEnum>;
+type MongoDBVersion = z.infer<typeof mongoDBVersionEnum>;
+type Backup = z.infer<typeof backupEnum>;
 
 function getMaxAutoScalingSize(size: InstanceSize, provider: CloudProvider): string {
     // M60 and M80 extend beyond the selectable range. M140 is not supported on Azure.
     if (size === "M80") return "M200";
     if (size === "M60") return provider === "AZURE" ? "M200" : "M140";
-    return INSTANCE_SIZES[INSTANCE_SIZES.indexOf(size) + 2] ?? "M80";
+    return instanceSizeEnum.options[instanceSizeEnum.options.indexOf(size) + 2] ?? "M80";
 }
 
 type AutoScalingConfig = {
@@ -125,21 +125,19 @@ export const CreateClusterArgsShape = {
 
     clusterName: AtlasArgs.clusterName().describe("Name of the cluster."),
 
-    provider: z.enum(CLOUD_PROVIDERS).describe("Cloud provider for the cluster."),
+    provider: cloudProviderEnum.describe("Cloud provider for the cluster."),
 
     region: AtlasArgs.region().describe(
         "Cloud provider region in Atlas format using uppercase letters and underscores (e.g. US_EAST_1)."
     ),
 
-    clusterType: z
-        .enum(CLUSTER_TYPES)
+    clusterType: clusterTypeEnum
         .default("REPLICASET")
         .describe(
             "Cluster topology. Use `SHARDED` for single-shard clusters, requires M30 or higher. Defaults to `REPLICASET`."
         ),
 
-    instanceSize: z
-        .enum(INSTANCE_SIZES)
+    instanceSize: instanceSizeEnum
         .optional()
         .describe(
             "Instance size. NVME and high-memory instances are not supported. Minimum M30 when clusterType is SHARDED. Defaults to M10 for projects with fewer than 2 existing clusters, M30 otherwise. Omit unless explicitly specified by the user."
@@ -160,15 +158,13 @@ export const CreateClusterArgsShape = {
             "Initial disk size in GB. Disk autoscaling is always enabled regardless of this value. Omit unless explicitly specified by the user."
         ),
 
-    mongoDBVersion: z
-        .enum(MONGODB_VERSIONS)
+    mongoDBVersion: mongoDBVersionEnum
         .default("LATEST")
         .describe(
             "MongoDB version to deploy. Use a pinned version for production environments where version stability is required. Defaults to `LATEST`."
         ),
 
-    backup: z
-        .enum(BACKUP_OPTIONS)
+    backup: backupEnum
         .default("SNAPSHOT")
         .describe(
             "`OFF`: no backups. `SNAPSHOT`: cloud backup snapshots, recommended for most workloads. `CONTINUOUS`: point-in-time restore, required for RPO-sensitive production workloads. Defaults to `SNAPSHOT`."
@@ -184,12 +180,12 @@ export const CreateClusterArgsShape = {
 
 const CreateClusterOutputSchema = {
     clusterId: z.string().optional(),
-    provider: z.enum(CLOUD_PROVIDERS),
+    provider: cloudProviderEnum,
     region: z.string(),
-    instanceSize: z.enum(INSTANCE_SIZES),
-    clusterType: z.enum(CLUSTER_TYPES),
-    mongoDBVersion: z.enum(MONGODB_VERSIONS),
-    backup: z.enum(BACKUP_OPTIONS),
+    instanceSize: instanceSizeEnum,
+    clusterType: clusterTypeEnum,
+    mongoDBVersion: mongoDBVersionEnum,
+    backup: backupEnum,
     computeAutoScaling: z.boolean(),
     terminationProtectionEnabled: z.boolean(),
     diskSizeGB: z.number().optional(),

--- a/src/tools/atlas/create/createCluster.ts
+++ b/src/tools/atlas/create/createCluster.ts
@@ -243,7 +243,7 @@ export class CreateClusterTool extends AtlasToolBase {
                 {
                     type: "text",
                     text:
-                        `Cluster "${clusterName}" is being created in project "${projectId}". ` +
+                        `Cluster "${clusterName}" is being created in project "${projectId}" (${instanceSize} ${clusterType} on ${provider}/${region}). ` +
                         `Use the atlas-inspect-cluster tool with projectId "${projectId}" and clusterName "${clusterName}" to poll for readiness. ` +
                         `The cluster is ready when its state is IDLE, connection strings are unavailable until then.`,
                 },

--- a/src/tools/atlas/create/createCluster.ts
+++ b/src/tools/atlas/create/createCluster.ts
@@ -17,8 +17,15 @@ User-specified regions not present in the mapping MUST be respected, rely on the
 `;
 
 const INSTANCE_SIZES = ["M10", "M20", "M30", "M40", "M50", "M60", "M80"] as const;
+const CLOUD_PROVIDERS = ["AWS", "GCP", "AZURE"] as const;
+const CLUSTER_TYPES = ["REPLICASET", "SHARDED"] as const;
+const MONGODB_VERSIONS = ["7.0", "8.0", "LATEST"] as const;
+const BACKUP_OPTIONS = ["OFF", "SNAPSHOT", "CONTINUOUS"] as const;
+
 type InstanceSize = (typeof INSTANCE_SIZES)[number];
-type CloudProvider = "AWS" | "GCP" | "AZURE";
+type CloudProvider = (typeof CLOUD_PROVIDERS)[number];
+type MongoDBVersion = (typeof MONGODB_VERSIONS)[number];
+type Backup = (typeof BACKUP_OPTIONS)[number];
 
 function getMaxAutoScalingSize(size: InstanceSize, provider: CloudProvider): string {
     // M60 and M80 extend beyond the selectable range. M140 is not supported on Azure.
@@ -85,7 +92,7 @@ function buildReplicationSpecs(
     ];
 }
 
-function buildBackupConfig(backups: "OFF" | "SNAPSHOT" | "CONTINUOUS"): {
+function buildBackupConfig(backups: Backup): {
     backupEnabled: boolean;
     pitEnabled: boolean;
 } {
@@ -99,7 +106,7 @@ function buildBackupConfig(backups: "OFF" | "SNAPSHOT" | "CONTINUOUS"): {
     }
 }
 
-function buildVersionConfig(version: "7.0" | "8.0" | "LATEST"): {
+function buildVersionConfig(version: MongoDBVersion): {
     versionReleaseSystem: "LTS" | "CONTINUOUS";
     mongoDBMajorVersion?: string;
 } {
@@ -118,21 +125,21 @@ export const CreateClusterArgsShape = {
 
     clusterName: AtlasArgs.clusterName().describe("Name of the cluster."),
 
-    provider: z.enum(["AWS", "GCP", "AZURE"]).describe("Cloud provider for the cluster."),
+    provider: z.enum(CLOUD_PROVIDERS).describe("Cloud provider for the cluster."),
 
     region: AtlasArgs.region().describe(
         "Cloud provider region in Atlas format using uppercase letters and underscores (e.g. US_EAST_1)."
     ),
 
     clusterType: z
-        .enum(["REPLICASET", "SHARDED"])
+        .enum(CLUSTER_TYPES)
         .default("REPLICASET")
         .describe(
             "Cluster topology. Use `SHARDED` for single-shard clusters, requires M30 or higher. Defaults to `REPLICASET`."
         ),
 
     instanceSize: z
-        .enum(["M10", "M20", "M30", "M40", "M50", "M60", "M80"])
+        .enum(INSTANCE_SIZES)
         .optional()
         .describe(
             "Instance size. NVME and high-memory instances are not supported. Minimum M30 when clusterType is SHARDED. Defaults to M10 for projects with fewer than 2 existing clusters, M30 otherwise. Omit unless explicitly specified by the user."
@@ -154,14 +161,14 @@ export const CreateClusterArgsShape = {
         ),
 
     mongoDBVersion: z
-        .enum(["7.0", "8.0", "LATEST"])
+        .enum(MONGODB_VERSIONS)
         .default("LATEST")
         .describe(
             "MongoDB version to deploy. Use a pinned version for production environments where version stability is required. Defaults to `LATEST`."
         ),
 
     backup: z
-        .enum(["OFF", "SNAPSHOT", "CONTINUOUS"])
+        .enum(BACKUP_OPTIONS)
         .default("SNAPSHOT")
         .describe(
             "`OFF`: no backups. `SNAPSHOT`: cloud backup snapshots, recommended for most workloads. `CONTINUOUS`: point-in-time restore, required for RPO-sensitive production workloads. Defaults to `SNAPSHOT`."
@@ -177,12 +184,12 @@ export const CreateClusterArgsShape = {
 
 const CreateClusterOutputSchema = {
     clusterId: z.string().optional(),
-    provider: z.enum(["AWS", "GCP", "AZURE"]),
+    provider: z.enum(CLOUD_PROVIDERS),
     region: z.string(),
-    instanceSize: z.enum(["M10", "M20", "M30", "M40", "M50", "M60", "M80"]),
-    clusterType: z.enum(["REPLICASET", "SHARDED"]),
-    mongoDBVersion: z.enum(["7.0", "8.0", "LATEST"]),
-    backup: z.enum(["OFF", "SNAPSHOT", "CONTINUOUS"]),
+    instanceSize: z.enum(INSTANCE_SIZES),
+    clusterType: z.enum(CLUSTER_TYPES),
+    mongoDBVersion: z.enum(MONGODB_VERSIONS),
+    backup: z.enum(BACKUP_OPTIONS),
     computeAutoScaling: z.boolean(),
     terminationProtectionEnabled: z.boolean(),
     diskSizeGB: z.number().optional(),

--- a/tests/accuracy/createCluster.test.ts
+++ b/tests/accuracy/createCluster.test.ts
@@ -15,15 +15,25 @@ interface ClusterMockParams {
     clusterName: string;
     instanceSize?: string;
     mongoDBVersion?: string;
+    clusterType?: string;
+    provider?: string;
+    region?: string;
 }
 
-function mockCreateClusterResponse({ projectId, clusterName }: ClusterMockParams): () => CallToolResult {
+function mockCreateClusterResponse({
+    projectId,
+    clusterName,
+    provider,
+    region,
+    instanceSize = "M10",
+    clusterType = "REPLICASET",
+}: ClusterMockParams): () => CallToolResult {
     return () => ({
         content: [
             {
                 type: "text",
                 text:
-                    `Cluster "${clusterName}" is being created in project "${projectId}". ` +
+                    `Cluster "${clusterName}" is being created in project "${projectId}" (${instanceSize} ${clusterType} on ${provider}/${region}). ` +
                     `Use the atlas-inspect-cluster tool with projectId "${projectId}" and clusterName "${clusterName}" to poll for readiness. ` +
                     `The cluster is ready when its state is IDLE, connection strings are unavailable until then.`,
             },
@@ -65,7 +75,12 @@ describeAccuracyTests([
         prompt: `Create a cluster named "${CLUSTER_NAME}" in project "${PROJECT_ID}" on AWS in US_EAST_1`,
         mockedTools: {
             ...mockListProjects,
-            "atlas-create-cluster": mockCreateClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "AWS",
+                region: "US_EAST_1",
+            }),
         },
         expectedToolCalls: [
             ...optionalListProjects,
@@ -85,7 +100,13 @@ describeAccuracyTests([
         prompt: `Set up an M30 cluster called "${CLUSTER_NAME}" on GCP central US for project ${PROJECT_ID}`,
         mockedTools: {
             ...mockListProjects,
-            "atlas-create-cluster": mockCreateClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "GCP",
+                region: "CENTRAL_US",
+                instanceSize: "M30",
+            }),
         },
         expectedToolCalls: [
             ...optionalListProjects,
@@ -106,7 +127,12 @@ describeAccuracyTests([
         prompt: `I need an Azure cluster called "${CLUSTER_NAME}" in europe_west for project ${PROJECT_ID}. Lock the version to 7.0.`,
         mockedTools: {
             ...mockListProjects,
-            "atlas-create-cluster": mockCreateClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "AZURE",
+                region: "EUROPE_WEST",
+            }),
         },
         expectedToolCalls: [
             ...optionalListProjects,
@@ -127,7 +153,12 @@ describeAccuracyTests([
         prompt: `Set up cluster "${CLUSTER_NAME}" in project ${PROJECT_ID} on AWS US_EAST_1. I need point-in-time recovery enabled.`,
         mockedTools: {
             ...mockListProjects,
-            "atlas-create-cluster": mockCreateClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "AWS",
+                region: "US_EAST_1",
+            }),
         },
         expectedToolCalls: [
             ...optionalListProjects,
@@ -148,7 +179,12 @@ describeAccuracyTests([
         prompt: `Create a dev cluster named "${CLUSTER_NAME}" in project "${PROJECT_ID}" on GCP in SOUTH_AMERICA_EAST_1 without any backups`,
         mockedTools: {
             ...mockListProjects,
-            "atlas-create-cluster": mockCreateClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "GCP",
+                region: "SOUTH_AMERICA_EAST_1",
+            }),
         },
         expectedToolCalls: [
             ...optionalListProjects,
@@ -169,7 +205,13 @@ describeAccuracyTests([
         prompt: `Provision an M30 cluster "${CLUSTER_NAME}" in project ${PROJECT_ID} on Azure North Europe. No autoscaling or backups.`,
         mockedTools: {
             ...mockListProjects,
-            "atlas-create-cluster": mockCreateClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "AZURE",
+                region: "EUROPE_NORTH",
+                instanceSize: "M30",
+            }),
         },
         expectedToolCalls: [
             ...optionalListProjects,
@@ -192,7 +234,12 @@ describeAccuracyTests([
         prompt: `Create a cluster named "${CLUSTER_NAME}" in project "${PROJECT_ID}" on AWS in EU_WEST_1, make sure it can't be accidentally removed.`,
         mockedTools: {
             ...mockListProjects,
-            "atlas-create-cluster": mockCreateClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "AWS",
+                region: "EU_WEST_1",
+            }),
         },
         expectedToolCalls: [
             ...optionalListProjects,
@@ -213,7 +260,14 @@ describeAccuracyTests([
         prompt: `Create a sharded cluster named "${CLUSTER_NAME}" in project "${PROJECT_ID}" on GCP in US_EAST_4`,
         mockedTools: {
             ...mockListProjects,
-            "atlas-create-cluster": mockCreateClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "GCP",
+                region: "US_EAST_4",
+                clusterType: "SHARDED",
+                instanceSize: "M30",
+            }),
         },
         expectedToolCalls: [
             ...optionalListProjects,
@@ -237,7 +291,12 @@ describeAccuracyTests([
         prompt: `I need a new cluster called "${CLUSTER_NAME}" in my project "${PROJECT_NAME}" on AWS US_EAST_1`,
         mockedTools: {
             ...mockListProjects,
-            "atlas-create-cluster": mockCreateClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "AWS",
+                region: "US_EAST_1",
+            }),
         },
         expectedToolCalls: [
             {
@@ -261,7 +320,12 @@ describeAccuracyTests([
         prompt: `Spin up "${CLUSTER_NAME}" on AWS US_EAST_1 in project ${PROJECT_ID} and let me know when it's ready to use`,
         mockedTools: {
             ...mockListProjects,
-            "atlas-create-cluster": mockCreateClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "AWS",
+                region: "US_EAST_1",
+            }),
             "atlas-inspect-cluster": mockInspectClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
         },
         expectedToolCalls: [
@@ -335,6 +399,9 @@ describeAccuracyTests([
             "atlas-create-cluster": mockCreateClusterResponse({
                 projectId: PROJECT_ID,
                 clusterName: SOURCE_CLUSTER_NAME,
+                provider: "AWS",
+                region: "EU_WEST_1",
+                instanceSize: "M40",
             }),
         },
         expectedToolCalls: [


### PR DESCRIPTION
## Description

Followups to https://github.com/mongodb-js/mongodb-mcp-server/pull/1211

- Update `atlas-create-cluster` response content to include additional fields from the `structuredContent` (`instanceSize`, `clusterType`, `provider` & `region`).
- Extracted enums to reduce duplication.

Followup from 

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
