### PR TITLE
chore: update docker healthcheck to wait for primary

### DIFF
--- a/tests/integration/tools/mongodb/mongodbClusterProcess.ts
+++ b/tests/integration/tools/mongodb/mongodbClusterProcess.ts
@@ -71,7 +71,16 @@ export class MongoDBClusterProcess {
             const runningContainer = await new GenericContainer(config.image ?? DEFAULT_LOCAL_IMAGE)
                 .withExposedPorts(27017)
                 .withCommand(["/usr/local/bin/runner", "server"])
-                .withWaitStrategy(new ShellWaitStrategy(`mongosh --eval 'db.test.getSearchIndexes()'`))
+                // Require an elected, writable primary *and* search readiness before
+                // declaring the container ready. `getSearchIndexes()` is a read that
+                // succeeds before the single-node replica set finishes electing a
+                // primary, so gating on it alone lets the first connect/write race the
+                // election (manifesting as a flaky "not connected"/"not primary" error).
+                .withWaitStrategy(
+                    new ShellWaitStrategy(
+                        `mongosh --quiet --eval 'db.hello().isWritablePrimary || quit(1); db.test.getSearchIndexes()'`
+                    )
+                )
                 .start();
 
             return new MongoDBClusterProcess(

--- a/tests/integration/tools/mongodb/mongodbHelpers.ts
+++ b/tests/integration/tools/mongodb/mongodbHelpers.ts
@@ -9,6 +9,7 @@ import {
     setupIntegrationTest,
     defaultTestConfig,
     getDataFromUntrustedContent,
+    timeout,
 } from "../../helpers.js";
 import type { UserConfig } from "../../../../src/common/config/userConfig.js";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,6 +20,12 @@ import type { createMockElicitInput, MockClientCapabilities } from "../../../uti
 
 export const DEFAULT_WAIT_TIMEOUT = 1000;
 export const DEFAULT_RETRY_INTERVAL = 100;
+
+// How many times `connectMcpClient` retries a failed connect (and how long it
+// waits between attempts) before giving up and failing clearly. Connecting can
+// transiently fail while the cluster settles (e.g. a replica set election).
+const CONNECT_MAX_ATTEMPTS = 3;
+const CONNECT_RETRY_INTERVAL = 1000;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -118,11 +125,28 @@ export function describeWithMongoDB(
             ...mdbIntegration,
             connectMcpClient: async () => {
                 const { tools } = await integration.mcpClient().listTools();
-                if (tools.find((tool) => tool.name === "connect")) {
-                    await integration.mcpClient().callTool({
+                if (!tools.find((tool) => tool.name === "connect")) {
+                    return;
+                }
+
+                let attempt = 0;
+                while (true) {
+                    const response = await integration.mcpClient().callTool({
                         name: "connect",
                         arguments: { connectionString: mdbIntegration.connectionString() },
                     });
+
+                    if (!response.isError) {
+                        return;
+                    }
+
+                    if (++attempt >= CONNECT_MAX_ATTEMPTS) {
+                        throw new Error(
+                            `Failed to connect MCP client after ${attempt} attempts: ${getResponseContent(response.content)}`
+                        );
+                    }
+
+                    await timeout(CONNECT_RETRY_INTERVAL);
                 }
             },
         });

--- a/tests/integration/tools/mongodb/mongot-community-setup/docker-compose.yml
+++ b/tests/integration/tools/mongodb/mongot-community-setup/docker-compose.yml
@@ -15,8 +15,18 @@ services:
       - ./config/mongod.conf:/etc/mongod.conf:ro
       - ./init-mongo.sh:/docker-entrypoint-initdb.d/init-mongo.sh:ro
     healthcheck:
+      # Assert the single-node replica set has elected a writable primary, not
+      # just that mongod answers. `ping` succeeds before the replica set has
+      # initiated/elected, so gating on it lets the first write race the
+      # election and fail with NotWritablePrimary ("not primary").
       test:
-        ["CMD", "mongosh", "--eval", "db.adminCommand('ping').ok", "--quiet"]
+        [
+          "CMD",
+          "mongosh",
+          "--quiet",
+          "--eval",
+          "db.hello().isWritablePrimary || quit(1)",
+        ]
       interval: 5s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Proposed changes

This should address the flaky tests we're occasionally seeing on CI (e.g. https://github.com/mongodb-js/mongodb-mcp-server/actions/runs/27706370170/job/81993073414?pr=1257)