### PR TITLE
chore: Add token manager and config unit tests MCP-539

### DIFF
--- a/packages/mongodb-atlas-mcp-remote/src/config.test.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/config.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { loadConfig, ConfigurationError } from "./config.js";
+import { LOG_LEVELS } from "./common.js";
+import type { AppConfig } from "./common.js";
+
+const TEST_CLIENT_ID = "client-id";
+const TEST_CLIENT_SECRET = "client-secret";
+
+const CONFIG_ENV_VARS = [
+    "MDB_MCP_API_CLIENT_ID",
+    "MDB_MCP_API_CLIENT_SECRET",
+    "MDB_MCP_API_BASE_URL",
+    "MDB_MCP_LOG_LEVEL",
+    "MDB_MCP_TOKEN_TIMEOUT_MS",
+] as const;
+
+function stubSA(): void {
+    vi.stubEnv("MDB_MCP_API_CLIENT_ID", TEST_CLIENT_ID);
+    vi.stubEnv("MDB_MCP_API_CLIENT_SECRET", TEST_CLIENT_SECRET);
+}
+
+function loadConfigExpectConfigurationError(): ConfigurationError {
+    try {
+        loadConfig();
+        expect.fail("expected error");
+    } catch (e) {
+        expect(e).toBeInstanceOf(ConfigurationError);
+        return e as ConfigurationError;
+    }
+}
+
+const DEFAULT_CONFIG: AppConfig = {
+    clientId: TEST_CLIENT_ID,
+    clientSecret: TEST_CLIENT_SECRET,
+    tokenUrl: "https://cloud.mongodb.com/api/oauth/token",
+    remoteUrl: "https://cloud.mongodb.com/api/private/mcp",
+    logLevel: "info",
+    tokenTimeoutMs: 10_000,
+};
+
+describe("loadConfig", () => {
+    beforeEach(() => {
+        // Prevent shell env vars from being picked up
+        for (const envVar of CONFIG_ENV_VARS) {
+            vi.stubEnv(envVar, undefined);
+        }
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    describe("valid configurations", () => {
+        it("basic config", () => {
+            stubSA();
+            expect(loadConfig()).toEqual(DEFAULT_CONFIG);
+        });
+
+        it("accepts all valid log levels", () => {
+            stubSA();
+            for (const level of LOG_LEVELS) {
+                vi.stubEnv("MDB_MCP_LOG_LEVEL", level);
+                expect(loadConfig()).toEqual({ ...DEFAULT_CONFIG, logLevel: level });
+            }
+        });
+
+        it("accepts MDB_MCP_API_BASE_URL", () => {
+            stubSA();
+            vi.stubEnv("MDB_MCP_API_BASE_URL", "https://test.mongodb.com");
+            expect(loadConfig()).toEqual({
+                ...DEFAULT_CONFIG,
+                tokenUrl: "https://test.mongodb.com/api/oauth/token",
+                remoteUrl: "https://test.mongodb.com/api/private/mcp",
+            });
+        });
+
+        it("accepts valid MDB_MCP_TOKEN_TIMEOUT_MS", () => {
+            stubSA();
+            vi.stubEnv("MDB_MCP_TOKEN_TIMEOUT_MS", "5000");
+            expect(loadConfig()).toEqual({ ...DEFAULT_CONFIG, tokenTimeoutMs: 5000 });
+        });
+    });
+
+    describe("invalid configurations", () => {
+        it("throws ConfigurationError when client id and secret are missing", () => {
+            const error = loadConfigExpectConfigurationError();
+            expect(error.errors).toContain("MDB_MCP_API_CLIENT_ID is required");
+            expect(error.errors).toContain("MDB_MCP_API_CLIENT_SECRET is required");
+        });
+
+        it("throws ConfigurationError when client id is missing", () => {
+            vi.stubEnv("MDB_MCP_API_CLIENT_SECRET", TEST_CLIENT_SECRET);
+
+            const error = loadConfigExpectConfigurationError();
+            expect(error.errors).toContain("MDB_MCP_API_CLIENT_ID is required");
+        });
+
+        it("throws ConfigurationError when client secret is missing", () => {
+            vi.stubEnv("MDB_MCP_API_CLIENT_ID", TEST_CLIENT_ID);
+
+            const error = loadConfigExpectConfigurationError();
+            expect(error.errors).toContain("MDB_MCP_API_CLIENT_SECRET is required");
+        });
+
+        it("throws ConfigurationError for invalid log levels", () => {
+            stubSA();
+            vi.stubEnv("MDB_MCP_LOG_LEVEL", "invalid");
+
+            const error = loadConfigExpectConfigurationError();
+            expect(error.errors[0]).toContain("MDB_MCP_LOG_LEVEL must be one of");
+            expect(error.errors[0]).toContain("got: invalid");
+        });
+
+        it("throws ConfigurationError for invalid token timeouts", () => {
+            stubSA();
+            for (const value of ["abc", "-1", "0"]) {
+                vi.stubEnv("MDB_MCP_TOKEN_TIMEOUT_MS", value);
+
+                const error = loadConfigExpectConfigurationError();
+                expect(error.errors).toContain(`MDB_MCP_TOKEN_TIMEOUT_MS must be a positive integer, got: ${value}`);
+            }
+        });
+    });
+});

--- a/packages/mongodb-atlas-mcp-remote/src/tokenManager.test.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/tokenManager.test.ts
@@ -1,0 +1,145 @@
+import type { Mock } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TokenManager, TokenError } from "./tokenManager.js";
+import type { FetchLike } from "@modelcontextprotocol/client";
+
+const TEST_TOKEN_1 = "token-1";
+const TEST_TOKEN_2 = "token-2";
+
+function createManager(fetch: FetchLike): TokenManager {
+    return new TokenManager("https://test.com/api/oauth/token", "client_id", "client_secret", 10_000, fetch);
+}
+
+function mockOkFetch(tokens: string[] = [TEST_TOKEN_1]): Mock {
+    const mock = vi.fn();
+    for (const token of tokens) {
+        mock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => ({ access_token: token, expires_in: 3600 }),
+        });
+    }
+    return mock;
+}
+
+describe("TokenManager", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("token fetching, caching and refreshing", () => {
+        it("fetches a token on the first call", async () => {
+            const mockFetch = mockOkFetch();
+            const manager = createManager(mockFetch);
+            const token = await manager.getToken();
+
+            expect(token).toBe(TEST_TOKEN_1);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it("returns the cached token on subsequent calls", async () => {
+            const mockFetch = mockOkFetch();
+            const manager = createManager(mockFetch);
+
+            await manager.getToken();
+            const token = await manager.getToken();
+
+            expect(token).toBe(TEST_TOKEN_1);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it("refreshes when within 10 minutes to expiration", async () => {
+            const mockFetch = mockOkFetch([TEST_TOKEN_1, TEST_TOKEN_2]);
+            const manager = createManager(mockFetch);
+
+            const token1 = await manager.getToken();
+            vi.setSystemTime(Date.now() + 51 * 60 * 1000);
+            const token2 = await manager.getToken();
+
+            expect(token1).toBe(TEST_TOKEN_1);
+            expect(token2).toBe(TEST_TOKEN_2);
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+
+        it("refreshes when the token is expired", async () => {
+            const mockFetch = mockOkFetch([TEST_TOKEN_1, TEST_TOKEN_2]);
+            const manager = createManager(mockFetch);
+
+            const token1 = await manager.getToken();
+            vi.setSystemTime(Date.now() + 61 * 60 * 1000);
+            const token2 = await manager.getToken();
+
+            expect(token1).toBe(TEST_TOKEN_1);
+            expect(token2).toBe(TEST_TOKEN_2);
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+
+        it("fetches a new token after invalidating", async () => {
+            const mockFetch = mockOkFetch([TEST_TOKEN_1, TEST_TOKEN_2]);
+            const manager = createManager(mockFetch);
+
+            const token1 = await manager.getToken();
+            manager.invalidateToken();
+            const token2 = await manager.getToken();
+
+            expect(token1).toBe(TEST_TOKEN_1);
+            expect(token2).toBe(TEST_TOKEN_2);
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe("single-flight refresh", () => {
+        it("concurrent getToken() calls share a single fetch", async () => {
+            const mockFetch = mockOkFetch();
+            const manager = createManager(mockFetch);
+
+            const [token1, token2] = await Promise.all([manager.getToken(), manager.getToken()]);
+
+            expect(token1).toBe(TEST_TOKEN_1);
+            expect(token2).toBe(TEST_TOKEN_1);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("error cases", () => {
+        it("throws TokenError with the HTTP status code on a non-OK response", async () => {
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: false,
+                status: 401,
+                text: () => "Unauthorized",
+            });
+            const manager = createManager(mockFetch);
+
+            const error = await manager.getToken().catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(TokenError);
+            expect((error as TokenError).statusCode).toBe(401);
+            expect((error as TokenError).message).toContain("Token request failed");
+        });
+
+        it("throws TokenError with a timeout message on TimeoutError", async () => {
+            const mockFetch = vi.fn().mockRejectedValue(Object.assign(new Error("timeout"), { name: "TimeoutError" }));
+            const manager = createManager(mockFetch);
+
+            const error = await manager.getToken().catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(TokenError);
+            expect((error as TokenError).message).toContain("Token request timed out");
+        });
+
+        it("throws TokenError when access_token is missing from the response", async () => {
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                status: 200,
+                json: () => ({ expires_in: 3600 }),
+            });
+            const manager = createManager(mockFetch);
+
+            const error = await manager.getToken().catch((e: unknown) => e);
+            expect(error).toBeInstanceOf(TokenError);
+            expect((error as TokenError).message).toContain("Token response missing access_token");
+        });
+    });
+});


### PR DESCRIPTION
## Description

Adding unit tests for the mcp wrapper package.

Integ tests and e2e tests to be covered in a separate PR.

Ticket: MCP-539