### PR TITLE
chore: add npm bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
   "types": "./dist/cjs/lib.d.ts",
   "author": "MongoDB <info@mongodb.com>",
   "homepage": "https://github.com/mongodb-js/mongodb-mcp-server",
+  "bugs": {
+    "url": "https://github.com/mongodb-js/mongodb-mcp-server/issues"
+  },
   "repository": {
     "url": "https://github.com/mongodb-js/mongodb-mcp-server.git"
   },


### PR DESCRIPTION
## Summary
- add the npm `bugs.url` metadata field pointing to the public GitHub issue tracker

## Verification
- `node -e "const p=require(\"./package.json\"); if (p.bugs?.url !== \"https://github.com/mongodb-js/mongodb-mcp-server/issues\") throw new Error(\"missing bugs.url\"); console.log(JSON.stringify({name:p.name,version:p.version,bugs:p.bugs}, null, 2));"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`