### PR TITLE
Docs/health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ npx -y mongodb-mcp-server@latest --transport http --httpHost=0.0.0.0 --httpPort=
 
 > **Note:** The default transport is `stdio`, which is suitable for integration with most MCP clients. Use `http` transport if you need to interact with the server over HTTP.
 
-##### Monitoring server (health check and metrics)
+##### Monitoring server health checks
 
 When running with `--transport http`, you can optionally start a **separate** monitoring HTTP server that exposes a health-check endpoint and, optionally, a metrics endpoint. It listens on its own host and port, independent of the main MCP HTTP server, so you can keep it on an internal-only interface.
 
@@ -286,7 +286,7 @@ The monitoring server is only started when **both** `--monitoringServerHost` and
 ```shell
 npx -y mongodb-mcp-server@latest --transport http \
   --httpHost=0.0.0.0 --httpPort=3000 \
-  --monitoringServerHost=0.0.0.0 --monitoringServerPort=8080
+  --monitoringServerHost=127.0.0.1 --monitoringServerPort=8080
 ```
 
 It exposes the following routes:
@@ -299,7 +299,7 @@ It exposes the following routes:
 Check the health endpoint:
 
 ```shell
-curl http://0.0.0.0:8080/health
+curl http://127.0.0.1:8080/health
 # {"status":"ok"}
 ```
 
@@ -308,7 +308,7 @@ Use `--monitoringServerFeatures` (or `MDB_MCP_MONITORING_SERVER_FEATURES`) to co
 ```shell
 npx -y mongodb-mcp-server@latest --transport http \
   --httpHost=0.0.0.0 --httpPort=3000 \
-  --monitoringServerHost=0.0.0.0 --monitoringServerPort=8080 \
+  --monitoringServerHost=127.0.0.1 --monitoringServerPort=8080 \
   --monitoringServerFeatures=health-check,metrics
 ```
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,47 @@ npx -y mongodb-mcp-server@latest --transport http --httpHost=0.0.0.0 --httpPort=
 
 > **Note:** The default transport is `stdio`, which is suitable for integration with most MCP clients. Use `http` transport if you need to interact with the server over HTTP.
 
+##### Monitoring server (health check and metrics)
+
+When running with `--transport http`, you can optionally start a **separate** monitoring HTTP server that exposes a health-check endpoint and, optionally, a metrics endpoint. It listens on its own host and port, independent of the main MCP HTTP server, so you can keep it on an internal-only interface.
+
+The monitoring server is only started when **both** `--monitoringServerHost` and `--monitoringServerPort` are set (setting only one of them is rejected at startup). It is disabled by default.
+
+```shell
+npx -y mongodb-mcp-server@latest --transport http \
+  --httpHost=0.0.0.0 --httpPort=3000 \
+  --monitoringServerHost=0.0.0.0 --monitoringServerPort=8080
+```
+
+It exposes the following routes:
+
+| Route      | Enabled by                       | Response                                                    |
+| ---------- | -------------------------------- | ----------------------------------------------------------- |
+| `/health`  | `health-check` feature (default) | `200` with `{"status":"ok"}`                                |
+| `/metrics` | `metrics` feature                | `200` with `text/plain` metrics for scraping by a collector |
+
+Check the health endpoint:
+
+```shell
+curl http://0.0.0.0:8080/health
+# {"status":"ok"}
+```
+
+Use `--monitoringServerFeatures` (or `MDB_MCP_MONITORING_SERVER_FEATURES`) to control which routes are exposed. It accepts a comma-separated list and defaults to `health-check`. To expose both the health check and metrics:
+
+```shell
+npx -y mongodb-mcp-server@latest --transport http \
+  --httpHost=0.0.0.0 --httpPort=3000 \
+  --monitoringServerHost=0.0.0.0 --monitoringServerPort=8080 \
+  --monitoringServerFeatures=health-check,metrics
+```
+
+- `--monitoringServerHost` (default: `<not set>`): Host to bind the monitoring server to.
+- `--monitoringServerPort` (default: `<not set>`): Port for the monitoring server.
+- `--monitoringServerFeatures` (default: `health-check`): Comma-separated features to expose (`health-check`, `metrics`).
+
+> **Note:** The `--healthCheckHost` and `--healthCheckPort` options are deprecated aliases for `--monitoringServerHost` and `--monitoringServerPort`; prefer the `monitoringServer*` options.
+
 #### Option 6: Copilot CLI
 
 You can use the Copilot CLI to interactively add the MCP server:


### PR DESCRIPTION
## Proposed changes
Adds a "Monitoring server" subsection under the HTTP transport docs, documenting the optional monitoring HTTP server exposed when running with `--transport http`:

  - documents the `/health` route (returns `{"status":"ok"}`) and the `/metrics` route
  - explains that the monitoring server starts only when both `--monitoringServerHost` and `--monitoringServerPort` are set
  - documents `--monitoringServerFeatures` (default `health-check`, optional `metrics`)
  - notes the deprecated `--healthCheckHost` / `--healthCheckPort` aliases
  - adds a runnable example with a `curl` health check

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
