### PR TITLE
fix: prevent dropTarget when delete operations are disabled MCP-526

### DIFF
--- a/src/tools/mongodb/update/renameCollection.ts
+++ b/src/tools/mongodb/update/renameCollection.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
+import { ErrorCodes, MongoDBError } from "../../../common/errors.js";
 
 const RenameCollectionOutputSchema = {
     database: z.string(),
@@ -28,6 +29,17 @@ export class RenameCollectionTool extends MongoDBToolBase {
         newName,
         dropTarget,
     }: ToolArgs<typeof this.argsShape>): Promise<ToolResult<typeof this.outputSchema>> {
+        if (dropTarget && this.config.disabledTools.includes("delete")) {
+            // Renaming with `dropTarget: true` drops the existing target collection, which is a
+            // destructive delete operation. Since this tool's operation type is `update`, it remains
+            // available even when delete operations are disabled, so reject `dropTarget` in that case
+            // to prevent it from being used to drop a collection through the back door.
+            throw new MongoDBError(
+                ErrorCodes.ForbiddenWriteOperation,
+                "When 'delete' operations are disabled, you can not rename a collection with 'dropTarget' set to true, as it would drop the target collection."
+            );
+        }
+
         const provider = await this.ensureConnected();
         const result = await provider.renameCollection(database, collection, newName, {
             dropTarget,

--- a/tests/integration/tools/mongodb/update/renameCollection.test.ts
+++ b/tests/integration/tools/mongodb/update/renameCollection.test.ts
@@ -4,7 +4,7 @@ import {
     validateToolMetadata,
     validateThrowsForInvalidArguments,
 } from "../../../helpers.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { describeWithMongoDB, validateAutoConnectBehavior } from "../mongodbHelpers.js";
 import type { RenameCollectionOutput } from "../../../../../src/tools/mongodb/update/renameCollection.js";
 
@@ -189,6 +189,79 @@ describeWithMongoDB("renameCollection tool", (integration) => {
                 .toArray();
             expect(docsInAfter).toHaveLength(1);
             expect(docsInAfter[0]?.value).toEqual(42);
+        });
+    });
+
+    describe("when dropping the target collection is not allowed", () => {
+        afterEach(() => {
+            integration.mcpServer().userConfig.disabledTools = [];
+        });
+
+        it("does not drop the target collection when 'delete' operations are disabled", async () => {
+            await integration
+                .mongoClient()
+                .db(integration.randomDbName())
+                .collection("before")
+                .insertOne({ value: 42 });
+            await integration.mongoClient().db(integration.randomDbName()).collection("after").insertOne({ value: 84 });
+
+            await integration.connectMcpClient();
+            integration.mcpServer().userConfig.disabledTools = ["delete"];
+            const response = await integration.mcpClient().callTool({
+                name: "rename-collection",
+                arguments: {
+                    database: integration.randomDbName(),
+                    collection: "before",
+                    newName: "after",
+                    dropTarget: true,
+                },
+            });
+            const content = getResponseContent(response.content);
+            expect(content).toEqual(
+                "Error running rename-collection: When 'delete' operations are disabled, you can not rename a collection with 'dropTarget' set to true, as it would drop the target collection."
+            );
+
+            // Ensure no data was lost
+            const docsInBefore = await integration
+                .mongoClient()
+                .db(integration.randomDbName())
+                .collection("before")
+                .find({})
+                .toArray();
+            expect(docsInBefore).toHaveLength(1);
+            expect(docsInBefore[0]?.value).toEqual(42);
+
+            const docsInAfter = await integration
+                .mongoClient()
+                .db(integration.randomDbName())
+                .collection("after")
+                .find({})
+                .toArray();
+            expect(docsInAfter).toHaveLength(1);
+            expect(docsInAfter[0]?.value).toEqual(84);
+        });
+
+        it("still allows renaming without dropTarget when 'delete' operations are disabled", async () => {
+            await integration
+                .mongoClient()
+                .db(integration.randomDbName())
+                .collection("before")
+                .insertOne({ value: 42 });
+
+            await integration.connectMcpClient();
+            integration.mcpServer().userConfig.disabledTools = ["delete"];
+            const response = await integration.mcpClient().callTool({
+                name: "rename-collection",
+                arguments: {
+                    database: integration.randomDbName(),
+                    collection: "before",
+                    newName: "after",
+                },
+            });
+            const content = getResponseContent(response.content);
+            expect(content).toEqual(
+                `Collection "before" renamed to "after" in database "${integration.randomDbName()}".`
+            );
         });
     });
 


### PR DESCRIPTION
## Proposed changes

`rename-collection` would allow to be called with `dropTarget: true`, even when destructive operations are disabled. This change adds an extra validation to prevent that.