### PR TITLE
feat: expose a hook to set readonly at execution time

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -25,6 +25,7 @@ import type http from 'http';
 import type { IDeviceId } from '@mongodb-js/mcp-types';
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import type { LoggingMessageNotification } from '@modelcontextprotocol/sdk/types.js';
+import type { MaybePromise } from '@mongodb-js/mcp-types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { MetricDefinitions } from '@mongodb-js/mcp-metrics';
 import { Metrics } from '@mongodb-js/mcp-metrics';
@@ -273,7 +274,7 @@ export type ConnectionErrorHandled = {
 };
 
 // @public (undocumented)
-export type ConnectionErrorHandler = (error: MongoDBError<ErrorCodes.NotConnectedToMongoDB | ErrorCodes.MisconfiguredConnectionString>, additionalContext: ConnectionErrorHandlerContext) => ConnectionErrorUnhandled | ConnectionErrorHandled | Promise<ConnectionErrorUnhandled | ConnectionErrorHandled>;
+export type ConnectionErrorHandler = (error: MongoDBError<ErrorCodes.NotConnectedToMongoDB | ErrorCodes.MisconfiguredConnectionString>, additionalContext: ConnectionErrorHandlerContext) => MaybePromise<ConnectionErrorUnhandled | ConnectionErrorHandled>;
 
 // @public (undocumented)
 export const connectionErrorHandler: ConnectionErrorHandler;
@@ -341,6 +342,8 @@ export interface ConnectionSettings extends Omit<ConnectionInfo, "driverOptions"
     atlas?: AtlasClusterConnectionInfo;
     // (undocumented)
     driverOptions?: ConnectionInfo["driverOptions"];
+    // (undocumented)
+    readOnly?: boolean;
 }
 
 // @public (undocumented)
@@ -355,13 +358,15 @@ export interface ConnectionState {
 
 // @public (undocumented)
 export class ConnectionStateConnected implements ConnectionState {
-    constructor(serviceProvider: NodeDriverServiceProvider, connectionStringInfo?: ConnectionStringInfo | undefined, connectedAtlasCluster?: AtlasClusterConnectionInfo | undefined);
+    constructor(serviceProvider: NodeDriverServiceProvider, connectionStringInfo?: ConnectionStringInfo | undefined, connectedAtlasCluster?: AtlasClusterConnectionInfo | undefined, readOnly?: boolean | undefined);
     // (undocumented)
     connectedAtlasCluster?: AtlasClusterConnectionInfo | undefined;
     // (undocumented)
     connectionStringInfo?: ConnectionStringInfo | undefined;
     // (undocumented)
     isSearchSupported(logger: LoggerBase): Promise<boolean>;
+    // (undocumented)
+    readonly readOnly?: boolean | undefined;
     // (undocumented)
     serviceProvider: NodeDriverServiceProvider;
     // (undocumented)
@@ -376,6 +381,8 @@ export interface ConnectionStateConnecting extends ConnectionState {
     oidcLoginUrl?: string;
     // (undocumented)
     oidcUserCode?: string;
+    // (undocumented)
+    readOnly?: boolean;
     // (undocumented)
     serviceProvider: Promise<NodeDriverServiceProvider>;
     // (undocumented)
@@ -434,7 +441,7 @@ export type CreateMonitoringServerFn<TMetrics extends DefaultMetrics = DefaultMe
 export type CreateSessionConfigFn<TUserConfig extends UserConfig = UserConfig> = (context: {
     userConfig: TUserConfig;
     request?: TransportRequestContext;
-}) => Promise<TUserConfig> | TUserConfig;
+}) => MaybePromise<TUserConfig>;
 
 // @public
 export type CreateSessionStoreFn<TTransport extends CloseableTransport = CloseableTransport, TMetrics extends DefaultMetrics = DefaultMetrics> = (args: SessionStoreConstructorArgs<TMetrics>) => ISessionStore<TTransport>;
@@ -448,7 +455,7 @@ export interface Credentials {
 }
 
 // @public (undocumented)
-export type CustomizableServerOptions<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = Partial<Pick<ServerOptions<TUserConfig, TContext>, "uiRegistry" | "tools" | "toolContext" | "elicitation">> & {
+export type CustomizableServerOptions<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = Partial<Pick<ServerOptions<TUserConfig, TContext>, "uiRegistry" | "tools" | "toolContext" | "elicitation" | "authorizeToolExecution">> & {
     telemetryProperties?: Partial<CommonProperties>;
 };
 
@@ -837,6 +844,8 @@ export { Secret }
 export class Server<TUserConfig extends UserConfig = UserConfig, TContext = unknown, TMetrics extends DefaultMetrics = DefaultMetrics> {
     constructor(input: ServerOptions<TUserConfig, TContext, TMetrics>);
     // (undocumented)
+    readonly authorizeToolExecution?: ToolExecutionAuthorizer;
+    // (undocumented)
     close(): Promise<void>;
     // (undocumented)
     connect(transport: Transport): Promise<void>;
@@ -874,6 +883,7 @@ export class Server<TUserConfig extends UserConfig = UserConfig, TContext = unkn
 
 // @public (undocumented)
 export interface ServerOptions<TUserConfig extends UserConfig = UserConfig, TContext = unknown, TMetrics extends DefaultMetrics = DefaultMetrics> {
+    authorizeToolExecution?: ToolExecutionAuthorizer;
     // @deprecated (undocumented)
     connectionErrorHandler: ConnectionErrorHandler;
     // (undocumented)
@@ -1094,6 +1104,23 @@ export { TelemetryEvents }
 // @public
 export type ToolCategory = "mongodb" | "atlas" | "atlas-local" | "assistant";
 
+// @public
+export type ToolExecutionAuthorizer = (input: {
+    tool: {
+        name: string;
+        category: ToolCategory;
+        operationType: OperationType;
+    };
+    args: unknown;
+    session: Session;
+    context: ToolExecutionContext;
+}) => MaybePromise<{
+    allowed: true;
+} | {
+    allowed: false;
+    reason: string;
+}>;
+
 // @public (undocumented)
 export interface ToolExecutionContext {
     requestInfo?: {
@@ -1169,14 +1196,14 @@ export type TransportRunnerConfig<TUserConfig extends UserConfig = UserConfig, T
 // @public
 export class UIRegistry {
     constructor(options?: {
-        customUIs?: (toolName: string) => string | null | Promise<string | null>;
+        customUIs?: (toolName: string) => MaybePromise<string | null>;
     });
     get(toolName: string): Promise<string | null>;
 }
 
 // @public (undocumented)
 export type UIRegistryOptions = {
-    customUIs?: (toolName: string) => string | null | Promise<string | null>;
+    customUIs?: (toolName: string) => MaybePromise<string | null>;
 };
 
 // @public (undocumented)

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -17,6 +17,7 @@ import type { FindCursor } from 'mongodb';
 import type { IDeviceId } from '@mongodb-js/mcp-types';
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import type { LoggingMessageNotification } from '@modelcontextprotocol/sdk/types.js';
+import type { MaybePromise } from '@mongodb-js/mcp-types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Metrics } from '@mongodb-js/mcp-metrics';
 import type { MongoLogId } from 'mongodb-log-writer';
@@ -1285,6 +1286,8 @@ export abstract class MongoDBToolBase extends ToolBase {
     // (undocumented)
     protected handleError(error: unknown, args: ToolArgs<typeof MongoDBToolBase.argsShape>): Promise<CallToolResult>;
     // (undocumented)
+    protected isEffectivelyReadOnly(): boolean;
+    // (undocumented)
     register(server: Server): boolean;
     protected resolveTelemetryMetadata(_args: ToolArgs<typeof MongoDBToolBase.argsShape>, input: {
         result: CallToolResult;
@@ -1705,6 +1708,8 @@ export abstract class ToolBase<TUserConfig extends UserConfig = UserConfig, TCon
     // (undocumented)
     get annotations(): ToolAnnotations;
     abstract argsShape: ZodRawShape;
+    protected assertWriteOperationAllowed(): void;
+    protected readonly authorizeToolExecution?: ToolExecutionAuthorizer;
     readonly category: ToolCategory;
     protected readonly config: TUserConfig;
     protected readonly context?: TContext;
@@ -1718,8 +1723,9 @@ export abstract class ToolBase<TUserConfig extends UserConfig = UserConfig, TCon
     protected getConfirmationMessage(args: ToolArgs<typeof ToolBase.argsShape>): string;
     // (undocumented)
     protected getConnectionInfoMetadata(): ConnectionMetadata;
-    protected handleError(error: unknown, args: z.infer<z.ZodObject<typeof ToolBase.argsShape>>): Promise<CallToolResult> | CallToolResult;
+    protected handleError(error: unknown, args: z.infer<z.ZodObject<typeof ToolBase.argsShape>>): MaybePromise<CallToolResult>;
     invoke(args: ToolArgs<typeof ToolBase.argsShape>, context: ToolExecutionContext): Promise<CallToolResult>;
+    protected isEffectivelyReadOnly(): boolean;
     // (undocumented)
     isEnabled(): boolean;
     // (undocumented)
@@ -1765,7 +1771,25 @@ export type ToolConstructorParams<TUserConfig extends UserConfig = UserConfig, T
     metrics: Metrics<TMetrics>;
     uiRegistry?: UIRegistry;
     context?: TContext;
+    authorizeToolExecution?: ToolExecutionAuthorizer;
 };
+
+// @public
+export type ToolExecutionAuthorizer = (input: {
+    tool: {
+        name: string;
+        category: ToolCategory;
+        operationType: OperationType;
+    };
+    args: unknown;
+    session: Session;
+    context: ToolExecutionContext;
+}) => MaybePromise<{
+    allowed: true;
+} | {
+    allowed: false;
+    reason: string;
+}>;
 
 // @public (undocumented)
 export interface ToolExecutionContext {

--- a/api-extractor/reports/ui.public.api.md
+++ b/api-extractor/reports/ui.public.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import type { MaybePromise } from '@mongodb-js/mcp-types';
 import { ReactElement } from 'react';
 
 // @public (undocumented)
@@ -12,7 +13,7 @@ export const ListDatabases: () => ReactElement | null;
 // @public
 export class UIRegistry {
     constructor(options?: {
-        customUIs?: (toolName: string) => string | null | Promise<string | null>;
+        customUIs?: (toolName: string) => MaybePromise<string | null>;
     });
     get(toolName: string): Promise<string | null>;
 }

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -18,6 +18,7 @@ import type { FindCursor } from 'mongodb';
 import type { IDeviceId } from '@mongodb-js/mcp-types';
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import type { LoggingMessageNotification } from '@modelcontextprotocol/sdk/types.js';
+import type { MaybePromise } from '@mongodb-js/mcp-types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { MetricDefinitions } from '@mongodb-js/mcp-metrics';
 import { Metrics } from '@mongodb-js/mcp-metrics';
@@ -308,7 +309,7 @@ export type ConnectionErrorHandled = {
 };
 
 // @public (undocumented)
-export type ConnectionErrorHandler = (error: MongoDBError<ErrorCodes.NotConnectedToMongoDB | ErrorCodes.MisconfiguredConnectionString>, additionalContext: ConnectionErrorHandlerContext) => ConnectionErrorUnhandled | ConnectionErrorHandled | Promise<ConnectionErrorUnhandled | ConnectionErrorHandled>;
+export type ConnectionErrorHandler = (error: MongoDBError<ErrorCodes.NotConnectedToMongoDB | ErrorCodes.MisconfiguredConnectionString>, additionalContext: ConnectionErrorHandlerContext) => MaybePromise<ConnectionErrorUnhandled | ConnectionErrorHandled>;
 
 // @public (undocumented)
 export type ConnectionErrorHandlerContext = {
@@ -385,6 +386,8 @@ export interface ConnectionSettings extends Omit<ConnectionInfo, "driverOptions"
     atlas?: AtlasClusterConnectionInfo;
     // (undocumented)
     driverOptions?: ConnectionInfo["driverOptions"];
+    // (undocumented)
+    readOnly?: boolean;
 }
 
 // @public (undocumented)
@@ -399,13 +402,15 @@ export interface ConnectionState {
 
 // @public (undocumented)
 export class ConnectionStateConnected implements ConnectionState {
-    constructor(serviceProvider: NodeDriverServiceProvider, connectionStringInfo?: ConnectionStringInfo | undefined, connectedAtlasCluster?: AtlasClusterConnectionInfo | undefined);
+    constructor(serviceProvider: NodeDriverServiceProvider, connectionStringInfo?: ConnectionStringInfo | undefined, connectedAtlasCluster?: AtlasClusterConnectionInfo | undefined, readOnly?: boolean | undefined);
     // (undocumented)
     connectedAtlasCluster?: AtlasClusterConnectionInfo | undefined;
     // (undocumented)
     connectionStringInfo?: ConnectionStringInfo | undefined;
     // (undocumented)
     isSearchSupported(logger: LoggerBase): Promise<boolean>;
+    // (undocumented)
+    readonly readOnly?: boolean | undefined;
     // (undocumented)
     serviceProvider: NodeDriverServiceProvider;
     // (undocumented)
@@ -420,6 +425,8 @@ export interface ConnectionStateConnecting extends ConnectionState {
     oidcLoginUrl?: string;
     // (undocumented)
     oidcUserCode?: string;
+    // (undocumented)
+    readOnly?: boolean;
     // (undocumented)
     serviceProvider: Promise<NodeDriverServiceProvider>;
     // (undocumented)
@@ -463,7 +470,7 @@ export { createDefaultMetrics }
 export type CreateSessionConfigFn<TUserConfig extends UserConfig = UserConfig> = (context: {
     userConfig: TUserConfig;
     request?: TransportRequestContext;
-}) => Promise<TUserConfig> | TUserConfig;
+}) => MaybePromise<TUserConfig>;
 
 // @public (undocumented)
 export interface Credentials {
@@ -474,7 +481,7 @@ export interface Credentials {
 }
 
 // @public (undocumented)
-export type CustomizableServerOptions<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = Partial<Pick<ServerOptions<TUserConfig, TContext>, "uiRegistry" | "tools" | "toolContext" | "elicitation">> & {
+export type CustomizableServerOptions<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = Partial<Pick<ServerOptions<TUserConfig, TContext>, "uiRegistry" | "tools" | "toolContext" | "elicitation" | "authorizeToolExecution">> & {
     telemetryProperties?: Partial<CommonProperties>;
 };
 
@@ -737,6 +744,8 @@ export { Secret }
 export class Server<TUserConfig extends UserConfig = UserConfig, TContext = unknown, TMetrics extends DefaultMetrics = DefaultMetrics> {
     constructor(input: ServerOptions<TUserConfig, TContext, TMetrics>);
     // (undocumented)
+    readonly authorizeToolExecution?: ToolExecutionAuthorizer;
+    // (undocumented)
     close(): Promise<void>;
     // (undocumented)
     connect(transport: Transport): Promise<void>;
@@ -774,6 +783,7 @@ export class Server<TUserConfig extends UserConfig = UserConfig, TContext = unkn
 
 // @public (undocumented)
 export interface ServerOptions<TUserConfig extends UserConfig = UserConfig, TContext = unknown, TMetrics extends DefaultMetrics = DefaultMetrics> {
+    authorizeToolExecution?: ToolExecutionAuthorizer;
     // @deprecated (undocumented)
     connectionErrorHandler: ConnectionErrorHandler;
     // (undocumented)
@@ -944,6 +954,8 @@ export abstract class ToolBase<TUserConfig extends UserConfig = UserConfig, TCon
     // (undocumented)
     get annotations(): ToolAnnotations;
     abstract argsShape: ZodRawShape;
+    protected assertWriteOperationAllowed(): void;
+    protected readonly authorizeToolExecution?: ToolExecutionAuthorizer;
     readonly category: ToolCategory;
     protected readonly config: TUserConfig;
     protected readonly context?: TContext;
@@ -957,8 +969,9 @@ export abstract class ToolBase<TUserConfig extends UserConfig = UserConfig, TCon
     protected getConfirmationMessage(args: ToolArgs<typeof ToolBase.argsShape>): string;
     // (undocumented)
     protected getConnectionInfoMetadata(): ConnectionMetadata;
-    protected handleError(error: unknown, args: z.infer<z.ZodObject<typeof ToolBase.argsShape>>): Promise<CallToolResult> | CallToolResult;
+    protected handleError(error: unknown, args: z.infer<z.ZodObject<typeof ToolBase.argsShape>>): MaybePromise<CallToolResult>;
     invoke(args: ToolArgs<typeof ToolBase.argsShape>, context: ToolExecutionContext): Promise<CallToolResult>;
+    protected isEffectivelyReadOnly(): boolean;
     // (undocumented)
     isEnabled(): boolean;
     // (undocumented)
@@ -1004,7 +1017,25 @@ export type ToolConstructorParams<TUserConfig extends UserConfig = UserConfig, T
     metrics: Metrics<TMetrics>;
     uiRegistry?: UIRegistry;
     context?: TContext;
+    authorizeToolExecution?: ToolExecutionAuthorizer;
 };
+
+// @public
+export type ToolExecutionAuthorizer = (input: {
+    tool: {
+        name: string;
+        category: ToolCategory;
+        operationType: OperationType;
+    };
+    args: unknown;
+    session: Session;
+    context: ToolExecutionContext;
+}) => MaybePromise<{
+    allowed: true;
+} | {
+    allowed: false;
+    reason: string;
+}>;
 
 // @public (undocumented)
 export interface ToolExecutionContext {
@@ -1084,7 +1115,7 @@ export type TransportRunnerConfig<TUserConfig extends UserConfig = UserConfig, T
 // @public
 export class UIRegistry {
     constructor(options?: {
-        customUIs?: (toolName: string) => string | null | Promise<string | null>;
+        customUIs?: (toolName: string) => MaybePromise<string | null>;
     });
     get(toolName: string): Promise<string | null>;
 }

--- a/packages/types/src/helpers.ts
+++ b/packages/types/src/helpers.ts
@@ -1,3 +1,8 @@
+/**
+ * A value that may be provided either synchronously or as a promise.
+ */
+export type MaybePromise<T> = T | Promise<T>;
+
 export type AppNameComponents = {
     appName: string;
     deviceId?: Promise<string>;

--- a/packages/types/src/ui.ts
+++ b/packages/types/src/ui.ts
@@ -1,5 +1,7 @@
+import type { MaybePromise } from "./helpers.js";
+
 export type UIRegistryOptions = {
-    customUIs?: (toolName: string) => string | null | Promise<string | null>;
+    customUIs?: (toolName: string) => MaybePromise<string | null>;
 };
 
 export interface IUIRegistry {

--- a/src/common/connectionErrorHandler.ts
+++ b/src/common/connectionErrorHandler.ts
@@ -2,11 +2,12 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ErrorCodes, type MongoDBError } from "./errors.js";
 import type { AnyConnectionState } from "./connectionManager.js";
 import type { AnyToolBase } from "../tools/tool.js";
+import type { MaybePromise } from "@mongodb-js/mcp-types";
 
 export type ConnectionErrorHandler = (
     error: MongoDBError<ErrorCodes.NotConnectedToMongoDB | ErrorCodes.MisconfiguredConnectionString>,
     additionalContext: ConnectionErrorHandlerContext
-) => ConnectionErrorUnhandled | ConnectionErrorHandled | Promise<ConnectionErrorUnhandled | ConnectionErrorHandled>;
+) => MaybePromise<ConnectionErrorUnhandled | ConnectionErrorHandled>;
 
 export type ConnectionErrorHandlerContext = { availableTools: AnyToolBase[]; connectionState: AnyConnectionState };
 export type ConnectionErrorUnhandled = { errorHandled: false };

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -19,6 +19,7 @@ export type { ConnectionStringInfo, ConnectionStringAuthType, AtlasClusterConnec
 export interface ConnectionSettings extends Omit<ConnectionInfo, "driverOptions"> {
     driverOptions?: ConnectionInfo["driverOptions"];
     atlas?: AtlasClusterConnectionInfo;
+    readOnly?: boolean;
 }
 
 export type ConnectionTag = "connected" | "connecting" | "disconnected" | "errored";
@@ -54,7 +55,8 @@ export class ConnectionStateConnected implements ConnectionState {
     constructor(
         public serviceProvider: NodeDriverServiceProvider,
         public connectionStringInfo?: ConnectionStringInfo,
-        public connectedAtlasCluster?: AtlasClusterConnectionInfo
+        public connectedAtlasCluster?: AtlasClusterConnectionInfo,
+        public readonly readOnly?: boolean
     ) {}
 
     private _isSearchSupported?: boolean;
@@ -166,6 +168,7 @@ export interface ConnectionStateConnecting extends ConnectionState {
     oidcConnectionType: OIDCConnectionAuthType;
     oidcLoginUrl?: string;
     oidcUserCode?: string;
+    readOnly?: boolean;
 }
 
 export interface ConnectionStateDisconnected extends ConnectionState {
@@ -360,13 +363,19 @@ export class MCPConnectionManager extends ConnectionManager {
                     serviceProvider,
                     connectedAtlasCluster: settings.atlas,
                     connectionStringInfo,
+                    readOnly: settings.readOnly,
                     oidcConnectionType: connectionStringInfo.authType as OIDCConnectionAuthType,
                 });
             }
 
             return this.changeState(
                 "connection-success",
-                new ConnectionStateConnected(await serviceProvider, connectionStringInfo, settings.atlas)
+                new ConnectionStateConnected(
+                    await serviceProvider,
+                    connectionStringInfo,
+                    settings.atlas,
+                    settings.readOnly
+                )
             );
         } catch (error: unknown) {
             const errorReason = error instanceof Error ? error.message : `${error as string}`;
@@ -449,7 +458,8 @@ export class MCPConnectionManager extends ConnectionManager {
                 new ConnectionStateConnected(
                     await this.currentConnectionState.serviceProvider,
                     this.currentConnectionState.connectionStringInfo,
-                    this.currentConnectionState.connectedAtlasCluster
+                    this.currentConnectionState.connectedAtlasCluster,
+                    this.currentConnectionState.readOnly
                 )
             );
         }

--- a/src/common/managedTimeout.ts
+++ b/src/common/managedTimeout.ts
@@ -1,9 +1,11 @@
+import type { MaybePromise } from "@mongodb-js/mcp-types";
+
 export interface ManagedTimeout {
     cancel: () => void;
     restart: () => void;
 }
 
-export function setManagedTimeout(callback: () => Promise<void> | void, timeoutMS: number): ManagedTimeout {
+export function setManagedTimeout(callback: () => MaybePromise<void>, timeoutMS: number): ManagedTimeout {
     let timeoutId: NodeJS.Timeout | undefined = setTimeout(() => {
         void callback();
     }, timeoutMS);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -110,7 +110,7 @@ export {
 } from "./common/atlas/apiClient.js";
 export type { AuthProvider, Credentials } from "./common/atlas/auth/authProvider.js";
 export { type UIRegistryOptions, UIRegistry } from "./ui/registry/registry.js";
-export { type ToolExecutionContext, type AnyToolBase } from "./tools/tool.js";
+export { type ToolExecutionContext, type ToolExecutionAuthorizer, type AnyToolBase } from "./tools/tool.js";
 export {
     PrometheusMetrics,
     createDefaultMetrics,

--- a/src/resources/resource.ts
+++ b/src/resources/resource.ts
@@ -5,6 +5,7 @@ import type { Telemetry } from "../telemetry/telemetry.js";
 import type { SessionEvents } from "../common/session.js";
 import type { ReadResourceCallback, ResourceMetadata } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { LogId } from "../common/logging/index.js";
+import type { MaybePromise } from "@mongodb-js/mcp-types";
 
 type PayloadOf<K extends keyof SessionEvents> = SessionEvents[K][0];
 
@@ -106,5 +107,5 @@ export abstract class ReactiveResource<
     }
 
     protected abstract reduce(eventName: RelevantEvents[number], ...event: PayloadOf<RelevantEvents[number]>[]): Value;
-    public abstract toOutput(): string | Promise<string>;
+    public abstract toOutput(): MaybePromise<string>;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import {
     SubscribeRequestSchema,
     UnsubscribeRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { AnyToolBase, ToolCategory, ToolClass } from "./tools/tool.js";
+import type { AnyToolBase, ToolCategory, ToolClass, ToolExecutionAuthorizer } from "./tools/tool.js";
 export type { ToolCategory } from "./tools/tool.js";
 import { validateConnectionString } from "./helpers/connectionOptions.js";
 import { packageInfo } from "./common/packageInfo.js";
@@ -102,6 +102,12 @@ export interface ServerOptions<
      * ```
      */
     toolContext?: TContext;
+    /**
+     * Optional hosting-provided callback invoked before each tool execution to
+     * authorize the call for the current target/session. Forwarded to every
+     * registered tool.
+     */
+    authorizeToolExecution?: ToolExecutionAuthorizer;
 }
 
 export class Server<
@@ -119,6 +125,7 @@ export class Server<
     public readonly connectionErrorHandler: ConnectionErrorHandler;
     public readonly uiRegistry?: UIRegistry;
     public readonly toolContext?: TContext;
+    public readonly authorizeToolExecution?: ToolExecutionAuthorizer;
     public readonly metrics: Metrics<TMetrics>;
 
     private _mcpLogLevel: LogLevel;
@@ -143,6 +150,7 @@ export class Server<
         uiRegistry,
         toolContext,
         metrics,
+        authorizeToolExecution,
     }: ServerOptions<TUserConfig, TContext, TMetrics>) {
         this.startTime = Date.now();
         this.session = session;
@@ -155,6 +163,7 @@ export class Server<
         this.uiRegistry = uiRegistry;
         this.toolContext = toolContext;
         this.metrics = metrics;
+        this.authorizeToolExecution = authorizeToolExecution;
 
         this._mcpLogLevel = userConfig.mcpClientLogLevel;
         this.mcpLogLevelFloor = this._mcpLogLevel;
@@ -325,6 +334,7 @@ export class Server<
                 metrics: this.metrics,
                 uiRegistry: this.uiRegistry,
                 context: this.toolContext,
+                authorizeToolExecution: this.authorizeToolExecution,
             });
             if (tool.register(this)) {
                 this.tools.push(tool);

--- a/src/tools/atlas/atlasTool.ts
+++ b/src/tools/atlas/atlasTool.ts
@@ -5,6 +5,7 @@ import { LogId } from "../../common/logging/index.js";
 import { z } from "zod";
 import { ApiClientError } from "../../common/atlas/apiClientError.js";
 import type { ApiClient } from "../../common/atlas/apiClient.js";
+import type { MaybePromise } from "@mongodb-js/mcp-types";
 
 export abstract class AtlasToolBase extends ToolBase {
     public static category: ToolCategory = "atlas";
@@ -28,10 +29,7 @@ export abstract class AtlasToolBase extends ToolBase {
         return client;
     }
 
-    protected handleError(
-        error: unknown,
-        args: ToolArgs<typeof this.argsShape>
-    ): Promise<CallToolResult> | CallToolResult {
+    protected handleError(error: unknown, args: ToolArgs<typeof this.argsShape>): MaybePromise<CallToolResult> {
         if (error instanceof ApiClientError) {
             const statusCode = error.response.status;
 

--- a/src/tools/atlas/streams/streamsToolBase.ts
+++ b/src/tools/atlas/streams/streamsToolBase.ts
@@ -4,12 +4,13 @@ import type { ToolArgs } from "../../tool.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ApiClientError } from "../../../common/atlas/apiClientError.js";
 import type { StreamsToolMetadata } from "../../../telemetry/types.js";
+import type { MaybePromise } from "@mongodb-js/mcp-types";
 
 export abstract class StreamsToolBase extends AtlasToolBase {
     protected override handleError(
         error: unknown,
         args: ToolArgs<typeof this.argsShape>
-    ): Promise<CallToolResult> | CallToolResult {
+    ): MaybePromise<CallToolResult> {
         if (error instanceof ApiClientError) {
             const statusCode = error.response.status;
 

--- a/src/tools/atlasLocal/atlasLocalTool.ts
+++ b/src/tools/atlasLocal/atlasLocalTool.ts
@@ -4,6 +4,7 @@ import { ToolBase } from "../tool.js";
 import type { Client } from "@mongodb-js/atlas-local";
 import { LogId } from "../../common/logging/index.js";
 import type { ConnectionMetadata } from "../../telemetry/types.js";
+import type { MaybePromise } from "@mongodb-js/mcp-types";
 
 export const AtlasLocalToolMetadataDeploymentIdKey = "deploymentId";
 
@@ -79,10 +80,7 @@ please log a ticket here: https://github.com/mongodb-js/mongodb-mcp-server/issue
         context: { client: Client }
     ): Promise<CallToolResult>;
 
-    protected handleError(
-        error: unknown,
-        args: ToolArgs<typeof this.argsShape>
-    ): Promise<CallToolResult> | CallToolResult {
+    protected handleError(error: unknown, args: ToolArgs<typeof this.argsShape>): MaybePromise<CallToolResult> {
         // Error Handling for expected Atlas Local errors go here
         const errorMessage = error instanceof Error ? error.message : String(error);
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -29,5 +29,6 @@ export {
     type OperationType,
     type ToolArgs,
     type ToolExecutionContext,
+    type ToolExecutionAuthorizer,
     type ToolResult,
 } from "./tool.js";

--- a/src/tools/mongodb/metadata/collectionIndexes.ts
+++ b/src/tools/mongodb/metadata/collectionIndexes.ts
@@ -1,6 +1,7 @@
 import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
 import { formatUntrustedData } from "../../tool.js";
+import type { MaybePromise } from "@mongodb-js/mcp-types";
 import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -88,7 +89,7 @@ export class CollectionIndexesTool extends MongoDBToolBase {
             };
         }
 
-        return super.handleError(error, args) as ToolResult | Promise<ToolResult>;
+        return super.handleError(error, args) as MaybePromise<ToolResult>;
     }
 
     /**

--- a/src/tools/mongodb/metadata/collectionStorageSize.ts
+++ b/src/tools/mongodb/metadata/collectionStorageSize.ts
@@ -1,5 +1,6 @@
 import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolExecutionContext, ToolResult } from "../../tool.js";
+import type { MaybePromise } from "@mongodb-js/mcp-types";
 import { z } from "zod";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -66,7 +67,7 @@ export class CollectionStorageSizeTool extends MongoDBToolBase {
             };
         }
 
-        return super.handleError(error, args) as ToolResult | Promise<ToolResult>;
+        return super.handleError(error, args) as MaybePromise<ToolResult>;
     }
 
     private static getStats(value: number): { value: number; units: string } {

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -22,6 +22,13 @@ export abstract class MongoDBToolBase extends ToolBase {
     protected server?: Server;
     static category: ToolCategory = "mongodb";
 
+    protected override isEffectivelyReadOnly(): boolean {
+        const connectionState = this.session.connectionManager.currentConnectionState;
+        return (
+            super.isEffectivelyReadOnly() || (connectionState.tag === "connected" && connectionState.readOnly === true)
+        );
+    }
+
     protected async ensureConnected(): Promise<NodeDriverServiceProvider> {
         if (!this.session.isConnectedToMongoDB) {
             if (this.session.connectedAtlasCluster) {
@@ -90,7 +97,7 @@ export abstract class MongoDBToolBase extends ToolBase {
             const writeOperations: OperationType[] = ["update", "create", "delete"];
 
             let writeStageForbiddenErrorMessage = "";
-            if (this.config.readOnly) {
+            if (this.isEffectivelyReadOnly()) {
                 writeStageForbiddenErrorMessage =
                     "In readOnly mode you can not run pipelines with $out or $merge stages.";
             } else if (this.config.disabledTools.some((t) => writeOperations.includes(t as OperationType))) {

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -15,6 +15,8 @@ import { TRANSPORT_PAYLOAD_LIMITS, type TransportType } from "../transports/cons
 import { getRandomUUID } from "../helpers/getRandomUUID.js";
 import type { Metrics, DefaultMetrics } from "@mongodb-js/mcp-metrics";
 import { redact } from "mongodb-redact";
+import { ErrorCodes, MongoDBError } from "../common/errors.js";
+import type { MaybePromise } from "@mongodb-js/mcp-types";
 
 export type ToolArgs<T extends ZodRawShape> = {
     [K in keyof T]: z.infer<T[K]>;
@@ -54,6 +56,21 @@ type StructuredToolResult<OutputSchema extends ZodRawShape> = {
  * - `connect` is used for tools that allow you to connect or switch the connection to a MongoDB instance.
  */
 export type OperationType = "metadata" | "read" | "create" | "delete" | "update" | "connect";
+
+const READONLY_ALLOWED_OPERATIONS: OperationType[] = ["read", "metadata", "connect"];
+
+/**
+ * Optional hosting-provided callback invoked before every tool execution to
+ * decide whether the call is permitted for the current target/session. It is
+ * intentionally generic (not read-only specific) so it can express any
+ * per-request authorization policy.
+ */
+export type ToolExecutionAuthorizer = (input: {
+    tool: { name: string; category: ToolCategory; operationType: OperationType };
+    args: unknown;
+    session: Session;
+    context: ToolExecutionContext;
+}) => MaybePromise<{ allowed: true } | { allowed: false; reason: string }>;
 
 /**
  * The category of the tool. This is used when evaluating if a tool is allowed to run based on
@@ -154,6 +171,12 @@ export type ToolConstructorParams<
      * ```
      */
     context?: TContext;
+
+    /**
+     * Optional hosting-provided callback invoked before each tool execution to
+     * authorize the call for the current target/session.
+     */
+    authorizeToolExecution?: ToolExecutionAuthorizer;
 };
 
 /**
@@ -488,6 +511,25 @@ export abstract class ToolBase<
         let startTime: number = Date.now();
 
         try {
+            const toolExecutionAuthorized = await this.authorizeToolExecution?.({
+                tool: { name: this.name, category: this.category, operationType: this.operationType },
+                args,
+                session: this.session,
+                context,
+            });
+
+            if (toolExecutionAuthorized?.allowed === false) {
+                // `reason` comes from the hosting-provided authorizer and is not under our control,
+                // so it is redacted (unlike the fully-controlled tool-lifecycle log messages below).
+                this.session.logger.debug({
+                    id: LogId.toolExecute,
+                    context: "tool",
+                    message: `Execution of the \`${this.name}\` tool was rejected by the authorizer: ${toolExecutionAuthorized.reason}`,
+                });
+
+                return this.buildAuthorizationDeniedResult(toolExecutionAuthorized.reason);
+            }
+
             if (this.requiresConfirmation()) {
                 if (!(await this.verifyConfirmed(args))) {
                     this.session.logger.debug({
@@ -511,6 +553,8 @@ export abstract class ToolBase<
                 // a separate field for elicitation time in the future.
                 startTime = Date.now();
             }
+
+            this.assertWriteOperationAllowed();
             this.session.logger.debug({
                 id: LogId.toolExecute,
                 context: "tool",
@@ -565,6 +609,18 @@ export abstract class ToolBase<
 
             return toolResult;
         }
+    }
+
+    private buildAuthorizationDeniedResult(reason: string): CallToolResult {
+        return {
+            content: [
+                {
+                    type: "text",
+                    text: `The \`${this.name}\` tool is available but was not permitted for this request: ${reason}`,
+                },
+            ],
+            isError: true,
+        };
     }
 
     /**
@@ -665,6 +721,12 @@ export abstract class ToolBase<
      */
     protected readonly context?: TContext;
 
+    /**
+     * Optional hosting-provided authorization callback. When set, it is invoked
+     * before each execution; a denial short-circuits the tool with an error.
+     */
+    protected readonly authorizeToolExecution?: ToolExecutionAuthorizer;
+
     constructor({
         name,
         category,
@@ -676,6 +738,7 @@ export abstract class ToolBase<
         metrics,
         uiRegistry,
         context,
+        authorizeToolExecution,
     }: ToolConstructorParams<TUserConfig, TContext, TMetrics>) {
         this.name = name;
         this.category = category;
@@ -687,6 +750,7 @@ export abstract class ToolBase<
         this.metrics = metrics;
         this.uiRegistry = uiRegistry;
         this.context = context;
+        this.authorizeToolExecution = authorizeToolExecution;
     }
 
     public register(server: Server<TUserConfig, TContext, TMetrics>): boolean {
@@ -753,12 +817,37 @@ export abstract class ToolBase<
         this.registeredTool.enable();
     }
 
+    /**
+     * Whether write operations must currently be rejected, derived from the
+     * session config and — for data-plane subclasses — the active connection's
+     * read-only flag. Recomputed on each call because the active connection (and
+     * therefore the effective value) can change over the tool's lifetime.
+     */
+    protected isEffectivelyReadOnly(): boolean {
+        return this.config.readOnly ?? false;
+    }
+
+    /**
+     * Throws when the target is effectively read-only and the tool performs a
+     * non-read operation. Mirrors the registration-time read-only rule but at
+     * execution time, so write tools registered under a writable session can
+     * still be rejected for a read-only target.
+     */
+    protected assertWriteOperationAllowed(): void {
+        if (this.isEffectivelyReadOnly() && !READONLY_ALLOWED_OPERATIONS.includes(this.operationType)) {
+            throw new MongoDBError(
+                ErrorCodes.ForbiddenWriteOperation,
+                `The \`${this.name}\` tool is available but was rejected for this target: it performs a \`${this.operationType}\` operation, which is not permitted because the current target is configured as read-only. Only read and metadata operations are allowed here.`
+            );
+        }
+    }
+
     // Checks if a tool is allowed to run based on the config
     protected verifyAllowed(): boolean {
         let errorClarification: string | undefined;
 
         // Check read-only mode first
-        if (this.config.readOnly && !["read", "metadata", "connect"].includes(this.operationType)) {
+        if (this.config.readOnly && !READONLY_ALLOWED_OPERATIONS.includes(this.operationType)) {
             errorClarification = `read-only mode is enabled, its operation type, \`${this.operationType}\`,`;
         } else if (this.config.disabledTools.includes(this.category)) {
             errorClarification = `its category, \`${this.category}\`,`;
@@ -814,7 +903,7 @@ export abstract class ToolBase<
         error: unknown,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         args: z.infer<z.ZodObject<typeof this.argsShape>>
-    ): Promise<CallToolResult> | CallToolResult {
+    ): MaybePromise<CallToolResult> {
         const rawMessage = error instanceof Error ? error.message : String(error);
         const safeMessage = redact(rawMessage, this.session.keychain.allSecrets);
         return {

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -519,8 +519,6 @@ export abstract class ToolBase<
             });
 
             if (toolExecutionAuthorized?.allowed === false) {
-                // `reason` comes from the hosting-provided authorizer and is not under our control,
-                // so it is redacted (unlike the fully-controlled tool-lifecycle log messages below).
                 this.session.logger.debug({
                     id: LogId.toolExecute,
                     context: "tool",
@@ -529,6 +527,8 @@ export abstract class ToolBase<
 
                 return this.buildAuthorizationDeniedResult(toolExecutionAuthorized.reason);
             }
+
+            this.assertWriteOperationAllowed();
 
             if (this.requiresConfirmation()) {
                 if (!(await this.verifyConfirmed(args))) {
@@ -554,7 +554,6 @@ export abstract class ToolBase<
                 startTime = Date.now();
             }
 
-            this.assertWriteOperationAllowed();
             this.session.logger.debug({
                 id: LogId.toolExecute,
                 context: "tool",
@@ -837,7 +836,7 @@ export abstract class ToolBase<
         if (this.isEffectivelyReadOnly() && !READONLY_ALLOWED_OPERATIONS.includes(this.operationType)) {
             throw new MongoDBError(
                 ErrorCodes.ForbiddenWriteOperation,
-                `The \`${this.name}\` tool is available but was rejected for this target: it performs a \`${this.operationType}\` operation, which is not permitted because the current target is configured as read-only. Only read and metadata operations are allowed here.`
+                `The \`${this.name}\` tool is available but was rejected for this target: it performs a \`${this.operationType}\` operation, which is not permitted because the current target is configured as read-only. Only non-destructive operations are allowed here.`
             );
         }
     }

--- a/src/transports/base.ts
+++ b/src/transports/base.ts
@@ -25,7 +25,7 @@ import { defaultCreateApiClient } from "../common/atlas/apiClient.js";
 import type { UIRegistry } from "../ui/registry/index.js";
 import { PrometheusMetrics, createDefaultMetrics, type Metrics, type DefaultMetrics } from "@mongodb-js/mcp-metrics";
 
-import type { TransportRequestContext } from "@mongodb-js/mcp-types";
+import type { MaybePromise, TransportRequestContext } from "@mongodb-js/mcp-types";
 
 export type { TransportRequestContext };
 
@@ -40,7 +40,10 @@ export type CustomizableSessionOptions<TUserConfig extends UserConfig = UserConf
 >;
 
 export type CustomizableServerOptions<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = Partial<
-    Pick<ServerOptions<TUserConfig, TContext>, "uiRegistry" | "tools" | "toolContext" | "elicitation">
+    Pick<
+        ServerOptions<TUserConfig, TContext>,
+        "uiRegistry" | "tools" | "toolContext" | "elicitation" | "authorizeToolExecution"
+    >
 > & {
     /**
      * An optional key value pair of telemetry properties that are reported to
@@ -70,7 +73,7 @@ export type CustomizableServerOptions<TUserConfig extends UserConfig = UserConfi
 export type CreateSessionConfigFn<TUserConfig extends UserConfig = UserConfig> = (context: {
     userConfig: TUserConfig;
     request?: TransportRequestContext;
-}) => Promise<TUserConfig> | TUserConfig;
+}) => MaybePromise<TUserConfig>;
 
 /**
  * Configuration options for customizing how transport runners are initialized.
@@ -360,6 +363,7 @@ export abstract class TransportRunnerBase<
             tools: serverOptions?.tools ?? this.tools,
             uiRegistry,
             toolContext: serverOptions?.toolContext,
+            authorizeToolExecution: serverOptions?.authorizeToolExecution,
             metrics: this.metrics,
         });
 

--- a/src/ui/registry/registry.ts
+++ b/src/ui/registry/registry.ts
@@ -2,6 +2,7 @@
 type UILoaders = Record<string, (() => Promise<string>) | undefined>;
 
 import { uiLoaders as _uiLoaders } from "../lib/loaders.js";
+import type { MaybePromise } from "@mongodb-js/mcp-types";
 const uiLoaders = _uiLoaders as UILoaders;
 
 export type UIRegistryOptions = {
@@ -24,17 +25,17 @@ export type UIRegistryOptions = {
      * });
      * ```
      */
-    customUIs?: (toolName: string) => string | null | Promise<string | null>;
+    customUIs?: (toolName: string) => MaybePromise<string | null>;
 };
 
 /**
  * UI Registry that manages bundled UI HTML strings for tools.
  */
 export class UIRegistry {
-    private customUIs?: (toolName: string) => string | null | Promise<string | null>;
+    private customUIs?: (toolName: string) => MaybePromise<string | null>;
     private cache: Map<string, string> = new Map();
 
-    constructor(options?: { customUIs?: (toolName: string) => string | null | Promise<string | null> }) {
+    constructor(options?: { customUIs?: (toolName: string) => MaybePromise<string | null> }) {
         this.customUIs = options?.customUIs;
     }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -79,6 +79,7 @@ export {
     type OperationType,
     type ToolArgs,
     type ToolExecutionContext,
+    type ToolExecutionAuthorizer,
 } from "./tools/tool.js";
 export { Telemetry } from "./telemetry/telemetry.js";
 export type { TelemetryEvents, TelemetryConfig } from "./telemetry/telemetry.js";

--- a/tests/unit/toolAuthorization.test.ts
+++ b/tests/unit/toolAuthorization.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { Server } from "../../src/server.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Session } from "../../src/common/session.js";
+import { UserConfigSchema } from "../../src/common/config/userConfig.js";
+import type { Telemetry } from "../../src/telemetry/telemetry.js";
+import type { Elicitation } from "../../src/elicitation.js";
+import { connectionErrorHandler } from "../../src/common/connectionErrorHandler.js";
+import type { ToolExecutionContext, ToolExecutionAuthorizer } from "../../src/tools/tool.js";
+import { EchoTool } from "./mocks/tools.js";
+import { MockMetrics } from "./mocks/metrics.js";
+
+function buildServer(authorizeToolExecution?: ToolExecutionAuthorizer): Server {
+    const session = {
+        logger: { debug() {}, error() {}, info() {}, warning() {} },
+    } as unknown as Session;
+    return new Server({
+        session,
+        userConfig: UserConfigSchema.parse({}),
+        mcpServer: new McpServer({ name: "test", version: "1.0.0" }),
+        telemetry: { isTelemetryEnabled: () => false, emitEvents() {} } as unknown as Telemetry,
+        elicitation: { requestConfirmation: () => Promise.resolve(true) } as unknown as Elicitation,
+        connectionErrorHandler,
+        tools: [EchoTool],
+        metrics: new MockMetrics(),
+        authorizeToolExecution,
+    });
+}
+
+const execContext: ToolExecutionContext = { signal: new AbortController().signal, requestInfo: { headers: {} } };
+
+describe("Server authorizeToolExecution threading", () => {
+    it("passes the authorizer to tools and blocks denied calls", async () => {
+        const server = buildServer(() => ({ allowed: false, reason: "denied by policy" }));
+        server.registerTools();
+        const tool = server.tools.find((t) => t.name === "echo-tool")!;
+        const result = await tool.invoke({}, execContext);
+        expect(result.isError).toBe(true);
+        expect((result.content[0] as { text: string }).text).toContain("denied by policy");
+    });
+
+    it("executes normally when the authorizer allows", async () => {
+        const authorizer = vi.fn().mockReturnValue({ allowed: true });
+        const server = buildServer(authorizer);
+        server.registerTools();
+        const tool = server.tools.find((t) => t.name === "echo-tool")!;
+        const result = await tool.invoke({}, execContext);
+        expect(result.isError).toBeUndefined();
+        expect((result.content[0] as { text: string }).text).toBe("ok");
+        expect(authorizer).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/unit/toolBase.test.ts
+++ b/tests/unit/toolBase.test.ts
@@ -1,7 +1,7 @@
 import type { Mock } from "vitest";
 import { describe, it, expect, vi, beforeEach, type MockedFunction } from "vitest";
 import type { ZodRawShape } from "zod";
-import type { ToolConstructorParams } from "../../src/tools/tool.js";
+import type { ToolConstructorParams, ToolExecutionContext, ToolExecutionAuthorizer } from "../../src/tools/tool.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { Session } from "../../src/common/session.js";
 import type { UserConfig } from "../../src/common/config/userConfig.js";
@@ -15,7 +15,13 @@ import type { PreviewFeature } from "../../src/common/schemas.js";
 import { UIRegistry } from "../../src/ui/registry/index.js";
 import { TRANSPORT_PAYLOAD_LIMITS } from "../../src/transports/constants.js";
 import { expectDefined } from "../integration/helpers.js";
-import { TestTool, TestToolWithOutputSchema, TestToolWithoutStructuredContent, ErrorTool } from "./mocks/tools.js";
+import {
+    TestTool,
+    TestToolWithOutputSchema,
+    TestToolWithoutStructuredContent,
+    ErrorTool,
+    EchoTool,
+} from "./mocks/tools.js";
 import { MockMetrics } from "./mocks/metrics.js";
 import { Keychain } from "../../src/common/keychain.js";
 
@@ -121,6 +127,60 @@ describe("ToolBase", () => {
 
             expect(result).toBe(false);
             expect(mockRequestConfirmation).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("authorizeToolExecution hook", () => {
+        const execContext: ToolExecutionContext = {
+            signal: new AbortController().signal,
+            requestInfo: { headers: {} },
+        };
+
+        function makeTool(authorizeToolExecution?: ToolExecutionAuthorizer): TestTool {
+            return new TestTool({
+                name: TestTool.toolName,
+                category: TestTool.category,
+                operationType: TestTool.operationType,
+                session: mockSession,
+                config: mockConfig,
+                telemetry: mockTelemetry,
+                elicitation: mockElicitation,
+                metrics: mockMetrics,
+                authorizeToolExecution,
+            });
+        }
+
+        it("executes normally when no authorizer is provided", async () => {
+            const result = await makeTool().invoke({ param1: "x" }, execContext);
+            expect(result.isError).toBeUndefined();
+            expect((result.content[0] as { text: string }).text).toBe("Test tool executed successfully");
+        });
+
+        it("executes when the authorizer allows", async () => {
+            const result = await makeTool(() => ({ allowed: true })).invoke({ param1: "x" }, execContext);
+            expect(result.isError).toBeUndefined();
+            expect((result.content[0] as { text: string }).text).toBe("Test tool executed successfully");
+        });
+
+        it("blocks and surfaces the reason when the authorizer denies", async () => {
+            const result = await makeTool(() => ({ allowed: false, reason: "org is read-only" })).invoke(
+                { param1: "x" },
+                execContext
+            );
+            expect(result.isError).toBe(true);
+            const text = (result.content[0] as { text: string }).text;
+            expect(text).toContain("org is read-only");
+            expect(text).not.toContain("Test tool executed successfully");
+        });
+
+        it("passes tool identity and args to the authorizer", async () => {
+            const authorizer = vi.fn<ToolExecutionAuthorizer>().mockReturnValue({ allowed: true });
+            await makeTool(authorizer).invoke({ param1: "abc" }, execContext);
+            expect(authorizer).toHaveBeenCalledTimes(1);
+            const input = authorizer.mock.calls[0]![0];
+            expect(input.tool).toEqual({ name: "test-tool", category: "mongodb", operationType: "delete" });
+            expect(input.args).toEqual({ param1: "abc" });
+            expect(input.session).toBe(mockSession);
         });
     });
 
@@ -549,6 +609,44 @@ describe("ToolBase", () => {
                     v.labels.status === "error"
             );
             expect(count?.value).toBe(1);
+        });
+    });
+    describe("effective read-only write guard", () => {
+        const execContext = { signal: new AbortController().signal, requestInfo: { headers: {} } };
+
+        function makeTool<T extends typeof TestTool | typeof EchoTool>(ctor: T): InstanceType<T> {
+            return new ctor({
+                name: ctor.toolName,
+                category: ctor.category,
+                operationType: ctor.operationType,
+                session: mockSession,
+                config: mockConfig,
+                telemetry: mockTelemetry,
+                elicitation: mockElicitation,
+                metrics: mockMetrics,
+            }) as InstanceType<T>;
+        }
+
+        it("blocks a write operation when config.readOnly is true", async () => {
+            mockConfig.readOnly = true;
+            const result = await makeTool(TestTool).invoke({ param1: "x" }, execContext);
+            expect(result.isError).toBe(true);
+            const text = (result.content[0] as { text: string }).text;
+            expect(text).toContain("read-only");
+            expect(text).toContain("delete");
+        });
+
+        it("allows a write operation when config.readOnly is false", async () => {
+            mockConfig.readOnly = false;
+            const result = await makeTool(TestTool).invoke({ param1: "x" }, execContext);
+            expect(result.isError).toBeUndefined();
+        });
+
+        it("allows a read operation even when config.readOnly is true", async () => {
+            mockConfig.readOnly = true;
+            const result = await makeTool(EchoTool).invoke({}, execContext);
+            expect(result.isError).toBeUndefined();
+            expect((result.content[0] as { text: string }).text).toBe("ok");
         });
     });
 });

--- a/tests/unit/tools/mongodb/mongodbTool.test.ts
+++ b/tests/unit/tools/mongodb/mongodbTool.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { MongoDBToolBase } from "../../../../src/tools/mongodb/mongodbTool.js";
+import type { OperationType } from "../../../../src/tools/tool.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { Session } from "../../../../src/common/session.js";
+import type { UserConfig } from "../../../../src/common/config/userConfig.js";
+import { MongoDBError, ErrorCodes } from "../../../../src/common/errors.js";
+import { Keychain } from "../../../../src/common/keychain.js";
+import type { TelemetryToolMetadata } from "../../../../src/telemetry/types.js";
+
+class TestMongoDBTool extends MongoDBToolBase {
+    public description = "test mongodb tool";
+    public argsShape = { input: z.string() };
+    protected execute(): Promise<CallToolResult> {
+        return Promise.resolve({ content: [] });
+    }
+    protected resolveTelemetryMetadata(): TelemetryToolMetadata {
+        return {};
+    }
+    public callAssertMqlIsAllowed(value: Record<string, unknown> | Record<string, unknown>[] | undefined): void {
+        this.assertMqlIsAllowed(value);
+    }
+    public callIsEffectivelyReadOnly(): boolean {
+        return this.isEffectivelyReadOnly();
+    }
+}
+
+function makeTool({
+    connectionReadOnly,
+    configReadOnly,
+    operationType = "read",
+}: {
+    connectionReadOnly?: boolean;
+    configReadOnly: boolean;
+    operationType?: OperationType;
+}): TestMongoDBTool {
+    const session = {
+        logger: { debug() {}, info() {}, warning() {}, error() {} },
+        keychain: new Keychain(),
+        connectionManager: {
+            currentConnectionState: { tag: "connected", readOnly: connectionReadOnly },
+        },
+    } as unknown as Session;
+
+    const config = {
+        readOnly: configReadOnly,
+        disabledTools: [],
+        disableServerSideJs: false,
+        confirmationRequiredTools: [],
+        previewFeatures: [],
+    } as unknown as UserConfig;
+
+    return new TestMongoDBTool({
+        name: "test-mongodb-tool",
+        category: TestMongoDBTool.category,
+        operationType,
+        session,
+        config,
+        telemetry: { isTelemetryEnabled: () => false, emitEvents(): void {} } as never,
+        elicitation: { requestConfirmation: () => Promise.resolve(true) } as never,
+        metrics: { get: () => ({ observe(): void {} }) } as never,
+    });
+}
+
+describe("MongoDBToolBase effective read-only", () => {
+    it("reflects connection read-only even when config is writable", () => {
+        expect(makeTool({ connectionReadOnly: true, configReadOnly: false }).callIsEffectivelyReadOnly()).toBe(true);
+        expect(makeTool({ connectionReadOnly: false, configReadOnly: false }).callIsEffectivelyReadOnly()).toBe(false);
+        expect(makeTool({ connectionReadOnly: undefined, configReadOnly: false }).callIsEffectivelyReadOnly()).toBe(
+            false
+        );
+        expect(makeTool({ connectionReadOnly: false, configReadOnly: true }).callIsEffectivelyReadOnly()).toBe(true);
+    });
+
+    it("rejects $out pipelines on a read-only connection", () => {
+        const tool = makeTool({ connectionReadOnly: true, configReadOnly: false });
+        try {
+            tool.callAssertMqlIsAllowed([{ $out: "outpeople" }]);
+            throw new Error("expected assertMqlIsAllowed to throw");
+        } catch (err) {
+            expect(err).toBeInstanceOf(MongoDBError);
+            expect((err as MongoDBError).code).toBe(ErrorCodes.ForbiddenWriteOperation);
+            expect((err as Error).message).toContain(
+                "In readOnly mode you can not run pipelines with $out or $merge stages."
+            );
+        }
+    });
+
+    it("allows $out pipelines on a writable connection", () => {
+        expect(() =>
+            makeTool({ connectionReadOnly: false, configReadOnly: false }).callAssertMqlIsAllowed([
+                { $out: "outpeople" },
+            ])
+        ).not.toThrow();
+    });
+
+    it("rejects a write-operation tool at execution time when the connection is read-only", async () => {
+        const tool = makeTool({ connectionReadOnly: true, configReadOnly: false, operationType: "delete" });
+        const result = await tool.invoke(
+            { input: "x" },
+            { signal: new AbortController().signal, requestInfo: { headers: {} } }
+        );
+        expect(result.isError).toBe(true);
+        const text = (result.content[0] as { text: string }).text;
+        expect(text).toContain("read-only");
+        expect(text).toContain("delete");
+    });
+
+    it("allows a write-operation tool at execution time when the connection is writable", async () => {
+        const tool = makeTool({ connectionReadOnly: false, configReadOnly: false, operationType: "delete" });
+        const result = await tool.invoke(
+            { input: "x" },
+            { signal: new AbortController().signal, requestInfo: { headers: {} } }
+        );
+        expect(result.isError).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Proposed changes

Adds execution-time, per-target read-only enforcement so a single server (initialized readOnly: false) can still reject writes against read-only targets. Two cooperating mechanisms: a generic, hosting-injected ToolExecutionAuthorizer hook (run at the top of ToolBase.invoke()) that lets the host allow/deny each call — e.g. mapping an Atlas tool's orgId/projectId arg to that org's policy — and a built-in connection-scoped read-only flag stashed on ConnectionStateConnected that data-plane tools honor via isEffectivelyReadOnly(), gating write operations and the $out/$merge aggregation guard.

To integrate into hosted MCP services:

1. Pass  `authorizeToolExecution` to `createServer`:
    ```ts
    createServer({
        // ...
        serverOptions: {
            // ...
            authorizeToolExecution: async ({ tool, args, session, context }) => {
                // Check if tool execution is allowed
                return { allowed: false, reason: "Tool not allowed because xyz" };
            }
        }
    });
    ```

    `authorizeToolExecution` is invoked on every tool call and allows integrators to reject the execution based on the arguments, tool name, session state, etc.

2. In the ConnectionManager implementation, pass `readOnly: true | false` to the `connect` method:

    ```ts
    this.connect({
        connectionString: "...",
        driverOptions: { /* ... */ },
        readOnly: true
    })
    ```

    The connection readonly flag is stored on the state and is checked in all `mongodb` tools, where we compute an "effective" readonly configuration based on the connection state and the config.readOnly flag.