### PR TITLE
chore: Implement core logic for the mcp-remote package MCP-536

### DIFF
--- a/packages/mongodb-mcp-remote/package.json
+++ b/packages/mongodb-mcp-remote/package.json
@@ -25,6 +25,9 @@
     "compile": "tsc --project tsconfig.json",
     "test": "vitest --run"
   },
+  "dependencies": {
+    "@mongodb-js/devtools-proxy-support": "^0.7.14"
+  },
   "devDependencies": {
     "@types/node": "^25.6.0",
     "typescript": "^5.9.2",

--- a/packages/mongodb-mcp-remote/src/cli.ts
+++ b/packages/mongodb-mcp-remote/src/cli.ts
@@ -1,10 +1,65 @@
 #!/usr/bin/env node
 
-/**
- * Main entry point for the MongoDB Remote MCP proxy.
- */
+import { createFetch, systemCA } from "@mongodb-js/devtools-proxy-support";
+import type { ProxyAwareFetch } from "./common.js";
+import { loadConfig, ConfigurationError } from "./config.js";
+import { TokenManager, TokenError } from "./tokenManager.js";
+import { Forwarder } from "./forwarder.js";
+import { StdioTransport } from "./stdio.js";
+import { logger } from "./logger.js";
+
 async function main(): Promise<void> {
-    // TODO: Not yet implemented.
+    let config;
+    try {
+        config = loadConfig();
+    } catch (error) {
+        if (error instanceof ConfigurationError) {
+            // Logger not configured yet, write to stderr directly.
+            process.stderr.write(`${error.message}\n`);
+            process.exit(1);
+        }
+        throw error;
+    }
+
+    logger.setLevel(config.logLevel);
+
+    await systemCA().catch((error) => {
+        logger.warning(`Failed to load system CA certificates: ${String(error)}`);
+    });
+
+    const fetch = createFetch({ useEnvironmentVariableProxies: true }) as unknown as ProxyAwareFetch;
+
+    const tokenManager = new TokenManager(
+        config.tokenUrl,
+        config.clientId,
+        config.clientSecret,
+        config.tokenTimeoutMs,
+        fetch
+    );
+    const forwarder = new Forwarder(config.remoteUrl, tokenManager, config.remoteTimeoutMs, fetch);
+
+    try {
+        await tokenManager.getToken();
+    } catch (error) {
+        const message = error instanceof TokenError ? error.message : String(error);
+        logger.error(`Failed to acquire access token: ${message}`);
+        process.exit(1);
+    }
+
+    const stdioTransport = new StdioTransport(forwarder, () => process.exit(0));
+
+    const shutdown = (): void => {
+        logger.info("Shutting down");
+        stdioTransport.stop();
+        process.exit(0);
+    };
+
+    process.on("SIGINT", shutdown);
+    process.on("SIGABRT", shutdown);
+    process.on("SIGTERM", shutdown);
+    process.on("SIGQUIT", shutdown);
+
+    stdioTransport.start();
 }
 
 main().catch((error) => {

--- a/packages/mongodb-mcp-remote/src/common.ts
+++ b/packages/mongodb-mcp-remote/src/common.ts
@@ -1,0 +1,80 @@
+// OAuth2 Token Response
+export interface TokenResponse {
+    access_token: string;
+    expires_in?: number;
+}
+
+export interface CachedToken {
+    accessToken: string;
+    expiresAt: number;
+}
+
+export const LOG_LEVELS = ["debug", "info", "notice", "warning", "error", "critical", "alert", "emergency"] as const;
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+export interface AppConfig {
+    remoteUrl: string;
+    tokenUrl: string;
+    clientId: string;
+    clientSecret: string;
+    remoteTimeoutMs: number;
+    tokenTimeoutMs: number;
+    logLevel: LogLevel;
+}
+
+// === JSON-RPC 2.0 types ===
+
+export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
+
+export interface JsonRpcRequest {
+    jsonrpc: "2.0";
+    id: string | number;
+    method: string;
+    params?: unknown;
+}
+
+export interface JsonRpcNotification {
+    jsonrpc: "2.0";
+    method: string;
+    params?: unknown;
+}
+
+export interface JsonRpcError {
+    code: number;
+    message: string;
+    data?: unknown;
+}
+
+export interface JsonRpcResponse {
+    jsonrpc: "2.0";
+    id: string | number | null;
+    result?: unknown;
+    error?: JsonRpcError;
+}
+
+export const JsonRpcErrorCodes = {
+    PARSE_ERROR: -32700,
+    INVALID_REQUEST: -32600,
+    METHOD_NOT_FOUND: -32601,
+    INVALID_PARAMS: -32602,
+    INTERNAL_ERROR: -32603,
+    // Custom error codes
+    TOKEN_ERROR: -32000,
+    REMOTE_ERROR: -32001,
+    TIMEOUT_ERROR: -32002,
+} as const;
+
+export type ProxyAwareFetch = typeof fetch;
+
+export interface MessageProcessor {
+    forward(message: JsonRpcMessage): Promise<JsonRpcResponse | null>;
+}
+
+export function createErrorResponse(
+    id: string | number | null,
+    code: number,
+    message: string,
+    data?: unknown
+): JsonRpcResponse {
+    return { jsonrpc: "2.0", id, error: { code, message, data } };
+}

--- a/packages/mongodb-mcp-remote/src/config.ts
+++ b/packages/mongodb-mcp-remote/src/config.ts
@@ -1,0 +1,69 @@
+import { LOG_LEVELS } from "./common.js";
+import type { AppConfig, LogLevel } from "./common.js";
+
+const DEFAULT_BASE_URL = "https://cloud.mongodb.com";
+const DEFAULT_REMOTE_TIMEOUT_MS = 30_000;
+const DEFAULT_TOKEN_TIMEOUT_MS = 10_000;
+const DEFAULT_LOG_LEVEL: LogLevel = "info";
+
+function loadPosIntEnvVar(name: string, defaultValue: number, errors: string[]): number {
+    const value = process.env[name];
+    if (value === undefined) return defaultValue;
+
+    const n = parseInt(value, 10);
+    if (isNaN(n) || n <= 0) {
+        errors.push(`${name} must be a positive integer, got: ${value}`);
+        return defaultValue;
+    }
+    return n;
+}
+
+export function loadConfig(): AppConfig {
+    const errors: string[] = [];
+
+    const clientId = process.env.MDB_MCP_API_CLIENT_ID;
+    if (!clientId) {
+        errors.push("MDB_MCP_API_CLIENT_ID is required");
+    }
+
+    const clientSecret = process.env.MDB_MCP_API_CLIENT_SECRET;
+    if (!clientSecret) {
+        errors.push("MDB_MCP_API_CLIENT_SECRET is required");
+    }
+
+    const baseUrl = process.env.MDB_MCP_API_BASE_URL
+        ? process.env.MDB_MCP_API_BASE_URL.replace(/\/+$/, "")
+        : DEFAULT_BASE_URL;
+
+    const remoteTimeoutMs = loadPosIntEnvVar("MDB_MCP_REMOTE_TIMEOUT_MS", DEFAULT_REMOTE_TIMEOUT_MS, errors);
+    const tokenTimeoutMs = loadPosIntEnvVar("MDB_MCP_TOKEN_TIMEOUT_MS", DEFAULT_TOKEN_TIMEOUT_MS, errors);
+
+    let logLevel: LogLevel = DEFAULT_LOG_LEVEL;
+    if (process.env.MDB_MCP_LOG_LEVEL) {
+        logLevel = process.env.MDB_MCP_LOG_LEVEL.toLowerCase() as LogLevel;
+        if (!LOG_LEVELS.includes(logLevel)) {
+            errors.push(`MDB_MCP_LOG_LEVEL must be one of: ${LOG_LEVELS.join(", ")}, got: ${logLevel}`);
+        }
+    }
+
+    if (errors.length > 0) {
+        throw new ConfigurationError(errors);
+    }
+
+    return {
+        clientId: clientId ?? "",
+        clientSecret: clientSecret ?? "",
+        tokenUrl: new URL("/api/oauth/token", baseUrl).toString(),
+        remoteUrl: new URL("/api/private/mcp", baseUrl).toString(), // TODO: Switch to https://mcp.mongodb.com/mcp once available across all environments.
+        remoteTimeoutMs,
+        tokenTimeoutMs,
+        logLevel,
+    };
+}
+
+export class ConfigurationError extends Error {
+    constructor(public readonly errors: string[]) {
+        super(`Configuration errors:\n${errors.map((e) => `  - ${e}`).join("\n")}`);
+        this.name = "ConfigurationError";
+    }
+}

--- a/packages/mongodb-mcp-remote/src/forwarder.ts
+++ b/packages/mongodb-mcp-remote/src/forwarder.ts
@@ -1,0 +1,202 @@
+import type {
+    JsonRpcMessage,
+    JsonRpcNotification,
+    JsonRpcRequest,
+    JsonRpcResponse,
+    MessageProcessor,
+    ProxyAwareFetch,
+} from "./common.js";
+import { JsonRpcErrorCodes, createErrorResponse } from "./common.js";
+
+import type { TokenManager } from "./tokenManager.js";
+import { TokenError } from "./tokenManager.js";
+import { logger } from "./logger.js";
+
+class AuthError extends Error {
+    constructor(
+        message: string,
+        public readonly statusCode: number
+    ) {
+        super(message);
+        this.name = "AuthError";
+    }
+}
+
+class RemoteError extends Error {
+    constructor(
+        message: string,
+        public readonly statusCode: number
+    ) {
+        super(message);
+        this.name = "RemoteError";
+    }
+}
+
+class TimeoutError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "TimeoutError";
+    }
+}
+
+export class Forwarder implements MessageProcessor {
+    private sessionId: string | null = null;
+
+    constructor(
+        private readonly remoteUrl: string,
+        private readonly tokenManager: TokenManager,
+        private readonly timeoutMs: number,
+        private readonly fetch: ProxyAwareFetch
+    ) {}
+
+    async forward(message: JsonRpcMessage): Promise<JsonRpcResponse | null> {
+        if (isRequest(message)) {
+            try {
+                const response = await this.send(message);
+                return this.parseResponse(response, message.id);
+            } catch (error: unknown) {
+                return this.errorToResponse(message.id, error);
+            }
+        } else if (isNotification(message)) {
+            try {
+                await this.send(message);
+            } catch (error: unknown) {
+                logger.warning(`Failed to forward notification: ${String(error)}`);
+            }
+        }
+
+        return null;
+    }
+
+    private async send(message: JsonRpcMessage): Promise<Response> {
+        try {
+            return await this.post(message);
+        } catch (error: unknown) {
+            if (error instanceof AuthError) {
+                logger.debug("Auth error, retrying");
+                return this.post(message);
+            }
+            throw error;
+        }
+    }
+
+    private async post(message: JsonRpcMessage): Promise<Response> {
+        const token = await this.tokenManager.getToken();
+
+        const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+            Authorization: `Bearer ${token}`,
+        };
+        if (this.sessionId) headers["Mcp-Session-Id"] = this.sessionId;
+
+        const body =
+            "method" in message && !("params" in message)
+                ? JSON.stringify({ ...message, params: {} })
+                : JSON.stringify(message);
+
+        const response = await this.fetch(this.remoteUrl, {
+            method: "POST",
+            headers,
+            body,
+            signal: AbortSignal.timeout(this.timeoutMs),
+        }).catch((error: unknown) => {
+            if (error instanceof Error) {
+                if (error.name === "TimeoutError") {
+                    throw new TimeoutError(`Request timed out after ${this.timeoutMs}ms`);
+                }
+                throw new RemoteError(`Request failed: ${error.message}`, 0);
+            }
+            throw new RemoteError(`Request failed: ${String(error)}`, 0);
+        });
+
+        const resSessionId = response.headers.get("Mcp-Session-Id");
+        if (resSessionId) this.sessionId = resSessionId;
+
+        if (response.status === 401 || response.status === 403) {
+            const errorBody = await response.text();
+            this.tokenManager.invalidateToken();
+            throw new AuthError(`Authentication failed with status ${response.status}: ${errorBody}`, response.status);
+        }
+
+        return response;
+    }
+
+    private async parseResponse(response: Response, messageId: string | number): Promise<JsonRpcResponse> {
+        if (!response.ok) {
+            try {
+                // Server always returns a JSON-RPC error body, except for 413 (Content Too Large).
+                const body = (await response.json()) as JsonRpcResponse;
+                return { ...body, id: messageId };
+            } catch {
+                throw new RemoteError(`Remote server error ${response.status}`, response.status);
+            }
+        }
+
+        const contentType = response.headers.get("Content-Type") ?? "";
+        let parsed: JsonRpcResponse;
+        if (contentType.includes("text/event-stream")) {
+            const body = await response.text();
+            parsed = this.parseSSEBody(body);
+        } else {
+            parsed = (await response.json()) as JsonRpcResponse;
+        }
+
+        if (parsed.jsonrpc !== "2.0") {
+            throw new RemoteError("Invalid JSON-RPC response from remote server", 0);
+        }
+
+        return parsed;
+    }
+
+    private parseSSEBody(body: string): JsonRpcResponse {
+        const dataLines = body
+            .split(/\r\n|\r|\n/)
+            .filter((line) => line.startsWith("data:"))
+            .map((line) => line.slice(5).trimStart());
+
+        if (dataLines.length === 0) {
+            throw new RemoteError("No data found in SSE response", 0);
+        }
+
+        try {
+            return JSON.parse(dataLines.join("\n")) as JsonRpcResponse;
+        } catch {
+            throw new RemoteError("Failed to parse SSE response as JSON", 0);
+        }
+    }
+
+    private errorToResponse(id: string | number, error: unknown): JsonRpcResponse {
+        if (error instanceof TokenError) {
+            return createErrorResponse(id, JsonRpcErrorCodes.TOKEN_ERROR, `Token error: ${error.message}`, {
+                statusCode: error.statusCode,
+            });
+        }
+        if (error instanceof AuthError) {
+            return createErrorResponse(id, JsonRpcErrorCodes.TOKEN_ERROR, `Authentication error: ${error.message}`, {
+                statusCode: error.statusCode,
+            });
+        }
+        if (error instanceof TimeoutError) {
+            return createErrorResponse(id, JsonRpcErrorCodes.TIMEOUT_ERROR, error.message);
+        }
+        if (error instanceof RemoteError) {
+            return createErrorResponse(id, JsonRpcErrorCodes.REMOTE_ERROR, error.message, {
+                statusCode: error.statusCode,
+            });
+        }
+        return createErrorResponse(
+            id,
+            JsonRpcErrorCodes.INTERNAL_ERROR,
+            `Internal error: ${error instanceof Error ? error.message : String(error)}`
+        );
+    }
+}
+
+function isRequest(message: JsonRpcMessage): message is JsonRpcRequest {
+    return "method" in message && "id" in message;
+}
+
+function isNotification(message: JsonRpcMessage): message is JsonRpcNotification {
+    return "method" in message && !("id" in message);
+}

--- a/packages/mongodb-mcp-remote/src/logger.ts
+++ b/packages/mongodb-mcp-remote/src/logger.ts
@@ -1,0 +1,56 @@
+import { LOG_LEVELS } from "./common.js";
+import type { LogLevel } from "./common.js";
+
+export interface Logger {
+    setLevel(level: LogLevel): void;
+    debug(message: string, data?: unknown): void;
+    info(message: string, data?: unknown): void;
+    notice(message: string, data?: unknown): void;
+    warning(message: string, data?: unknown): void;
+    error(message: string, data?: unknown): void;
+    critical(message: string, data?: unknown): void;
+    alert(message: string, data?: unknown): void;
+    emergency(message: string, data?: unknown): void;
+}
+
+// TODO: Tmp implementation, complete logger implementation in MCP-537
+class SimpleLogger implements Logger {
+    private level: LogLevel = "info";
+
+    setLevel(level: LogLevel): void {
+        this.level = level;
+    }
+
+    private log(level: LogLevel, message: string, data?: unknown): void {
+        if (LOG_LEVELS.indexOf(level) < LOG_LEVELS.indexOf(this.level)) return;
+        const dataStr = data !== undefined ? ` ${JSON.stringify(data)}` : "";
+        console.error(`[${level.toUpperCase()}] ${message}${dataStr}`);
+    }
+
+    debug(message: string, data?: unknown): void {
+        this.log("debug", message, data);
+    }
+    info(message: string, data?: unknown): void {
+        this.log("info", message, data);
+    }
+    notice(message: string, data?: unknown): void {
+        this.log("notice", message, data);
+    }
+    warning(message: string, data?: unknown): void {
+        this.log("warning", message, data);
+    }
+    error(message: string, data?: unknown): void {
+        this.log("error", message, data);
+    }
+    critical(message: string, data?: unknown): void {
+        this.log("critical", message, data);
+    }
+    alert(message: string, data?: unknown): void {
+        this.log("alert", message, data);
+    }
+    emergency(message: string, data?: unknown): void {
+        this.log("emergency", message, data);
+    }
+}
+
+export const logger: Logger = new SimpleLogger();

--- a/packages/mongodb-mcp-remote/src/packageInfo.ts
+++ b/packages/mongodb-mcp-remote/src/packageInfo.ts
@@ -1,0 +1,4 @@
+// TODO: Add a script (similar to scripts/updatePackageVersion.ts) to keep this in sync with package.json on release.
+export const packageInfo = {
+    version: "0.0.0",
+};

--- a/packages/mongodb-mcp-remote/src/stdio.ts
+++ b/packages/mongodb-mcp-remote/src/stdio.ts
@@ -1,0 +1,69 @@
+import { createInterface } from "node:readline";
+import type { JsonRpcMessage, JsonRpcResponse, MessageProcessor } from "./common.js";
+import { JsonRpcErrorCodes, createErrorResponse } from "./common.js";
+import { logger } from "./logger.js";
+
+export class StdioTransport {
+    private rl: ReturnType<typeof createInterface> | null = null;
+
+    constructor(
+        private readonly processor: MessageProcessor,
+        private readonly onClose: () => void
+    ) {}
+
+    start(): void {
+        this.rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+        this.rl.on("line", (line) => {
+            void this.processLine(line);
+        });
+
+        this.rl.on("close", () => {
+            logger.info("Stdio transport closed");
+            this.onClose();
+        });
+
+        logger.info("Stdio transport started");
+    }
+
+    stop(): void {
+        this.rl?.close();
+        this.rl = null;
+    }
+
+    private async processLine(line: string): Promise<void> {
+        const trimmedLine = line.trim();
+        if (!trimmedLine) return;
+
+        let message: JsonRpcMessage;
+        try {
+            message = JSON.parse(trimmedLine) as JsonRpcMessage;
+        } catch (error) {
+            logger.error("Failed to parse JSON-RPC message", { error: String(error) });
+            writeError(JsonRpcErrorCodes.PARSE_ERROR, "Parse error: invalid JSON");
+            return;
+        }
+
+        if (!isValidJsonRpc(message)) {
+            writeError(JsonRpcErrorCodes.INVALID_REQUEST, "Invalid Request");
+            return;
+        }
+
+        const response = await this.processor.forward(message);
+        if (response) {
+            writeResponse(response);
+        }
+    }
+}
+
+function writeResponse(response: JsonRpcResponse): void {
+    process.stdout.write(JSON.stringify(response) + "\n");
+}
+
+function writeError(code: number, message: string): void {
+    writeResponse(createErrorResponse(null, code, message));
+}
+
+function isValidJsonRpc(message: unknown): message is JsonRpcMessage {
+    return typeof message === "object" && message !== null && (message as Record<string, unknown>)["jsonrpc"] === "2.0";
+}

--- a/packages/mongodb-mcp-remote/src/tokenManager.ts
+++ b/packages/mongodb-mcp-remote/src/tokenManager.ts
@@ -1,0 +1,103 @@
+import type { CachedToken, TokenResponse, ProxyAwareFetch } from "./common.js";
+import { packageInfo } from "./packageInfo.js";
+import { logger } from "./logger.js";
+
+const TOKEN_EXPIRY_BUFFER_MS = 10 * 60 * 1000; // 10 minutes
+
+export class TokenError extends Error {
+    constructor(
+        message: string,
+        public readonly statusCode: number
+    ) {
+        super(message);
+        this.name = "TokenError";
+    }
+}
+
+export class TokenManager {
+    private cachedToken: CachedToken | null = null;
+    private refreshPromise: Promise<string> | null = null;
+
+    private readonly userAgent = `mongodb-mcp-remote/${packageInfo.version} (${process.platform}; ${process.arch})`;
+
+    constructor(
+        private readonly tokenUrl: string,
+        private readonly clientId: string,
+        private readonly clientSecret: string,
+        private readonly timeoutMs: number,
+        private readonly fetch: ProxyAwareFetch
+    ) {}
+
+    async getToken(): Promise<string> {
+        if (this.cachedToken && Date.now() < this.cachedToken.expiresAt - TOKEN_EXPIRY_BUFFER_MS) {
+            return this.cachedToken.accessToken;
+        }
+
+        if (this.refreshPromise) {
+            return this.refreshPromise;
+        }
+
+        this.refreshPromise = this.fetchToken()
+            .then((token) => {
+                this.cachedToken = token;
+                this.refreshPromise = null;
+                return token.accessToken;
+            })
+            .catch((error) => {
+                this.refreshPromise = null;
+                throw error;
+            });
+
+        return this.refreshPromise;
+    }
+
+    invalidateToken(): void {
+        this.cachedToken = null;
+    }
+
+    private async fetchToken(): Promise<CachedToken> {
+        logger.debug("Fetching new access token");
+
+        const credentials = Buffer.from(`${this.clientId}:${this.clientSecret}`).toString("base64");
+
+        const response = await this.fetch(this.tokenUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                Accept: "application/json",
+                Authorization: `Basic ${credentials}`,
+                "User-Agent": this.userAgent,
+            },
+            body: "grant_type=client_credentials",
+            signal: AbortSignal.timeout(this.timeoutMs),
+        }).catch((error: unknown) => {
+            const isTimeout = error instanceof Error && error.name === "TimeoutError";
+            throw new TokenError(
+                isTimeout
+                    ? `Token request timed out after ${this.timeoutMs}ms`
+                    : `Token request failed: ${String(error)}`,
+                0
+            );
+        });
+
+        if (!response.ok) {
+            const body = await response.text();
+            throw new TokenError(`Token request failed with status ${response.status}: ${body}`, response.status);
+        }
+
+        const data = (await response.json()) as TokenResponse;
+
+        if (!data.access_token) {
+            throw new TokenError("Token response missing access_token", 0);
+        }
+
+        const expiresInS = data.expires_in ?? 3600;
+        const token: CachedToken = {
+            accessToken: data.access_token,
+            expiresAt: Date.now() + expiresInS * 1000,
+        };
+
+        logger.debug(`Token acquired, expires in ${expiresInS}s`);
+        return token;
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,10 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/mongodb-mcp-remote:
+    dependencies:
+      '@mongodb-js/devtools-proxy-support':
+        specifier: ^0.7.14
+        version: 0.7.14
     devDependencies:
       '@types/node':
         specifier: ^25.6.0


### PR DESCRIPTION
## Description

Ticket: MCP-536

Core logic for the `mongodb-mcp-remote` package, includes:
* stdio <-> HTTP message forwarding
* Support `MDB_MCP_API_CLIENT_ID`, `MDB_MCP_API_CLIENT_SECRET` & `MDB_MCP_API_BASE_URL` env vars.
* OAuth client-credentials token fetching, caching, refreshing.
* Proxy support (uses `devtools-proxy-support`, same as the server).
* Placeholder logger implementation.

Tested manually against cloud-dev as a standalone server and within claude code.
Unit, integration & e2e tests to be covered as part of MCP-539.