### PR TITLE
fix(security): guard the update-many `update` document with assertMqlIsAllowed

### DIFF
--- a/src/tools/mongodb/update/updateMany.ts
+++ b/src/tools/mongodb/update/updateMany.ts
@@ -47,6 +47,11 @@ export class UpdateManyTool extends MongoDBToolBase {
         const provider = await this.ensureConnected();
 
         this.assertMqlIsAllowed(filter);
+        // The update document is also MQL and, in its aggregation-pipeline form, can carry
+        // server-side JS operators ($function/$where/$accumulator) and write stages ($out/$merge).
+        // It must go through the same guard as the filter so `disableServerSideJs` / readOnly /
+        // disabled-tools restrictions can't be bypassed via the update argument.
+        this.assertMqlIsAllowed(update);
 
         // Check if update operation uses an index if enabled
         if (this.config.indexCheck) {

--- a/tests/integration/tools/mongodb/update/updateMany.test.ts
+++ b/tests/integration/tools/mongodb/update/updateMany.test.ts
@@ -295,4 +295,33 @@ describeWithMongoDB("updateMany tool with server-side JavaScript operators", (in
             }
         });
     }
+
+    // The `update` document is MQL too, so it must go through the same guard as the `filter`
+    // (the regression this protects against). Unlike a filter, a classic update document does not
+    // execute the operator server-side, so the enabled case only asserts the guard lets it through.
+    for (const jsDisabled of [true, false]) {
+        it(`${jsDisabled ? "rejects" : "allows"} an update document carrying $function when disableServerSideJs is ${jsDisabled}`, async () => {
+            integration.mcpServer().userConfig.disableServerSideJs = jsDisabled;
+            await integration.connectMcpClient();
+            const response = await integration.mcpClient().callTool({
+                name: "update-many",
+                arguments: {
+                    database: integration.randomDbName(),
+                    collection: "people",
+                    filter: {},
+                    update: {
+                        $set: {
+                            flagged: { $function: { body: "function () { return true; }", args: [], lang: "js" } },
+                        },
+                    },
+                },
+            });
+            const content = getResponseContent(response.content);
+            if (jsDisabled) {
+                expect(content).toContain(`The "$function" operator is not allowed.`);
+            } else {
+                expect(content).not.toContain("server-side JavaScript operators");
+            }
+        });
+    }
 });


### PR DESCRIPTION
### What

`UpdateManyTool.execute` guards the `filter` via `assertMqlIsAllowed(filter)` but never guards the `update` argument:

https://github.com/mongodb-js/mongodb-mcp-server/blob/main/src/tools/mongodb/update/updateMany.ts#L49

Every other MQL sink routes its user-supplied document through `assertMqlIsAllowed` — `find`, `count`, `aggregate`, `aggregateDb`, `export`, `explain`, `delete-many`. `update-many`'s `update` was the only one missing it.

### Why it matters

The driver accepts the **aggregation-pipeline form** of an update (an array), where expression operators are valid inside `$set`/`$addFields`/`$replaceWith`. So an `update` such as:

```json
[ { "$set": { "x": { "$function": { "body": "function(){return 1}", "args": [], "lang": "js" } } } } ]
```

reaches `mongod` **without** passing the guard. The effect:

- `$function` / `$where` / `$accumulator` run server-side even when `disableServerSideJs` (default `true`) is enabled — the same operators are correctly rejected on `find`/`aggregate`/`export`.
- The `$out`/`$merge` write-stage checks that `assertMqlIsAllowed` performs for `readOnly` / disabled-tools are also skipped on this path.

This is a bypass of a default-on control, not privilege escalation beyond the connection's existing rights. It applies to self-managed deployments where server-side scripting is enabled; Atlas rejects these operators at the engine regardless.

### The fix

Parity — also call `this.assertMqlIsAllowed(update)`. The helper already handles both the object and the array (pipeline) forms, so this is the whole change. Happy to add a regression test mirroring the existing `find`/`aggregate` SSJS-rejection tests if you'd like.

---

Reported and fixed by [Aeon](https://github.com/aeonframework/aeon), an autonomous open-source security agent. No PoC beyond the minimal snippet above is included.