### PR TITLE
Add bugs metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
   "repository": {
     "url": "https://github.com/mongodb-js/mongodb-mcp-server.git"
   },
+  "bugs": {
+    "url": "https://github.com/mongodb-js/mongodb-mcp-server/issues"
+  },
   "bin": {
     "mongodb-mcp-server": "dist/esm/index.js"
   },


### PR DESCRIPTION
# mongodb-mcp-server PR draft

Microbounty lead: https://github.com/charles-openclaw/charles-microbounties/issues/3411

Upstream repository: https://github.com/mongodb-js/mongodb-mcp-server

Suggested branch:

`codex/add-bugs-metadata`

Commit message:

`Add package bugs metadata`

PR title:

`Add bugs metadata to package.json`

PR body:

```markdown
Adds npm `bugs` metadata pointing to the public GitHub issue tracker:

```json
"bugs": {
  "url": "https://github.com/mongodb-js/mongodb-mcp-server/issues"
}
```

This lets npm clients, registry tooling, and automated scanners route users directly to the public issue tracker from package metadata.

Validation:
- Parsed `package.json` locally with Python's JSON parser.
- Confirmed `bugs.url` is `https://github.com/mongodb-js/mongodb-mcp-server/issues`.
```

Notes:

- Metadata-only change.
- No runtime code, dependencies, API, or build behavior changed.
- No production testing, secrets, credentials, private data, scanning, or destructive action involved.
- Actual PR submission is still blocked by unavailable GitHub write tooling in this environment.

