### PR TITLE
feat: log x-request-id MCP-560

### DIFF
--- a/src/common/atlas/accessListUtils.ts
+++ b/src/common/atlas/accessListUtils.ts
@@ -1,4 +1,5 @@
-import { type ApiClient, type ApiClientRequestContext, requestIdAttr } from "./apiClient.js";
+import { type ApiClient, type ApiClientRequestContext } from "./apiClient.js";
+import { requestIdAttr } from "../../helpers/requestIdAttr.js";
 import { LogId } from "../logging/index.js";
 import { ApiClientError } from "./apiClientError.js";
 
@@ -42,7 +43,7 @@ export async function ensureCurrentIpInAccessList(
             id: LogId.atlasIpAccessListAdded,
             context: "accessListUtils",
             message: `IP access list created: ${JSON.stringify(entry)}`,
-            attributes: { ...requestIdAttr(context) },
+            attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
         });
         return true;
     } catch (err) {
@@ -52,7 +53,7 @@ export async function ensureCurrentIpInAccessList(
                 id: LogId.atlasIpAccessListAdded,
                 context: "accessListUtils",
                 message: `IP address ${entry.ipAddress} is already present in the access list for project ${projectId}.`,
-                attributes: { ...requestIdAttr(context) },
+                attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
             });
             return false;
         }
@@ -60,7 +61,7 @@ export async function ensureCurrentIpInAccessList(
             id: LogId.atlasIpAccessListAddFailure,
             context: "accessListUtils",
             message: `Error adding IP access list: ${err instanceof Error ? err.message : String(err)}`,
-            attributes: { ...requestIdAttr(context) },
+            attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
         });
     }
     return false;

--- a/src/common/atlas/accessListUtils.ts
+++ b/src/common/atlas/accessListUtils.ts
@@ -1,4 +1,4 @@
-import type { ApiClient, ApiClientRequestContext } from "./apiClient.js";
+import { type ApiClient, type ApiClientRequestContext, requestIdAttr } from "./apiClient.js";
 import { LogId } from "../logging/index.js";
 import { ApiClientError } from "./apiClientError.js";
 
@@ -42,6 +42,7 @@ export async function ensureCurrentIpInAccessList(
             id: LogId.atlasIpAccessListAdded,
             context: "accessListUtils",
             message: `IP access list created: ${JSON.stringify(entry)}`,
+            attributes: { ...requestIdAttr(context) },
         });
         return true;
     } catch (err) {
@@ -51,6 +52,7 @@ export async function ensureCurrentIpInAccessList(
                 id: LogId.atlasIpAccessListAdded,
                 context: "accessListUtils",
                 message: `IP address ${entry.ipAddress} is already present in the access list for project ${projectId}.`,
+                attributes: { ...requestIdAttr(context) },
             });
             return false;
         }
@@ -58,6 +60,7 @@ export async function ensureCurrentIpInAccessList(
             id: LogId.atlasIpAccessListAddFailure,
             context: "accessListUtils",
             message: `Error adding IP access list: ${err instanceof Error ? err.message : String(err)}`,
+            attributes: { ...requestIdAttr(context) },
         });
     }
     return false;

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -46,12 +46,6 @@ export type ApiClientRequestContext = {
     };
 };
 
-/** Returns `{ "x-request-id": "..." }` when the context carries one, else `{}`. Spread inside a LogPayload's `attributes` field. */
-export function requestIdAttr(context: ApiClientRequestContext | undefined): Record<string, string> {
-    const id = context?.requestInfo?.headers?.["x-request-id"];
-    return typeof id === "string" ? { "x-request-id": id } : {};
-}
-
 /**
  * Allowlist of incoming MCP request header names that may be forwarded to outgoing
  * Atlas API requests. Kept intentionally minimal to avoid propagating hop-by-hop

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -46,6 +46,12 @@ export type ApiClientRequestContext = {
     };
 };
 
+/** Returns `{ "x-request-id": "..." }` when the context carries one, else `{}`. Spread inside a LogPayload's `attributes` field. */
+export function requestIdAttr(context: ApiClientRequestContext | undefined): Record<string, string> {
+    const id = context?.requestInfo?.headers?.["x-request-id"];
+    return typeof id === "string" ? { "x-request-id": id } : {};
+}
+
 /**
  * Allowlist of incoming MCP request header names that may be forwarded to outgoing
  * Atlas API requests. Kept intentionally minimal to avoid propagating hop-by-hop

--- a/src/common/atlas/cluster.ts
+++ b/src/common/atlas/cluster.ts
@@ -3,7 +3,7 @@ import type {
     ClusterDescription20240805,
     FlexClusterDescription20241113,
 } from "./openapi.js";
-import type { ApiClient, ApiClientRequestContext } from "./apiClient.js";
+import { type ApiClient, type ApiClientRequestContext, requestIdAttr } from "./apiClient.js";
 import { LogId } from "../logging/index.js";
 import { ConnectionString } from "mongodb-connection-string-url";
 
@@ -135,6 +135,7 @@ export async function inspectCluster(
                 id: LogId.atlasInspectFailure,
                 context: "inspect-cluster",
                 message: `error inspecting cluster: ${err.message}`,
+                attributes: { ...requestIdAttr(context) },
             });
             throw error;
         }

--- a/src/common/atlas/cluster.ts
+++ b/src/common/atlas/cluster.ts
@@ -3,7 +3,8 @@ import type {
     ClusterDescription20240805,
     FlexClusterDescription20241113,
 } from "./openapi.js";
-import { type ApiClient, type ApiClientRequestContext, requestIdAttr } from "./apiClient.js";
+import { type ApiClient, type ApiClientRequestContext } from "./apiClient.js";
+import { requestIdAttr } from "../../helpers/requestIdAttr.js";
 import { LogId } from "../logging/index.js";
 import { ConnectionString } from "mongodb-connection-string-url";
 
@@ -135,7 +136,7 @@ export async function inspectCluster(
                 id: LogId.atlasInspectFailure,
                 context: "inspect-cluster",
                 message: `error inspecting cluster: ${err.message}`,
-                attributes: { ...requestIdAttr(context) },
+                attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
             });
             throw error;
         }

--- a/src/common/atlas/performanceAdvisorUtils.ts
+++ b/src/common/atlas/performanceAdvisorUtils.ts
@@ -1,5 +1,6 @@
 import { LogId } from "../logging/index.js";
-import { type ApiClient, type ApiClientRequestContext, requestIdAttr } from "./apiClient.js";
+import { type ApiClient, type ApiClientRequestContext } from "./apiClient.js";
+import { requestIdAttr } from "../../helpers/requestIdAttr.js";
 import { getProcessIdsFromCluster } from "./cluster.js";
 import type { components } from "./openapi.js";
 
@@ -49,7 +50,7 @@ export async function getSuggestedIndexes(
             id: LogId.atlasPaSuggestedIndexesFailure,
             context: "performanceAdvisorUtils",
             message: `Failed to list suggested indexes: ${err instanceof Error ? err.message : String(err)}`,
-            attributes: { ...requestIdAttr(context) },
+            attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
         });
         throw new Error(`Failed to list suggested indexes: ${err instanceof Error ? err.message : String(err)}`, {
             cause: err,
@@ -89,7 +90,7 @@ export async function getDropIndexSuggestions(
             id: LogId.atlasPaDropIndexSuggestionsFailure,
             context: "performanceAdvisorUtils",
             message: `Failed to list drop index suggestions: ${err instanceof Error ? err.message : String(err)}`,
-            attributes: { ...requestIdAttr(context) },
+            attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
         });
         throw new Error(`Failed to list drop index suggestions: ${err instanceof Error ? err.message : String(err)}`, {
             cause: err,
@@ -121,7 +122,7 @@ export async function getSchemaAdvice(
             id: LogId.atlasPaSchemaAdviceFailure,
             context: "performanceAdvisorUtils",
             message: `Failed to list schema advice: ${err instanceof Error ? err.message : String(err)}`,
-            attributes: { ...requestIdAttr(context) },
+            attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
         });
         throw new Error(`Failed to list schema advice: ${err instanceof Error ? err.message : String(err)}`, {
             cause: err,
@@ -175,7 +176,7 @@ export async function getSlowQueries(
             id: LogId.atlasPaSlowQueryLogsFailure,
             context: "performanceAdvisorUtils",
             message: `Failed to list slow query logs: ${err instanceof Error ? err.message : String(err)}`,
-            attributes: { ...requestIdAttr(context) },
+            attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
         });
         throw new Error(`Failed to list slow query logs: ${err instanceof Error ? err.message : String(err)}`, {
             cause: err,

--- a/src/common/atlas/performanceAdvisorUtils.ts
+++ b/src/common/atlas/performanceAdvisorUtils.ts
@@ -1,5 +1,5 @@
 import { LogId } from "../logging/index.js";
-import type { ApiClient, ApiClientRequestContext } from "./apiClient.js";
+import { type ApiClient, type ApiClientRequestContext, requestIdAttr } from "./apiClient.js";
 import { getProcessIdsFromCluster } from "./cluster.js";
 import type { components } from "./openapi.js";
 
@@ -49,6 +49,7 @@ export async function getSuggestedIndexes(
             id: LogId.atlasPaSuggestedIndexesFailure,
             context: "performanceAdvisorUtils",
             message: `Failed to list suggested indexes: ${err instanceof Error ? err.message : String(err)}`,
+            attributes: { ...requestIdAttr(context) },
         });
         throw new Error(`Failed to list suggested indexes: ${err instanceof Error ? err.message : String(err)}`, {
             cause: err,
@@ -88,6 +89,7 @@ export async function getDropIndexSuggestions(
             id: LogId.atlasPaDropIndexSuggestionsFailure,
             context: "performanceAdvisorUtils",
             message: `Failed to list drop index suggestions: ${err instanceof Error ? err.message : String(err)}`,
+            attributes: { ...requestIdAttr(context) },
         });
         throw new Error(`Failed to list drop index suggestions: ${err instanceof Error ? err.message : String(err)}`, {
             cause: err,
@@ -119,6 +121,7 @@ export async function getSchemaAdvice(
             id: LogId.atlasPaSchemaAdviceFailure,
             context: "performanceAdvisorUtils",
             message: `Failed to list schema advice: ${err instanceof Error ? err.message : String(err)}`,
+            attributes: { ...requestIdAttr(context) },
         });
         throw new Error(`Failed to list schema advice: ${err instanceof Error ? err.message : String(err)}`, {
             cause: err,
@@ -172,6 +175,7 @@ export async function getSlowQueries(
             id: LogId.atlasPaSlowQueryLogsFailure,
             context: "performanceAdvisorUtils",
             message: `Failed to list slow query logs: ${err instanceof Error ? err.message : String(err)}`,
+            attributes: { ...requestIdAttr(context) },
         });
         throw new Error(`Failed to list slow query logs: ${err instanceof Error ? err.message : String(err)}`, {
             cause: err,

--- a/src/common/atlas/sharedTierAlertsHook.ts
+++ b/src/common/atlas/sharedTierAlertsHook.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { type ApiClient, type ApiClientRequestContext, requestIdAttr } from "./apiClient.js";
+import { type ApiClient, type ApiClientRequestContext } from "./apiClient.js";
+import { requestIdAttr } from "../../helpers/requestIdAttr.js";
 import type { LoggerBase } from "../logging/loggerBase.js";
 import { LogId } from "../logging/index.js";
 import { SHARED_TIER_METRIC_NAMES } from "../../telemetry/types.js";
@@ -80,7 +81,7 @@ export async function runSharedTierAlertsHook({
             id: LogId.atlasSharedTierAlertsHookWarning,
             context: "shared-tier-alerts-hook",
             message: `Failed to list Atlas alerts for shared-tier hook: ${message}`,
-            attributes: { ...requestIdAttr(context) },
+            attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
         });
         return undefined;
     }

--- a/src/common/atlas/sharedTierAlertsHook.ts
+++ b/src/common/atlas/sharedTierAlertsHook.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ApiClient, ApiClientRequestContext } from "./apiClient.js";
+import { type ApiClient, type ApiClientRequestContext, requestIdAttr } from "./apiClient.js";
 import type { LoggerBase } from "../logging/loggerBase.js";
 import { LogId } from "../logging/index.js";
 import { SHARED_TIER_METRIC_NAMES } from "../../telemetry/types.js";
@@ -80,6 +80,7 @@ export async function runSharedTierAlertsHook({
             id: LogId.atlasSharedTierAlertsHookWarning,
             context: "shared-tier-alerts-hook",
             message: `Failed to list Atlas alerts for shared-tier hook: ${message}`,
+            attributes: { ...requestIdAttr(context) },
         });
         return undefined;
     }

--- a/src/helpers/requestIdAttr.ts
+++ b/src/helpers/requestIdAttr.ts
@@ -1,0 +1,5 @@
+/** Returns `{ "x-request-id": "..." }` when the headers carry one, else `{}`. Spread inside a LogPayload's `attributes` field. */
+export function requestIdAttr(headers: Record<string, unknown> | undefined): Record<string, string> {
+    const id = headers?.["x-request-id"];
+    return typeof id === "string" ? { "x-request-id": id } : {};
+}

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -1,10 +1,5 @@
-import {
-    type OperationType,
-    type ToolArgs,
-    type ToolResult,
-    type ToolExecutionContext,
-    requestIdAttr,
-} from "../../tool.js";
+import { type OperationType, type ToolArgs, type ToolResult, type ToolExecutionContext } from "../../tool.js";
+import { requestIdAttr } from "../../../helpers/requestIdAttr.js";
 import { z } from "zod";
 import { AtlasToolBase } from "../atlasTool.js";
 import { generateSecurePassword } from "../../../helpers/generatePassword.js";
@@ -173,7 +168,7 @@ export class ConnectClusterTool extends AtlasToolBase {
             context: "atlas-connect-cluster",
             message: `attempting to connect to cluster: ${this.session.connectedAtlasCluster?.clusterName}`,
             noRedaction: true,
-            attributes: { ...requestIdAttr(context) },
+            attributes: { ...requestIdAttr(context.requestInfo?.headers) },
         });
 
         // try to connect for about 5 minutes
@@ -192,7 +187,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                     id: LogId.atlasConnectFailure,
                     context: "atlas-connect-cluster",
                     message: `error connecting to cluster: ${error.message}`,
-                    attributes: { ...requestIdAttr(context) },
+                    attributes: { ...requestIdAttr(context.requestInfo?.headers) },
                 });
 
                 await sleep(500); // wait for 500ms before retrying
@@ -232,7 +227,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                             id: LogId.atlasConnectFailure,
                             context: "atlas-connect-cluster",
                             message: `error deleting database user: ${error.message}`,
-                            attributes: { ...requestIdAttr(context) },
+                            attributes: { ...requestIdAttr(context.requestInfo?.headers) },
                         });
                     });
             }
@@ -244,7 +239,7 @@ export class ConnectClusterTool extends AtlasToolBase {
             context: "atlas-connect-cluster",
             message: `connected to cluster: ${this.session.connectedAtlasCluster?.clusterName}`,
             noRedaction: true,
-            attributes: { ...requestIdAttr(context) },
+            attributes: { ...requestIdAttr(context.requestInfo?.headers) },
         });
     }
 

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -1,4 +1,10 @@
-import { type OperationType, type ToolArgs, type ToolResult, type ToolExecutionContext } from "../../tool.js";
+import {
+    type OperationType,
+    type ToolArgs,
+    type ToolResult,
+    type ToolExecutionContext,
+    requestIdAttr,
+} from "../../tool.js";
 import { z } from "zod";
 import { AtlasToolBase } from "../atlasTool.js";
 import { generateSecurePassword } from "../../../helpers/generatePassword.js";
@@ -167,6 +173,7 @@ export class ConnectClusterTool extends AtlasToolBase {
             context: "atlas-connect-cluster",
             message: `attempting to connect to cluster: ${this.session.connectedAtlasCluster?.clusterName}`,
             noRedaction: true,
+            attributes: { ...requestIdAttr(context) },
         });
 
         // try to connect for about 5 minutes
@@ -185,6 +192,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                     id: LogId.atlasConnectFailure,
                     context: "atlas-connect-cluster",
                     message: `error connecting to cluster: ${error.message}`,
+                    attributes: { ...requestIdAttr(context) },
                 });
 
                 await sleep(500); // wait for 500ms before retrying
@@ -224,6 +232,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                             id: LogId.atlasConnectFailure,
                             context: "atlas-connect-cluster",
                             message: `error deleting database user: ${error.message}`,
+                            attributes: { ...requestIdAttr(context) },
                         });
                     });
             }
@@ -235,6 +244,7 @@ export class ConnectClusterTool extends AtlasToolBase {
             context: "atlas-connect-cluster",
             message: `connected to cluster: ${this.session.connectedAtlasCluster?.clusterName}`,
             noRedaction: true,
+            attributes: { ...requestIdAttr(context) },
         });
     }
 

--- a/src/tools/atlas/streams/manage.ts
+++ b/src/tools/atlas/streams/manage.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { StreamsToolBase } from "./streamsToolBase.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { type OperationType, type ToolArgs, type ToolExecutionContext, requestIdAttr } from "../../tool.js";
+import { type OperationType, type ToolArgs, type ToolExecutionContext } from "../../tool.js";
+import { requestIdAttr } from "../../../helpers/requestIdAttr.js";
 import { AtlasArgs } from "../../args.js";
 import { ConnectionConfig, StreamsArgs } from "./streamsArgs.js";
 import { LogId } from "../../../common/logging/index.js";
@@ -323,7 +324,7 @@ export class StreamsManageTool extends StreamsToolBase {
                 id: LogId.streamsProcessorStateLookupFailure,
                 context: "streams-manage",
                 message: `Failed to get processor state before stop: ${error instanceof Error ? error.message : String(error)}`,
-                attributes: { ...requestIdAttr(context) },
+                attributes: { ...requestIdAttr(context.requestInfo?.headers) },
             });
         }
 

--- a/src/tools/atlas/streams/manage.ts
+++ b/src/tools/atlas/streams/manage.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { StreamsToolBase } from "./streamsToolBase.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import type { OperationType, ToolArgs, ToolExecutionContext } from "../../tool.js";
+import { type OperationType, type ToolArgs, type ToolExecutionContext, requestIdAttr } from "../../tool.js";
 import { AtlasArgs } from "../../args.js";
 import { ConnectionConfig, StreamsArgs } from "./streamsArgs.js";
 import { LogId } from "../../../common/logging/index.js";
@@ -323,6 +323,7 @@ export class StreamsManageTool extends StreamsToolBase {
                 id: LogId.streamsProcessorStateLookupFailure,
                 context: "streams-manage",
                 message: `Failed to get processor state before stop: ${error instanceof Error ? error.message : String(error)}`,
+                attributes: { ...requestIdAttr(context) },
             });
         }
 

--- a/src/tools/atlas/streams/teardown.ts
+++ b/src/tools/atlas/streams/teardown.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { StreamsToolBase } from "./streamsToolBase.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import type { OperationType, ToolArgs, ToolExecutionContext } from "../../tool.js";
+import { type OperationType, type ToolArgs, type ToolExecutionContext, requestIdAttr } from "../../tool.js";
 import { AtlasArgs } from "../../args.js";
 import { StreamsArgs } from "./streamsArgs.js";
 import { LogId } from "../../../common/logging/index.js";
@@ -136,6 +136,7 @@ export class StreamsTeardownTool extends StreamsToolBase {
                 id: LogId.streamsProcessorStateLookupFailure,
                 context: "streams-teardown",
                 message: `Failed to get processor state before delete: ${error instanceof Error ? error.message : String(error)}`,
+                attributes: { ...requestIdAttr(context) },
             });
         }
 

--- a/src/tools/atlas/streams/teardown.ts
+++ b/src/tools/atlas/streams/teardown.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { StreamsToolBase } from "./streamsToolBase.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { type OperationType, type ToolArgs, type ToolExecutionContext, requestIdAttr } from "../../tool.js";
+import { type OperationType, type ToolArgs, type ToolExecutionContext } from "../../tool.js";
+import { requestIdAttr } from "../../../helpers/requestIdAttr.js";
 import { AtlasArgs } from "../../args.js";
 import { StreamsArgs } from "./streamsArgs.js";
 import { LogId } from "../../../common/logging/index.js";
@@ -136,7 +137,7 @@ export class StreamsTeardownTool extends StreamsToolBase {
                 id: LogId.streamsProcessorStateLookupFailure,
                 context: "streams-teardown",
                 message: `Failed to get processor state before delete: ${error instanceof Error ? error.message : String(error)}`,
-                attributes: { ...requestIdAttr(context) },
+                attributes: { ...requestIdAttr(context.requestInfo?.headers) },
             });
         }
 

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -31,6 +31,12 @@ export interface ToolExecutionContext {
     };
 }
 
+/** Returns `{ "x-request-id": "..." }` when the context carries one, else `{}`. Spread inside a LogPayload's `attributes` field. */
+export function requestIdAttr(context: ToolExecutionContext): { "x-request-id": string } | Record<never, never> {
+    const id = context.requestInfo?.headers?.["x-request-id"];
+    return typeof id === "string" ? { "x-request-id": id } : {};
+}
+
 export type ToolResult<OutputSchema extends ZodRawShape | undefined = undefined> = OutputSchema extends ZodRawShape
     ? StructuredToolResult<OutputSchema>
     : { content: { type: "text"; text: string }[]; isError?: boolean };
@@ -495,6 +501,7 @@ export abstract class ToolBase<
                         context: "tool",
                         message: `User did not confirm the execution of the \`${this.name}\` tool so the operation was not performed.`,
                         noRedaction: true,
+                        attributes: { ...requestIdAttr(context) },
                     });
                     return {
                         content: [
@@ -516,6 +523,7 @@ export abstract class ToolBase<
                 context: "tool",
                 message: `Executing tool ${this.name}`,
                 noRedaction: true,
+                attributes: { ...requestIdAttr(context) },
             });
 
             const toolCallResult = await this.execute(args, context);
@@ -540,6 +548,7 @@ export abstract class ToolBase<
                 context: "tool",
                 message: `Executed tool ${this.name}`,
                 noRedaction: true,
+                attributes: { ...requestIdAttr(context) },
             });
             return result;
         } catch (error: unknown) {
@@ -547,6 +556,7 @@ export abstract class ToolBase<
                 id: LogId.toolExecuteFailure,
                 context: "tool",
                 message: `Error executing ${this.name}: ${error as string}`,
+                attributes: { ...requestIdAttr(context) },
             });
             const toolResult = await this.handleError(error, args);
             this.emitToolEvent(args, { startTime, result: toolResult });

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -13,6 +13,7 @@ import type { UIRegistry } from "../ui/registry/index.js";
 import { createUIResource, type UIResource } from "@mcp-ui/server";
 import { TRANSPORT_PAYLOAD_LIMITS, type TransportType } from "../transports/constants.js";
 import { getRandomUUID } from "../helpers/getRandomUUID.js";
+import { requestIdAttr } from "../helpers/requestIdAttr.js";
 import type { Metrics, DefaultMetrics } from "@mongodb-js/mcp-metrics";
 import { redact } from "mongodb-redact";
 
@@ -29,12 +30,6 @@ export interface ToolExecutionContext {
     requestInfo?: {
         headers?: Record<string, unknown>;
     };
-}
-
-/** Returns `{ "x-request-id": "..." }` when the context carries one, else `{}`. Spread inside a LogPayload's `attributes` field. */
-export function requestIdAttr(context: ToolExecutionContext): { "x-request-id": string } | Record<never, never> {
-    const id = context.requestInfo?.headers?.["x-request-id"];
-    return typeof id === "string" ? { "x-request-id": id } : {};
 }
 
 export type ToolResult<OutputSchema extends ZodRawShape | undefined = undefined> = OutputSchema extends ZodRawShape
@@ -501,7 +496,7 @@ export abstract class ToolBase<
                         context: "tool",
                         message: `User did not confirm the execution of the \`${this.name}\` tool so the operation was not performed.`,
                         noRedaction: true,
-                        attributes: { ...requestIdAttr(context) },
+                        attributes: { ...requestIdAttr(context.requestInfo?.headers) },
                     });
                     return {
                         content: [
@@ -523,7 +518,7 @@ export abstract class ToolBase<
                 context: "tool",
                 message: `Executing tool ${this.name}`,
                 noRedaction: true,
-                attributes: { ...requestIdAttr(context) },
+                attributes: { ...requestIdAttr(context.requestInfo?.headers) },
             });
 
             const toolCallResult = await this.execute(args, context);
@@ -548,7 +543,7 @@ export abstract class ToolBase<
                 context: "tool",
                 message: `Executed tool ${this.name}`,
                 noRedaction: true,
-                attributes: { ...requestIdAttr(context) },
+                attributes: { ...requestIdAttr(context.requestInfo?.headers) },
             });
             return result;
         } catch (error: unknown) {
@@ -556,7 +551,7 @@ export abstract class ToolBase<
                 id: LogId.toolExecuteFailure,
                 context: "tool",
                 message: `Error executing ${this.name}: ${error as string}`,
-                attributes: { ...requestIdAttr(context) },
+                attributes: { ...requestIdAttr(context.requestInfo?.headers) },
             });
             const toolResult = await this.handleError(error, args);
             this.emitToolEvent(args, { startTime, result: toolResult });

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -14,6 +14,7 @@ import {
 import { ConfigOverrideError } from "../common/config/configOverrides.js";
 import type { CustomizableServerOptions, CustomizableSessionOptions, TransportRequestContext } from "./base.js";
 import { ExpressBasedHttpServer } from "./expressBasedHttpServer.js";
+import { requestIdAttr } from "../helpers/requestIdAttr.js";
 import {
     JSON_RPC_ERROR_CODE_SESSION_ID_REQUIRED,
     JSON_RPC_ERROR_CODE_SESSION_ID_INVALID,
@@ -192,9 +193,7 @@ export class MCPHttpServer<
         const { StreamableHTTPServerTransport } = await import("@modelcontextprotocol/sdk/server/streamableHttp.js");
 
         const sessionId = providedSessionId ?? getRandomUUID();
-        const requestId = req.headers["x-request-id"];
-        const requestIdAttrs: Record<string, string> =
-            typeof requestId === "string" ? { "x-request-id": requestId } : {};
+        const requestIdAttrs = requestIdAttr(req.headers);
 
         // Check if session already exists
         if (await this.sessionStore.getSession(sessionId)) {
@@ -339,9 +338,7 @@ export class MCPHttpServer<
                 return this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_INVALID);
             }
 
-            const requestId = req.headers["x-request-id"];
-            const requestIdAttrs: Record<string, string> =
-                typeof requestId === "string" ? { "x-request-id": requestId } : {};
+            const requestIdAttrs = requestIdAttr(req.headers);
 
             let transport = await this.sessionStore.getSession(sessionId);
             if (!transport) {
@@ -380,12 +377,11 @@ export class MCPHttpServer<
 
                 if (isInitializeRequest(req.body)) {
                     if (sessionId && !this.userConfig.externallyManagedSessions) {
-                        const reqId = req.headers["x-request-id"];
                         this.logger.debug({
                             id: LogId.streamableHttpTransportDisallowedExternalSessionError,
                             context: "streamableHttpTransport",
                             message: `Client provided session ID ${sessionId}, but externallyManagedSessions is disabled`,
-                            attributes: typeof reqId === "string" ? { "x-request-id": reqId } : {},
+                            attributes: requestIdAttr(req.headers),
                         });
 
                         return this.reportSessionError(res, JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION);
@@ -431,12 +427,11 @@ export class MCPHttpServer<
     ) {
         return (req: express.Request, res: express.Response, next: express.NextFunction): void => {
             fn(req, res, next).catch((error) => {
-                const reqId = req.headers["x-request-id"];
                 this.logger.error({
                     id: LogId.streamableHttpTransportRequestFailure,
                     context: "streamableHttpTransport",
                     message: `Error handling request: ${error instanceof Error ? error.message : String(error)}`,
-                    attributes: typeof reqId === "string" ? { "x-request-id": reqId } : {},
+                    attributes: requestIdAttr(req.headers),
                 });
 
                 const message = error instanceof ConfigOverrideError ? error.message : `failed to handle request`;

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -192,6 +192,9 @@ export class MCPHttpServer<
         const { StreamableHTTPServerTransport } = await import("@modelcontextprotocol/sdk/server/streamableHttp.js");
 
         const sessionId = providedSessionId ?? getRandomUUID();
+        const requestId = req.headers["x-request-id"];
+        const requestIdAttrs: Record<string, string> =
+            typeof requestId === "string" ? { "x-request-id": requestId } : {};
 
         // Check if session already exists
         if (await this.sessionStore.getSession(sessionId)) {
@@ -205,6 +208,7 @@ export class MCPHttpServer<
                 id: LogId.streamableHttpTransportSessionNotFound,
                 context: "streamableHttpTransport",
                 message: `Session with ID ${sessionId} is already being initialized, waiting`,
+                attributes: { ...requestIdAttrs },
             });
             try {
                 await pendingInit;
@@ -219,6 +223,7 @@ export class MCPHttpServer<
             id: LogId.streamableHttpTransportSessionNotFound,
             context: "streamableHttpTransport",
             message: `Session with ID ${sessionId} not found, initializing new session`,
+            ...requestIdAttrs,
         });
 
         const initPromise = (async (): Promise<void> => {
@@ -288,6 +293,7 @@ export class MCPHttpServer<
                 id: LogId.streamableHttpTransportRequestFailure,
                 context: "streamableHttpTransport",
                 message: `Failed to initialize session ${sessionId}: ${error instanceof Error ? error.message : String(error)}`,
+                attributes: { ...requestIdAttrs },
             });
             // Remove the partially initialized session on failure so that
             // subsequent requests don't see a broken session and can retry

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -223,7 +223,9 @@ export class MCPHttpServer<
             id: LogId.streamableHttpTransportSessionNotFound,
             context: "streamableHttpTransport",
             message: `Session with ID ${sessionId} not found, initializing new session`,
-            ...requestIdAttrs,
+            attributes: {
+                ...requestIdAttrs,
+            },
         });
 
         const initPromise = (async (): Promise<void> => {
@@ -337,6 +339,10 @@ export class MCPHttpServer<
                 return this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_INVALID);
             }
 
+            const requestId = req.headers["x-request-id"];
+            const requestIdAttrs: Record<string, string> =
+                typeof requestId === "string" ? { "x-request-id": requestId } : {};
+
             let transport = await this.sessionStore.getSession(sessionId);
             if (!transport) {
                 if (!this.userConfig.externallyManagedSessions) {
@@ -344,6 +350,7 @@ export class MCPHttpServer<
                         id: LogId.streamableHttpTransportSessionNotFound,
                         context: "streamableHttpTransport",
                         message: `Session with ID ${sessionId} not found`,
+                        attributes: { ...requestIdAttrs },
                     });
 
                     return this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND);
@@ -373,10 +380,12 @@ export class MCPHttpServer<
 
                 if (isInitializeRequest(req.body)) {
                     if (sessionId && !this.userConfig.externallyManagedSessions) {
+                        const reqId = req.headers["x-request-id"];
                         this.logger.debug({
                             id: LogId.streamableHttpTransportDisallowedExternalSessionError,
                             context: "streamableHttpTransport",
                             message: `Client provided session ID ${sessionId}, but externallyManagedSessions is disabled`,
+                            attributes: typeof reqId === "string" ? { "x-request-id": reqId } : {},
                         });
 
                         return this.reportSessionError(res, JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION);
@@ -422,10 +431,12 @@ export class MCPHttpServer<
     ) {
         return (req: express.Request, res: express.Response, next: express.NextFunction): void => {
             fn(req, res, next).catch((error) => {
+                const reqId = req.headers["x-request-id"];
                 this.logger.error({
                     id: LogId.streamableHttpTransportRequestFailure,
                     context: "streamableHttpTransport",
                     message: `Error handling request: ${error instanceof Error ? error.message : String(error)}`,
+                    attributes: typeof reqId === "string" ? { "x-request-id": reqId } : {},
                 });
 
                 const message = error instanceof ConfigOverrideError ? error.message : `failed to handle request`;

--- a/tests/unit/accessListUtils.test.ts
+++ b/tests/unit/accessListUtils.test.ts
@@ -3,6 +3,7 @@ import type { ApiClient } from "../../src/common/atlas/apiClient.js";
 import { ensureCurrentIpInAccessList, DEFAULT_ACCESS_LIST_COMMENT } from "../../src/common/atlas/accessListUtils.js";
 import { ApiClientError } from "../../src/common/atlas/apiClientError.js";
 import { NullLogger } from "../../src/common/logging/index.js";
+import type { LoggerBase } from "../../src/common/logging/loggerBase.js";
 
 describe("accessListUtils", () => {
     it("should add the current IP to the access list", async () => {
@@ -43,6 +44,67 @@ describe("accessListUtils", () => {
                 body: [{ groupId: "projectId", ipAddress: "127.0.0.1", comment: DEFAULT_ACCESS_LIST_COMMENT }],
             },
             undefined
+        );
+    });
+
+    const context = { requestInfo: { headers: { "x-request-id": "req-access-1" } } };
+
+    function makeSpyApiClient(createResult: "resolve" | "conflict" | "error"): ApiClient & {
+        logger: { debug: ReturnType<typeof vi.fn>; warning: ReturnType<typeof vi.fn> };
+    } {
+        const logger = { debug: vi.fn(), warning: vi.fn() } as unknown as LoggerBase;
+        let createMock: ReturnType<typeof vi.fn>;
+        if (createResult === "resolve") {
+            createMock = vi.fn().mockResolvedValue(undefined);
+        } else if (createResult === "conflict") {
+            createMock = vi.fn().mockRejectedValue(
+                ApiClientError.fromError(
+                    { status: 409, statusText: "Conflict" } as Response,
+                    {
+                        message: "Conflict",
+                    } as never
+                )
+            );
+        } else {
+            createMock = vi.fn().mockRejectedValue(new Error("network error"));
+        }
+        return {
+            getIpInfo: vi.fn().mockResolvedValue({ currentIpv4Address: "1.2.3.4" }),
+            createAccessListEntry: createMock,
+            logger,
+        } as unknown as ApiClient & { logger: { debug: ReturnType<typeof vi.fn>; warning: ReturnType<typeof vi.fn> } };
+    }
+
+    it("includes x-request-id in debug log when IP is added", async () => {
+        const apiClient = makeSpyApiClient("resolve");
+        await ensureCurrentIpInAccessList(apiClient, "proj1", context);
+        expect(apiClient.logger.debug).toHaveBeenCalledWith(
+            expect.objectContaining({
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                attributes: expect.objectContaining({ "x-request-id": "req-access-1" }),
+            })
+        );
+    });
+
+    it("includes x-request-id in debug log when IP is already present (409)", async () => {
+        const apiClient = makeSpyApiClient("conflict");
+        await ensureCurrentIpInAccessList(apiClient, "proj1", context);
+        expect(apiClient.logger.debug).toHaveBeenCalledWith(
+            expect.objectContaining({
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                attributes: expect.objectContaining({ "x-request-id": "req-access-1" }),
+            })
+        );
+    });
+
+    it("includes x-request-id in warning log when add fails with non-409 error", async () => {
+        const apiClient = makeSpyApiClient("error");
+        await ensureCurrentIpInAccessList(apiClient, "proj1", context);
+        expect(apiClient.logger.warning).toHaveBeenCalledWith(
+            expect.objectContaining({
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                attributes: expect.objectContaining({ "x-request-id": "req-access-1" }),
+            })
         );
     });
 });

--- a/tests/unit/common/apiClient.test.ts
+++ b/tests/unit/common/apiClient.test.ts
@@ -1,8 +1,32 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiClient } from "../../../src/common/atlas/apiClient.js";
+import { ApiClient, requestIdAttr } from "../../../src/common/atlas/apiClient.js";
 import { packageInfo } from "../../../src/common/packageInfo.js";
 import type { CommonProperties, TelemetryEvent, TelemetryResult } from "../../../src/telemetry/types.js";
 import { NullLogger } from "../../../src/common/logging/index.js";
+
+describe("requestIdAttr", () => {
+    it("returns the x-request-id when present as a string header", () => {
+        expect(requestIdAttr({ requestInfo: { headers: { "x-request-id": "req-123" } } })).toEqual({
+            "x-request-id": "req-123",
+        });
+    });
+
+    it("returns empty object when context is undefined", () => {
+        expect(requestIdAttr(undefined)).toEqual({});
+    });
+
+    it("returns empty object when requestInfo is absent", () => {
+        expect(requestIdAttr({})).toEqual({});
+    });
+
+    it("returns empty object when x-request-id header is missing", () => {
+        expect(requestIdAttr({ requestInfo: { headers: {} } })).toEqual({});
+    });
+
+    it("returns empty object when x-request-id header is not a string", () => {
+        expect(requestIdAttr({ requestInfo: { headers: { "x-request-id": ["a", "b"] } } })).toEqual({});
+    });
+});
 
 describe("ApiClient", () => {
     let apiClient: ApiClient;

--- a/tests/unit/common/apiClient.test.ts
+++ b/tests/unit/common/apiClient.test.ts
@@ -1,32 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiClient, requestIdAttr } from "../../../src/common/atlas/apiClient.js";
+import { ApiClient } from "../../../src/common/atlas/apiClient.js";
 import { packageInfo } from "../../../src/common/packageInfo.js";
 import type { CommonProperties, TelemetryEvent, TelemetryResult } from "../../../src/telemetry/types.js";
 import { NullLogger } from "../../../src/common/logging/index.js";
-
-describe("requestIdAttr", () => {
-    it("returns the x-request-id when present as a string header", () => {
-        expect(requestIdAttr({ requestInfo: { headers: { "x-request-id": "req-123" } } })).toEqual({
-            "x-request-id": "req-123",
-        });
-    });
-
-    it("returns empty object when context is undefined", () => {
-        expect(requestIdAttr(undefined)).toEqual({});
-    });
-
-    it("returns empty object when requestInfo is absent", () => {
-        expect(requestIdAttr({})).toEqual({});
-    });
-
-    it("returns empty object when x-request-id header is missing", () => {
-        expect(requestIdAttr({ requestInfo: { headers: {} } })).toEqual({});
-    });
-
-    it("returns empty object when x-request-id header is not a string", () => {
-        expect(requestIdAttr({ requestInfo: { headers: { "x-request-id": ["a", "b"] } } })).toEqual({});
-    });
-});
 
 describe("ApiClient", () => {
     let apiClient: ApiClient;

--- a/tests/unit/common/cluster.test.ts
+++ b/tests/unit/common/cluster.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+import { inspectCluster } from "../../../src/common/atlas/cluster.js";
+import type { ApiClient } from "../../../src/common/atlas/apiClient.js";
+
+describe("inspectCluster", () => {
+    it("includes x-request-id in error log when both getCluster and getFlexCluster fail", async () => {
+        const debug = vi.fn();
+        const error = vi.fn();
+
+        const apiClient = {
+            getCluster: vi.fn().mockRejectedValue(new Error("cluster not found")),
+            getFlexCluster: vi.fn().mockRejectedValue(new Error("flex cluster not found")),
+            logger: { debug, error },
+        } as unknown as ApiClient;
+
+        const context = { requestInfo: { headers: { "x-request-id": "req-cluster-1" } } };
+
+        await expect(inspectCluster(apiClient, "proj1", "cluster1", context)).rejects.toThrow();
+
+        expect(error).toHaveBeenCalledWith(
+            expect.objectContaining({
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                attributes: expect.objectContaining({ "x-request-id": "req-cluster-1" }),
+            })
+        );
+    });
+});

--- a/tests/unit/common/performanceAdvisorUtils.test.ts
+++ b/tests/unit/common/performanceAdvisorUtils.test.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { describe, it, expect, vi } from "vitest";
+import {
+    getSuggestedIndexes,
+    getDropIndexSuggestions,
+    getSchemaAdvice,
+    getSlowQueries,
+} from "../../../src/common/atlas/performanceAdvisorUtils.js";
+import type { ApiClient } from "../../../src/common/atlas/apiClient.js";
+
+const context = { requestInfo: { headers: { "x-request-id": "req-pa-1" } } };
+
+function makeApiClient(overrides: Partial<Record<string, ReturnType<typeof vi.fn>>>): ApiClient & {
+    logger: { debug: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+} {
+    const debug = vi.fn();
+    const error = vi.fn();
+    return {
+        listClusterSuggestedIndexes: vi.fn().mockRejectedValue(new Error("fail")),
+        listDropIndexSuggestions: vi.fn().mockRejectedValue(new Error("fail")),
+        listSchemaAdvice: vi.fn().mockRejectedValue(new Error("fail")),
+        listSlowQueryLogs: vi.fn().mockRejectedValue(new Error("fail")),
+        getCluster: vi.fn().mockRejectedValue(new Error("fail")),
+        getFlexCluster: vi.fn().mockRejectedValue(new Error("fail")),
+        logger: { debug, error },
+        ...overrides,
+    } as unknown as ApiClient & { logger: { debug: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> } };
+}
+
+describe("performanceAdvisorUtils request ID logging", () => {
+    it("getSuggestedIndexes includes x-request-id in debug log on failure", async () => {
+        const apiClient = makeApiClient({});
+        await expect(getSuggestedIndexes(apiClient, "proj1", "cluster1", context)).rejects.toThrow();
+        expect(apiClient.logger.debug).toHaveBeenCalledWith(
+            expect.objectContaining({
+                attributes: expect.objectContaining({ "x-request-id": "req-pa-1" }),
+            })
+        );
+    });
+
+    it("getDropIndexSuggestions includes x-request-id in debug log on failure", async () => {
+        const apiClient = makeApiClient({});
+        await expect(getDropIndexSuggestions(apiClient, "proj1", "cluster1", context)).rejects.toThrow();
+        expect(apiClient.logger.debug).toHaveBeenCalledWith(
+            expect.objectContaining({
+                attributes: expect.objectContaining({ "x-request-id": "req-pa-1" }),
+            })
+        );
+    });
+
+    it("getSchemaAdvice includes x-request-id in debug log on failure", async () => {
+        const apiClient = makeApiClient({});
+        await expect(getSchemaAdvice(apiClient, "proj1", "cluster1", context)).rejects.toThrow();
+        expect(apiClient.logger.debug).toHaveBeenCalledWith(
+            expect.objectContaining({
+                attributes: expect.objectContaining({ "x-request-id": "req-pa-1" }),
+            })
+        );
+    });
+
+    it("getSlowQueries includes x-request-id in debug log on failure", async () => {
+        // getProcessIdsFromCluster calls getCluster then getFlexCluster; when both fail the catch
+        // block in getSlowQueries fires and logs with x-request-id
+        const apiClient = makeApiClient({});
+        await expect(getSlowQueries(apiClient, "proj1", "cluster1", undefined, undefined, context)).rejects.toThrow();
+        expect(apiClient.logger.debug).toHaveBeenCalledWith(
+            expect.objectContaining({
+                attributes: expect.objectContaining({ "x-request-id": "req-pa-1" }),
+            })
+        );
+    });
+});

--- a/tests/unit/helpers/requestIdAttr.test.ts
+++ b/tests/unit/helpers/requestIdAttr.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { requestIdAttr } from "../../../src/helpers/requestIdAttr.js";
+
+describe("requestIdAttr", () => {
+    it("returns x-request-id pair when header is a string", () => {
+        expect(requestIdAttr({ "x-request-id": "abc-123" })).toEqual({ "x-request-id": "abc-123" });
+    });
+
+    it("returns empty object when headers are undefined", () => {
+        expect(requestIdAttr(undefined)).toEqual({});
+    });
+
+    it("returns empty object when headers are empty", () => {
+        expect(requestIdAttr({})).toEqual({});
+    });
+
+    it("returns empty object when x-request-id is absent", () => {
+        expect(requestIdAttr({ "content-type": "application/json" })).toEqual({});
+    });
+
+    it("returns empty object when x-request-id is an array", () => {
+        expect(requestIdAttr({ "x-request-id": ["id1", "id2"] })).toEqual({});
+    });
+
+    it("returns empty object when x-request-id is a number", () => {
+        expect(requestIdAttr({ "x-request-id": 42 })).toEqual({});
+    });
+});

--- a/tests/unit/hooks/sharedTierAlertsHook.test.ts
+++ b/tests/unit/hooks/sharedTierAlertsHook.test.ts
@@ -132,6 +132,19 @@ describe("runSharedTierAlertsHook", () => {
         expect(listAlertsFailPayload?.message).toContain("network down");
     });
 
+    it("includes x-request-id in warning log when listAlerts rejects", async () => {
+        listAlerts.mockRejectedValue(new Error("timeout"));
+
+        await runSharedTierAlertsHook({
+            ...baseParams,
+            instanceType: "FREE",
+            context: { requestInfo: { headers: { "x-request-id": "req-hook-1" } } },
+        });
+
+        const payload = warning.mock.calls[0]?.[0];
+        expect(payload?.attributes).toEqual(expect.objectContaining({ "x-request-id": "req-hook-1" }));
+    });
+
     it("matches LOGICAL_SIZE among mixed OPEN alerts on one page", async () => {
         listAlerts.mockResolvedValue({
             results: [

--- a/tests/unit/toolBase.test.ts
+++ b/tests/unit/toolBase.test.ts
@@ -2,7 +2,6 @@ import type { Mock } from "vitest";
 import { describe, it, expect, vi, beforeEach, type MockedFunction } from "vitest";
 import type { ZodRawShape } from "zod";
 import type { ToolConstructorParams, ToolExecutionContext } from "../../src/tools/tool.js";
-import { requestIdAttr } from "../../src/tools/tool.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { Session } from "../../src/common/session.js";
 import type { UserConfig } from "../../src/common/config/userConfig.js";
@@ -606,36 +605,6 @@ describe("ToolBase", () => {
                 );
             }
         });
-    });
-});
-
-describe("requestIdAttr", () => {
-    it("returns the x-request-id when present as a string header", () => {
-        const context: ToolExecutionContext = {
-            signal: new AbortController().signal,
-            requestInfo: { headers: { "x-request-id": "my-req-id" } },
-        };
-        expect(requestIdAttr(context)).toEqual({ "x-request-id": "my-req-id" });
-    });
-
-    it("returns empty object when requestInfo is absent", () => {
-        expect(requestIdAttr({ signal: new AbortController().signal })).toEqual({});
-    });
-
-    it("returns empty object when x-request-id header is missing", () => {
-        const context: ToolExecutionContext = {
-            signal: new AbortController().signal,
-            requestInfo: { headers: {} },
-        };
-        expect(requestIdAttr(context)).toEqual({});
-    });
-
-    it("returns empty object when x-request-id header is not a string", () => {
-        const context: ToolExecutionContext = {
-            signal: new AbortController().signal,
-            requestInfo: { headers: { "x-request-id": ["id1", "id2"] } },
-        };
-        expect(requestIdAttr(context)).toEqual({});
     });
 });
 

--- a/tests/unit/toolBase.test.ts
+++ b/tests/unit/toolBase.test.ts
@@ -1,7 +1,8 @@
 import type { Mock } from "vitest";
 import { describe, it, expect, vi, beforeEach, type MockedFunction } from "vitest";
 import type { ZodRawShape } from "zod";
-import type { ToolConstructorParams } from "../../src/tools/tool.js";
+import type { ToolConstructorParams, ToolExecutionContext } from "../../src/tools/tool.js";
+import { requestIdAttr } from "../../src/tools/tool.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { Session } from "../../src/common/session.js";
 import type { UserConfig } from "../../src/common/config/userConfig.js";
@@ -550,6 +551,91 @@ describe("ToolBase", () => {
             );
             expect(count?.value).toBe(1);
         });
+    });
+
+    describe("invoke logging", () => {
+        const contextWithRequestId: ToolExecutionContext = {
+            signal: new AbortController().signal,
+            requestInfo: { headers: { "x-request-id": "req-test-123" } },
+        };
+        const contextWithoutRequestId: ToolExecutionContext = {
+            signal: new AbortController().signal,
+        };
+
+        it("includes x-request-id in debug logs when context carries it", async () => {
+            await testTool["invoke"]({ param1: "test" }, contextWithRequestId);
+
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    attributes: expect.objectContaining({ "x-request-id": "req-test-123" }),
+                })
+            );
+        });
+
+        it("includes x-request-id in error log when execute() throws", async () => {
+            const errorTool = new ErrorTool({
+                name: ErrorTool.toolName,
+                category: ErrorTool.category,
+                operationType: ErrorTool.operationType,
+                session: mockSession,
+                config: mockConfig,
+                telemetry: mockTelemetry,
+                elicitation: mockElicitation,
+                metrics: mockMetrics,
+            });
+
+            await errorTool["invoke"]({}, contextWithRequestId);
+
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    attributes: expect.objectContaining({ "x-request-id": "req-test-123" }),
+                })
+            );
+        });
+
+        it("omits x-request-id from log attributes when context has no requestInfo", async () => {
+            await testTool["invoke"]({ param1: "test" }, contextWithoutRequestId);
+
+            for (const [payload] of (mockLogger.debug as Mock).mock.calls) {
+                expect((payload as { attributes?: Record<string, string> }).attributes).not.toHaveProperty(
+                    "x-request-id"
+                );
+            }
+        });
+    });
+});
+
+describe("requestIdAttr", () => {
+    it("returns the x-request-id when present as a string header", () => {
+        const context: ToolExecutionContext = {
+            signal: new AbortController().signal,
+            requestInfo: { headers: { "x-request-id": "my-req-id" } },
+        };
+        expect(requestIdAttr(context)).toEqual({ "x-request-id": "my-req-id" });
+    });
+
+    it("returns empty object when requestInfo is absent", () => {
+        expect(requestIdAttr({ signal: new AbortController().signal })).toEqual({});
+    });
+
+    it("returns empty object when x-request-id header is missing", () => {
+        const context: ToolExecutionContext = {
+            signal: new AbortController().signal,
+            requestInfo: { headers: {} },
+        };
+        expect(requestIdAttr(context)).toEqual({});
+    });
+
+    it("returns empty object when x-request-id header is not a string", () => {
+        const context: ToolExecutionContext = {
+            signal: new AbortController().signal,
+            requestInfo: { headers: { "x-request-id": ["id1", "id2"] } },
+        };
+        expect(requestIdAttr(context)).toEqual({});
     });
 });
 

--- a/tests/unit/tools/atlas/connect/connectCluster.test.ts
+++ b/tests/unit/tools/atlas/connect/connectCluster.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ToolConstructorParams, ToolExecutionContext } from "../../../../../src/tools/tool.js";
+import { ConnectClusterTool } from "../../../../../src/tools/atlas/connect/connectCluster.js";
+import type { Session } from "../../../../../src/common/session.js";
+import type { UserConfig } from "../../../../../src/common/config/userConfig.js";
+import type { Telemetry } from "../../../../../src/telemetry/telemetry.js";
+import type { Elicitation } from "../../../../../src/elicitation.js";
+import type { CompositeLogger } from "../../../../../src/common/logging/index.js";
+import type { ApiClient } from "../../../../../src/common/atlas/apiClient.js";
+import type { AtlasClusterConnectionInfo } from "../../../../../src/common/connectionInfo.js";
+import { MockMetrics } from "../../../mocks/metrics.js";
+
+const ATLAS_INFO: AtlasClusterConnectionInfo = {
+    username: "user1",
+    projectId: "proj1",
+    clusterName: "cluster1",
+    instanceType: "DEDICATED",
+    expiryDate: new Date(),
+};
+
+describe("ConnectClusterTool", () => {
+    let mockLogger: Record<string, ReturnType<typeof vi.fn>>;
+    let mockSession: Partial<Session>;
+    let tool: ConnectClusterTool;
+
+    beforeEach(() => {
+        mockLogger = {
+            info: vi.fn(),
+            debug: vi.fn(),
+            warning: vi.fn(),
+            error: vi.fn(),
+        };
+
+        mockSession = {
+            logger: mockLogger as unknown as CompositeLogger,
+            apiClient: {} as unknown as ApiClient,
+            connectedAtlasCluster: ATLAS_INFO,
+            connectToMongoDB: vi.fn().mockResolvedValue(undefined),
+        };
+
+        const mockConfig = {
+            confirmationRequiredTools: [],
+            previewFeatures: [],
+            disabledTools: [],
+            apiClientId: "test-id",
+            apiClientSecret: "test-secret",
+        } as unknown as UserConfig;
+
+        const mockTelemetry = {
+            isTelemetryEnabled: () => true,
+            emitEvents: vi.fn(),
+        } as unknown as Telemetry;
+
+        const mockElicitation = {
+            requestConfirmation: vi.fn(),
+        } as unknown as Elicitation;
+
+        const params: ToolConstructorParams = {
+            name: ConnectClusterTool.toolName,
+            category: "atlas",
+            operationType: ConnectClusterTool.operationType,
+            session: mockSession as Session,
+            config: mockConfig,
+            telemetry: mockTelemetry,
+            elicitation: mockElicitation,
+            metrics: new MockMetrics(),
+        };
+
+        tool = new ConnectClusterTool(params);
+    });
+
+    describe("connectToCluster request ID logging", () => {
+        it("includes x-request-id in attempt and success debug logs", async () => {
+            const context: ToolExecutionContext = {
+                signal: new AbortController().signal,
+                requestInfo: { headers: { "x-request-id": "req-connect-abc" } },
+            };
+
+            await tool["connectToCluster"]("mongodb://localhost", ATLAS_INFO, context);
+
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    message: expect.stringContaining("attempting to connect"),
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    attributes: expect.objectContaining({ "x-request-id": "req-connect-abc" }),
+                })
+            );
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    message: expect.stringContaining("connected to cluster"),
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    attributes: expect.objectContaining({ "x-request-id": "req-connect-abc" }),
+                })
+            );
+        });
+
+        it("omits x-request-id from log attributes when context has no requestInfo", async () => {
+            const context: ToolExecutionContext = {
+                signal: new AbortController().signal,
+            };
+
+            await tool["connectToCluster"]("mongodb://localhost", ATLAS_INFO, context);
+
+            for (const [payload] of (mockLogger.debug as ReturnType<typeof vi.fn>).mock.calls) {
+                expect((payload as { attributes?: Record<string, string> }).attributes).not.toHaveProperty(
+                    "x-request-id"
+                );
+            }
+        });
+    });
+});

--- a/tests/unit/tools/atlas/streams/manage.test.ts
+++ b/tests/unit/tools/atlas/streams/manage.test.ts
@@ -317,6 +317,22 @@ describe("StreamsManageTool", () => {
                 })
             );
         });
+
+        it("includes x-request-id in debug log when getStreamProcessor throws during stop", async () => {
+            mockApiClient.getStreamProcessor!.mockRejectedValue(new Error("lookup failed"));
+
+            await tool["execute"]({ ...baseArgs, action: "stop-processor", resourceName: "proc1" } as never, {
+                signal: new AbortController().signal,
+                requestInfo: { headers: { "x-request-id": "req-stop-1" } },
+            });
+
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    context: "streams-manage",
+                    attributes: expect.objectContaining({ "x-request-id": "req-stop-1" }),
+                })
+            );
+        });
     });
 
     describe("modify-processor", () => {

--- a/tests/unit/tools/atlas/streams/teardown.test.ts
+++ b/tests/unit/tools/atlas/streams/teardown.test.ts
@@ -120,6 +120,24 @@ describe("StreamsTeardownTool", () => {
             );
         });
 
+        it("includes x-request-id in debug log when getStreamProcessor throws during delete", async () => {
+            mockApiClient.getStreamProcessor!.mockRejectedValue(new Error("lookup failed"));
+            mockApiClient.deleteStreamProcessor!.mockResolvedValue({});
+
+            await tool["execute"](
+                { ...baseArgs, resource: "processor", workspaceName: "ws1", resourceName: "proc1" } as never,
+                { signal: new AbortController().signal, requestInfo: { headers: { "x-request-id": "req-del-1" } } }
+            );
+
+            expect(mockLogger.debug).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    context: "streams-teardown",
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                    attributes: expect.objectContaining({ "x-request-id": "req-del-1" }),
+                })
+            );
+        });
+
         it("should delete a STOPPED processor without stopping first", async () => {
             mockApiClient.getStreamProcessor!.mockResolvedValue({ state: "STOPPED", name: "proc1" });
             mockApiClient.deleteStreamProcessor!.mockResolvedValue({});

--- a/tests/unit/transports/mcpHttpServer.test.ts
+++ b/tests/unit/transports/mcpHttpServer.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { MCPHttpServer } from "../../../src/transports/mcpHttpServer.js";
+import { defaultTestConfig, InMemoryLogger } from "../../integration/helpers.js";
+import { MockMetrics } from "../mocks/metrics.js";
+import { Keychain } from "../../../src/common/keychain.js";
+import type { ISessionStore } from "../../../src/common/sessionStore.js";
+import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const INIT_BODY = JSON.stringify({
+    jsonrpc: "2.0",
+    method: "initialize",
+    id: 1,
+    params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "test", version: "1.0" },
+    },
+});
+
+const NON_INIT_BODY = JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 });
+
+function makeSessionStore(
+    getSessionImpl: () => Promise<StreamableHTTPServerTransport | null>
+): ISessionStore<StreamableHTTPServerTransport> {
+    return {
+        getSession: vi.fn().mockImplementation(getSessionImpl),
+        addSession: vi.fn(),
+        closeSession: vi.fn().mockResolvedValue(undefined),
+        closeAllSessions: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+describe("MCPHttpServer x-request-id logging", () => {
+    let server: MCPHttpServer;
+    let logger: InMemoryLogger;
+
+    afterEach(async () => {
+        await server?.stop();
+    });
+
+    async function startServer(sessionStore: ISessionStore<StreamableHTTPServerTransport>): Promise<void> {
+        logger = new InMemoryLogger(Keychain.root);
+        server = new MCPHttpServer({
+            userConfig: { ...defaultTestConfig, httpPort: 0 },
+            createServerForRequest: vi.fn(),
+            logger,
+            metrics: new MockMetrics(),
+            sessionStore,
+        });
+        await server.start();
+    }
+
+    async function post(path: string, body: string, headers: Record<string, string>): Promise<Response> {
+        return fetch(`${server.serverAddress}${path}`, {
+            method: "POST",
+            headers: { "content-type": "application/json", ...headers },
+            body,
+        });
+    }
+
+    it("includes x-request-id in debug log when session is not found", async () => {
+        await startServer(makeSessionStore(() => Promise.resolve(null)));
+
+        const res = await post("/mcp", NON_INIT_BODY, {
+            "mcp-session-id": "sess-abc",
+            "x-request-id": "req-not-found",
+        });
+
+        expect(res.status).toBe(404);
+        const log = logger.messages.find((m) => m.level === "debug" && m.payload.message.includes("not found"));
+        expect(log?.payload.attributes).toEqual(expect.objectContaining({ "x-request-id": "req-not-found" }));
+    });
+
+    it("omits x-request-id from debug log when header is absent", async () => {
+        await startServer(makeSessionStore(() => Promise.resolve(null)));
+
+        await post("/mcp", NON_INIT_BODY, { "mcp-session-id": "sess-abc" });
+
+        const log = logger.messages.find((m) => m.level === "debug" && m.payload.message.includes("not found"));
+        expect(log?.payload.attributes?.["x-request-id"]).toBeUndefined();
+    });
+
+    it("includes x-request-id in debug log when externallyManagedSessions is disabled", async () => {
+        await startServer(makeSessionStore(() => Promise.resolve(null)));
+
+        const res = await post("/mcp", INIT_BODY, {
+            "mcp-session-id": "sess-xyz",
+            "x-request-id": "req-ext-sessions",
+        });
+
+        expect(res.status).toBe(400);
+        const log = logger.messages.find(
+            (m) => m.level === "debug" && m.payload.message.includes("externallyManagedSessions")
+        );
+        expect(log?.payload.attributes).toEqual(expect.objectContaining({ "x-request-id": "req-ext-sessions" }));
+    });
+
+    it("includes x-request-id in error log when handler throws", async () => {
+        await startServer(makeSessionStore(() => Promise.reject(new Error("storage failure"))));
+
+        const res = await post("/mcp", NON_INIT_BODY, {
+            "mcp-session-id": "sess-err",
+            "x-request-id": "req-throw",
+        });
+
+        expect(res.status).toBe(400);
+        const log = logger.messages.find(
+            (m) => m.level === "error" && m.payload.message.includes("Error handling request")
+        );
+        expect(log?.payload.attributes).toEqual(expect.objectContaining({ "x-request-id": "req-throw" }));
+    });
+});


### PR DESCRIPTION
MCP-560

Follow-up to https://github.com/mongodb-js/mongodb-mcp-server/pull/1279

Right now I'm just modifying logs to include x-request-id under log attributes wherever it is easily available. 