### PR TITLE
fix: add bugs.url metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,5 +213,8 @@
   "optionalDependencies": {
     "@mongodb-js/atlas-local": "^1.3.0",
     "kerberos": "^7.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/mongodb-js/mongodb-mcp-server/issues"
   }
 }


### PR DESCRIPTION
Adds the `bugs` field pointing to the GitHub issue tracker, which is required by npm best practices.