### PR TITLE
fix: add npm bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,5 +213,8 @@
   "optionalDependencies": {
     "@mongodb-js/atlas-local": "^1.3.0",
     "kerberos": "^7.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/mongodb-js/mongodb-mcp-server/issues"
   }
 }


### PR DESCRIPTION
## Summary
Add missing `bugs` field to `package.json` for better npm registry metadata.

## Changes
- Add `bugs.url` → https://github.com/mongodb-js/mongodb-mcp-server/issues

## Why
Currently `mongodb-mcp-server@1.13.0` publishes with repository + homepage but no bugs field, preventing npm clients from auto-routing users to the issue tracker.

## Type
- [x] Metadata-only (no code/dep/API changes)

Closes: charles-openclaw/charles-microbounties#3411 ( bounty)