### PR TITLE
fix: wait for connection string when creating a deployment

### DIFF
--- a/scripts/cleanupAtlasTestLeftovers.test.ts
+++ b/scripts/cleanupAtlasTestLeftovers.test.ts
@@ -3,10 +3,7 @@ import { ApiClient } from "../src/common/atlas/apiClient.js";
 import { ConsoleLogger } from "../src/common/logging/index.js";
 import { Keychain } from "../src/lib.js";
 import { describe, it } from "vitest";
-
-function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
+import { sleep } from "../src/common/managedTimeout.js";
 
 function isOlderThanTwoHours(date: string): boolean {
     const twoHoursInMs = 2 * 60 * 60 * 1000;

--- a/src/common/atlasLocal/connectionString.ts
+++ b/src/common/atlasLocal/connectionString.ts
@@ -1,8 +1,16 @@
 import type { Client } from "@mongodb-js/atlas-local";
 import { sleep } from "../managedTimeout.js";
 
-const DEFAULT_MAX_ATTEMPTS = 600;
-const DEFAULT_INTERVAL_MS = 500;
+/** Keep well under the MCP client's default ~60s request timeout. */
+export const DEFAULT_MAX_ATTEMPTS = 60;
+export const DEFAULT_INTERVAL_MS = 500;
+
+export class AtlasLocalDeploymentNotReadyError extends Error {
+    constructor(public readonly deploymentName: string) {
+        super(`Atlas Local deployment "${deploymentName}" is still starting up`);
+        this.name = "AtlasLocalDeploymentNotReadyError";
+    }
+}
 
 function isMissingPortBindingError(error: unknown): boolean {
     const message = error instanceof Error ? error.message : String(error);
@@ -11,7 +19,7 @@ function isMissingPortBindingError(error: unknown): boolean {
 
 /**
  * atlas-local-create-deployment can return before Docker publishes port bindings.
- * Wait until getConnectionString succeeds so connect works right after create.
+ * Retry briefly so connect usually works without exceeding MCP request timeouts.
  */
 export async function waitForConnectionString(
     client: Client,
@@ -21,24 +29,19 @@ export async function waitForConnectionString(
         intervalMs = DEFAULT_INTERVAL_MS,
     }: { maxAttempts?: number; intervalMs?: number } = {}
 ): Promise<string> {
-    let lastError: Error | undefined;
-
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
         try {
             return await client.getConnectionString(deploymentName);
         } catch (error: unknown) {
-            const err = error instanceof Error ? error : new Error(String(error));
-            lastError = err;
-
-            if (!isMissingPortBindingError(err)) {
-                throw err;
+            if (!isMissingPortBindingError(error)) {
+                throw error;
             }
 
-            await sleep(intervalMs);
+            if (attempt < maxAttempts - 1) {
+                await sleep(intervalMs);
+            }
         }
     }
 
-    throw (
-        lastError ?? new Error(`Timed out waiting for connection string for Atlas Local deployment "${deploymentName}"`)
-    );
+    throw new AtlasLocalDeploymentNotReadyError(deploymentName);
 }

--- a/src/common/atlasLocal/connectionString.ts
+++ b/src/common/atlasLocal/connectionString.ts
@@ -1,0 +1,44 @@
+import type { Client } from "@mongodb-js/atlas-local";
+import { sleep } from "../managedTimeout.js";
+
+const DEFAULT_MAX_ATTEMPTS = 600;
+const DEFAULT_INTERVAL_MS = 500;
+
+function isMissingPortBindingError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("Missing port binding information");
+}
+
+/**
+ * atlas-local-create-deployment can return before Docker publishes port bindings.
+ * Wait until getConnectionString succeeds so connect works right after create.
+ */
+export async function waitForConnectionString(
+    client: Client,
+    deploymentName: string,
+    {
+        maxAttempts = DEFAULT_MAX_ATTEMPTS,
+        intervalMs = DEFAULT_INTERVAL_MS,
+    }: { maxAttempts?: number; intervalMs?: number } = {}
+): Promise<string> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+            return await client.getConnectionString(deploymentName);
+        } catch (error: unknown) {
+            const err = error instanceof Error ? error : new Error(String(error));
+            lastError = err;
+
+            if (!isMissingPortBindingError(err)) {
+                throw err;
+            }
+
+            await sleep(intervalMs);
+        }
+    }
+
+    throw (
+        lastError ?? new Error(`Timed out waiting for connection string for Atlas Local deployment "${deploymentName}"`)
+    );
+}

--- a/src/common/managedTimeout.ts
+++ b/src/common/managedTimeout.ts
@@ -25,3 +25,7 @@ export function setManagedTimeout(callback: () => Promise<void> | void, timeoutM
         restart,
     };
 }
+
+export function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -12,16 +12,13 @@ import { getDefaultRoleFromConfig } from "../../../common/atlas/roles.js";
 import { AtlasArgs } from "../../args.js";
 import { SHARED_TIER_METRIC_NAMES } from "../../../telemetry/types.js";
 import type { ConnectionMetadata, SharedTierTier, SharedTierMetricName } from "../../../telemetry/types.js";
+import { sleep } from "../../../common/managedTimeout.js";
 
 const addedIpAccessListMessage =
     "Note: Your current IP address has been added to the Atlas project's IP access list to enable secure connection.";
 
 const createdUserMessage =
     "Note: A temporary user has been created to enable secure connection to the cluster. For more information, see https://dochub.mongodb.org/core/mongodb-mcp-server-tools-considerations\n\nNote to LLM Agent: it is important to include the following link in your response to the user in case they want to get more information about the temporary user created: https://dochub.mongodb.org/core/mongodb-mcp-server-tools-considerations";
-
-function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 export const ConnectClusterArgs = {
     projectId: AtlasArgs.projectId().describe("Atlas project ID"),

--- a/src/tools/atlasLocal/connect/connectDeployment.ts
+++ b/src/tools/atlasLocal/connect/connectDeployment.ts
@@ -2,7 +2,10 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasLocalToolBase } from "../atlasLocalTool.js";
 import type { OperationType, ToolArgs } from "../../tool.js";
 import type { Client } from "@mongodb-js/atlas-local";
-import { waitForConnectionString } from "../../../common/atlasLocal/connectionString.js";
+import {
+    AtlasLocalDeploymentNotReadyError,
+    waitForConnectionString,
+} from "../../../common/atlasLocal/connectionString.js";
 import { CommonArgs } from "../../args.js";
 import type { ConnectionMetadata } from "../../../telemetry/types.js";
 
@@ -18,9 +21,24 @@ export class ConnectDeploymentTool extends AtlasLocalToolBase {
         { deploymentName }: ToolArgs<typeof this.argsShape>,
         { client }: { client: Client }
     ): Promise<CallToolResult> {
-        const connectionString = await waitForConnectionString(client, deploymentName);
+        let connectionString: string;
+        try {
+            connectionString = await waitForConnectionString(client, deploymentName);
+        } catch (error: unknown) {
+            if (error instanceof AtlasLocalDeploymentNotReadyError) {
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Atlas Local deployment "${deploymentName}" is still starting up. Wait a few seconds and call atlas-local-connect-deployment again with the same deployment name.`,
+                        },
+                    ],
+                    isError: true,
+                };
+            }
+            throw error;
+        }
 
-        // Connect to the deployment
         await this.session.connectToMongoDB({ connectionString });
 
         return {

--- a/src/tools/atlasLocal/connect/connectDeployment.ts
+++ b/src/tools/atlasLocal/connect/connectDeployment.ts
@@ -2,6 +2,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasLocalToolBase } from "../atlasLocalTool.js";
 import type { OperationType, ToolArgs } from "../../tool.js";
 import type { Client } from "@mongodb-js/atlas-local";
+import { waitForConnectionString } from "../../../common/atlasLocal/connectionString.js";
 import { CommonArgs } from "../../args.js";
 import type { ConnectionMetadata } from "../../../telemetry/types.js";
 
@@ -17,8 +18,7 @@ export class ConnectDeploymentTool extends AtlasLocalToolBase {
         { deploymentName }: ToolArgs<typeof this.argsShape>,
         { client }: { client: Client }
     ): Promise<CallToolResult> {
-        // Get the connection string for the deployment
-        const connectionString = await client.getConnectionString(deploymentName);
+        const connectionString = await waitForConnectionString(client, deploymentName);
 
         // Connect to the deployment
         await this.session.connectToMongoDB({ connectionString });

--- a/src/tools/atlasLocal/create/createDeployment.ts
+++ b/src/tools/atlasLocal/create/createDeployment.ts
@@ -2,7 +2,10 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasLocalToolBase } from "../atlasLocalTool.js";
 import type { OperationType, ToolArgs } from "../../tool.js";
 import type { Client, CreateDeploymentOptions } from "@mongodb-js/atlas-local";
-import { waitForConnectionString } from "../../../common/atlasLocal/connectionString.js";
+import {
+    AtlasLocalDeploymentNotReadyError,
+    waitForConnectionString,
+} from "../../../common/atlasLocal/connectionString.js";
 import { CommonArgs } from "../../args.js";
 import z from "zod";
 
@@ -41,15 +44,28 @@ export class CreateDeploymentTool extends AtlasLocalToolBase {
         // createDeployment returns once the container is healthy, but Docker may
         // not have published port bindings yet. Block until connect can succeed.
         const resolvedDeploymentName = deployment.name ?? deploymentName;
+        let stillStarting = false;
         if (resolvedDeploymentName) {
-            await waitForConnectionString(client, resolvedDeploymentName);
+            try {
+                await waitForConnectionString(client, resolvedDeploymentName);
+            } catch (error: unknown) {
+                if (error instanceof AtlasLocalDeploymentNotReadyError) {
+                    stillStarting = true;
+                } else {
+                    throw error;
+                }
+            }
         }
+
+        const startingNote = stillStarting
+            ? " The deployment is still initializing; if atlas-local-connect-deployment fails, wait a few seconds and try connecting again."
+            : "";
 
         return {
             content: [
                 {
                     type: "text",
-                    text: `Deployment with container ID "${deployment.containerId}" and name "${deployment.name}" created (imageTag: ${imageTag}).`,
+                    text: `Deployment with container ID "${deployment.containerId}" and name "${deployment.name}" created (imageTag: ${imageTag}).${startingNote}`,
                 },
             ],
             _meta: {

--- a/src/tools/atlasLocal/create/createDeployment.ts
+++ b/src/tools/atlasLocal/create/createDeployment.ts
@@ -2,6 +2,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { AtlasLocalToolBase } from "../atlasLocalTool.js";
 import type { OperationType, ToolArgs } from "../../tool.js";
 import type { Client, CreateDeploymentOptions } from "@mongodb-js/atlas-local";
+import { waitForConnectionString } from "../../../common/atlasLocal/connectionString.js";
 import { CommonArgs } from "../../args.js";
 import z from "zod";
 
@@ -35,8 +36,14 @@ export class CreateDeploymentTool extends AtlasLocalToolBase {
             ...(this.config.voyageApiKey ? { voyageApiKey: this.config.voyageApiKey } : {}),
             doNotTrack: !this.telemetry.isTelemetryEnabled(),
         };
-        // Create the deployment
         const deployment = await client.createDeployment(deploymentOptions);
+
+        // createDeployment returns once the container is healthy, but Docker may
+        // not have published port bindings yet. Block until connect can succeed.
+        const resolvedDeploymentName = deployment.name ?? deploymentName;
+        if (resolvedDeploymentName) {
+            await waitForConnectionString(client, resolvedDeploymentName);
+        }
 
         return {
             content: [

--- a/tests/eval/lib/seeding.ts
+++ b/tests/eval/lib/seeding.ts
@@ -1,6 +1,7 @@
 import type { MongoClient } from "mongodb";
 import type { DbSeedEntry, SeedClassicIndex } from "./datasetTypes.js";
 import { getSeedDocuments, parseSeedEntry } from "./datasetHelpers.js";
+import { sleep } from "../../../src/common/managedTimeout.js";
 
 // ╭──────────────────────────────────────────────╮
 // │   ↘️ Seeding Constants                       │
@@ -47,8 +48,11 @@ async function waitForIndexesQueryable(
             }
         }
 
-        if (pending.size === 0) return;
-        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        if (pending.size === 0) {
+            return;
+        }
+
+        await sleep(intervalMs);
     }
 
     throw new Error(

--- a/tests/integration/common/connectionManager.oidc.test.ts
+++ b/tests/integration/common/connectionManager.oidc.test.ts
@@ -4,13 +4,14 @@ import semver from "semver";
 import process from "process";
 import type { MongoDBIntegrationTestCase } from "../tools/mongodb/mongodbHelpers.js";
 import { describeWithMongoDB, isCommunityServer, getServerVersion } from "../tools/mongodb/mongodbHelpers.js";
-import { connect, defaultTestConfig, responseAsText, timeout, waitUntil } from "../helpers.js";
+import { connect, defaultTestConfig, responseAsText, waitUntil } from "../helpers.js";
 import type { ConnectionStateConnected, ConnectionStateConnecting } from "../../../src/common/connectionManager.js";
 import type { UserConfig } from "../../../src/common/config/userConfig.js";
 import path from "path";
 import type { OIDCMockProviderConfig } from "@mongodb-js/oidc-mock-provider";
 import { OIDCMockProvider } from "@mongodb-js/oidc-mock-provider";
 import { type TestConnectionManager } from "../../utils/index.js";
+import { sleep } from "../../../src/common/managedTimeout.js";
 
 const DEFAULT_TIMEOUT = 60_000;
 const DEFAULT_RETRIES = 5;
@@ -242,7 +243,7 @@ describe.skipIf(process.platform !== "linux")("ConnectionManager OIDC Tests", as
                     signal
                 );
 
-                await timeout(2000);
+                await sleep(2000);
                 await state.serviceProvider.listDatabases("admin");
                 expect(tokenFetches).toBeGreaterThan(1);
             });

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -392,10 +392,6 @@ function validateToolAnnotations(tool: ToolInfo, name: string, operationType: Op
     }
 }
 
-export function timeout(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 /**
  * Subscribes to the resources changed notification for the provided URI
  */
@@ -456,10 +452,6 @@ export function getDataFromUntrustedContent(content: string): string {
         throw new Error("Could not find untrusted user data in content");
     }
     return match.groups.data.trim();
-}
-
-export function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export class InMemoryLogger extends LoggerBase {

--- a/tests/integration/resources/exportedData.test.ts
+++ b/tests/integration/resources/exportedData.test.ts
@@ -3,10 +3,11 @@ import fs from "fs/promises";
 import { EJSON, Long, ObjectId } from "bson";
 import { describe, expect, it, beforeEach, afterAll } from "vitest";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { defaultTestConfig, getDataFromUntrustedContent, resourceChangedNotification, timeout } from "../helpers.js";
+import { defaultTestConfig, getDataFromUntrustedContent, resourceChangedNotification } from "../helpers.js";
 import { describeWithMongoDB } from "../tools/mongodb/mongodbHelpers.js";
 import { contentWithResourceURILink } from "../tools/mongodb/read/export.test.js";
 import type { UserConfig } from "../../../src/lib.js";
+import { sleep } from "../../../src/common/managedTimeout.js";
 
 const userConfig: UserConfig = {
     ...defaultTestConfig,
@@ -83,7 +84,7 @@ describeWithMongoDB(
 
                 // wait for export expired
                 for (let tries = 0; tries < 10; tries++) {
-                    await timeout(300);
+                    await sleep(300);
                     const response = await integration.mcpClient().readResource({
                         uri: exportedResourceURI as string,
                     });

--- a/tests/integration/tools/atlas-local/createDeployment.test.ts
+++ b/tests/integration/tools/atlas-local/createDeployment.test.ts
@@ -1,5 +1,5 @@
 import { defaultTestConfig, expectDefined, getResponseElements } from "../../helpers.js";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import {
     createAtlasLocalDeployment,
     describeWithAtlasLocal,
@@ -10,6 +10,7 @@ import type { ListCollectionsOutput } from "../../../../src/tools/mongodb/metada
 
 // Config used for tests that require a voyageApiKey.
 const configWithVoyageApiKey = { ...defaultTestConfig, voyageApiKey: "test-voyage-api-key" };
+const SAMPLE_DATA_TEST_TIMEOUT_MS = 600_000;
 
 describeWithAtlasLocal(
     "atlas-local-create-deployment",
@@ -161,59 +162,73 @@ describeWithAtlasLocal(
             expect((deployment as { voyageApiKey?: string }).voyageApiKey).toBe(configWithVoyageApiKey.voyageApiKey);
         });
 
-        it("should load sample data when loadSampleData is true", async () => {
-            const deploymentName = `test-deployment-sample-${Date.now()}`;
-            deploymentNamesToCleanup.push(deploymentName);
+        it(
+            "should load sample data when loadSampleData is true",
+            { timeout: SAMPLE_DATA_TEST_TIMEOUT_MS },
+            async () => {
+                const deploymentName = `test-deployment-sample-${Date.now()}`;
+                deploymentNamesToCleanup.push(deploymentName);
 
-            const createResponse = await createAtlasLocalDeployment(integration, {
-                deploymentName,
-                loadSampleData: true,
-            });
-            const createElements = getResponseElements(createResponse.content);
-            expect(createElements.length).toBeGreaterThanOrEqual(1);
-            expect(createElements[0]?.text ?? "").toContain(deploymentName);
+                const createResponse = await createAtlasLocalDeployment(integration, {
+                    deploymentName,
+                    loadSampleData: true,
+                });
+                const createElements = getResponseElements(createResponse.content);
+                expect(createElements.length).toBeGreaterThanOrEqual(1);
+                expect(createElements[0]?.text ?? "").toContain(deploymentName);
 
-            // The MCP tool should propagate loadSampleData down to the underlying atlas-local client.
-            const client = integration.mcpServer().session.atlasLocalClient;
-            expectDefined(client);
-            const deployment = await client.getDeployment(deploymentName);
-            expect(deployment.mongodbLoadSampleData).toBe(true);
+                // The MCP tool should propagate loadSampleData down to the underlying atlas-local client.
+                const client = integration.mcpServer().session.atlasLocalClient;
+                expectDefined(client);
+                const deployment = await client.getDeployment(deploymentName);
+                expect(deployment.mongodbLoadSampleData).toBe(true);
 
-            // Connect so subsequent MongoDB tool calls target this deployment.
-            await integration.mcpClient().callTool({
-                name: "atlas-local-connect-deployment",
-                arguments: { deploymentName },
-            });
+                // Connect so subsequent MongoDB tool calls target this deployment.
+                // create may return before port bindings are ready; retry connect like a customer would.
+                await vi.waitFor(
+                    async () => {
+                        const response = await integration.mcpClient().callTool({
+                            name: "atlas-local-connect-deployment",
+                            arguments: { deploymentName },
+                        });
+                        if (response.isError) {
+                            const message = getResponseElements(response.content)[0]?.text ?? "connect failed";
+                            throw new Error(message);
+                        }
+                    },
+                    { timeout: SAMPLE_DATA_TEST_TIMEOUT_MS, interval: 5_000 }
+                );
 
-            // Verify the standard MongoDB sample datasets were loaded.
-            const dbsResponse = await integration.mcpClient().callTool({
-                name: "list-databases",
-                arguments: {},
-            });
-            const dbsContent = dbsResponse.structuredContent as ListDatabasesOutput;
-            const sampleDbNames = dbsContent.databases
-                .map((db) => db.name)
-                .filter((name) => name.startsWith("sample_"));
-            expect(sampleDbNames).toContain("sample_mflix");
+                // Verify the standard MongoDB sample datasets were loaded.
+                const dbsResponse = await integration.mcpClient().callTool({
+                    name: "list-databases",
+                    arguments: {},
+                });
+                const dbsContent = dbsResponse.structuredContent as ListDatabasesOutput;
+                const sampleDbNames = dbsContent.databases
+                    .map((db) => db.name)
+                    .filter((name) => name.startsWith("sample_"));
+                expect(sampleDbNames).toContain("sample_mflix");
 
-            // Verify a known collection from sample_mflix is present and has data.
-            const collsResponse = await integration.mcpClient().callTool({
-                name: "list-collections",
-                arguments: { database: "sample_mflix" },
-            });
-            const collsContent = collsResponse.structuredContent as ListCollectionsOutput;
-            const collNames = collsContent.collections.map((c) => c.name);
-            expect(collNames).toContain("movies");
+                // Verify a known collection from sample_mflix is present and has data.
+                const collsResponse = await integration.mcpClient().callTool({
+                    name: "list-collections",
+                    arguments: { database: "sample_mflix" },
+                });
+                const collsContent = collsResponse.structuredContent as ListCollectionsOutput;
+                const collNames = collsContent.collections.map((c) => c.name);
+                expect(collNames).toContain("movies");
 
-            const findResponse = await integration.mcpClient().callTool({
-                name: "find",
-                arguments: { database: "sample_mflix", collection: "movies", limit: 1 },
-            });
-            const findElements = getResponseElements(findResponse.content);
-            // Element 0 is the summary line ("Query on collection ... resulted in N documents..."),
-            // element 1 (when present) is the document payload.
-            expect(findElements[0]?.text ?? "").toMatch(/resulted in [1-9]\d* documents/);
-        });
+                const findResponse = await integration.mcpClient().callTool({
+                    name: "find",
+                    arguments: { database: "sample_mflix", collection: "movies", limit: 1 },
+                });
+                const findElements = getResponseElements(findResponse.content);
+                // Element 0 is the summary line ("Query on collection ... resulted in N documents..."),
+                // element 1 (when present) is the document payload.
+                expect(findElements[0]?.text ?? "").toMatch(/resulted in [1-9]\d* documents/);
+            }
+        );
 
         it("should create a deployment with imageTag latest", async () => {
             const deploymentName = `test-deployment-latest-${Date.now()}`;

--- a/tests/integration/tools/atlas/atlasHelpers.ts
+++ b/tests/integration/tools/atlas/atlasHelpers.ts
@@ -6,6 +6,7 @@ import { setupIntegrationTest, defaultTestConfig } from "../../helpers.js";
 import type { SuiteCollector } from "vitest";
 import { afterAll, beforeAll, describe } from "vitest";
 import type { Session } from "../../../../src/common/session.js";
+import { sleep } from "../../../../src/common/managedTimeout.js";
 
 export type IntegrationTestFunction = (integration: IntegrationTest) => void;
 
@@ -175,10 +176,6 @@ async function createGroup(apiClient: ApiClient): Promise<Group & Required<Pick<
     });
 
     return group as Group & Required<Pick<Group, "id">>;
-}
-
-export function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export async function assertClusterIsAvailable(

--- a/tests/integration/tools/atlas/clusters.test.ts
+++ b/tests/integration/tools/atlas/clusters.test.ts
@@ -1,3 +1,4 @@
+import { sleep } from "../../../../src/common/managedTimeout.js";
 import type { Session } from "../../../../src/common/session.js";
 import type { ConnectClusterOutput } from "../../../../src/tools/atlas/connect/connectCluster.js";
 import { expectDefined, getResponseContent } from "../../helpers.js";
@@ -8,7 +9,6 @@ import {
     randomId,
     deleteCluster,
     waitCluster,
-    sleep,
     assertApiClientIsAvailable,
 } from "./atlasHelpers.js";
 import { afterAll, beforeAll, describe, expect, it, vitest } from "vitest";

--- a/tests/integration/tools/mongodb/mongodbClusterProcess.ts
+++ b/tests/integration/tools/mongodb/mongodbClusterProcess.ts
@@ -6,6 +6,7 @@ import { MongoCluster } from "mongodb-runner";
 import { MongoClient } from "mongodb";
 import { ConnectionString } from "mongodb-connection-string-url";
 import { ShellWaitStrategy } from "testcontainers/build/wait-strategies/shell-wait-strategy.js";
+import { sleep } from "../../../../src/common/managedTimeout.js";
 
 export type MongoRunnerConfiguration = {
     runner: true;
@@ -165,7 +166,7 @@ export class MongoDBClusterProcess {
                         // Just wait a little bit and retry
                         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
                         console.error(`Failed to start cluster in ${dbsDir}, attempt ${i}: ${err}`);
-                        await new Promise((resolve) => setTimeout(resolve, 1000));
+                        await sleep(1000);
                     } else {
                         // If we still fail after 5 seconds, try another db dir
                         console.error(

--- a/tests/integration/tools/mongodb/mongodbHelpers.ts
+++ b/tests/integration/tools/mongodb/mongodbHelpers.ts
@@ -9,7 +9,6 @@ import {
     setupIntegrationTest,
     defaultTestConfig,
     getDataFromUntrustedContent,
-    timeout,
 } from "../../helpers.js";
 import type { UserConfig } from "../../../../src/common/config/userConfig.js";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,6 +16,7 @@ import { EJSON } from "bson";
 import { MongoDBClusterProcess } from "./mongodbClusterProcess.js";
 import type { MongoClusterConfiguration } from "./mongodbClusterProcess.js";
 import type { createMockElicitInput, MockClientCapabilities } from "../../../utils/elicitationMocks.js";
+import { sleep } from "../../../../src/common/managedTimeout.js";
 
 export const DEFAULT_WAIT_TIMEOUT = 1000;
 export const DEFAULT_RETRY_INTERVAL = 100;
@@ -146,7 +146,7 @@ export function describeWithMongoDB(
                         );
                     }
 
-                    await timeout(CONNECT_RETRY_INTERVAL);
+                    await sleep(CONNECT_RETRY_INTERVAL);
                 }
             },
         });

--- a/tests/integration/transports/createSessionConfig.test.ts
+++ b/tests/integration/transports/createSessionConfig.test.ts
@@ -4,6 +4,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { afterEach, describe, expect, it } from "vitest";
 import type { TransportRunnerConfig, UserConfig } from "../../../src/lib.js";
 import { defaultTestConfig, expectDefined } from "../helpers.js";
+import { sleep } from "../../../src/common/managedTimeout.js";
 
 describe("createSessionConfig", () => {
     const userConfig = defaultTestConfig;
@@ -82,7 +83,7 @@ describe("createSessionConfig", () => {
                 userConfig: { ...userConfig, connectionString: undefined },
                 createSessionConfig: async ({ userConfig }) => {
                     // Simulate fetching connection string from environment or secrets
-                    await new Promise((resolve) => setTimeout(resolve, 10));
+                    await sleep(10);
                     return {
                         ...userConfig,
                         connectionString: "mongodb://test-server:27017/test-db",
@@ -100,7 +101,7 @@ describe("createSessionConfig", () => {
             await startRunner({
                 createSessionConfig: async ({ userConfig }) => {
                     // Simulate async config modification
-                    await new Promise((resolve) => setTimeout(resolve, 10));
+                    await sleep(10);
                     return {
                         ...userConfig,
                         readOnly: true, // Enable read-only mode

--- a/tests/integration/transports/streamableHttp.test.ts
+++ b/tests/integration/transports/streamableHttp.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { LogId, type LoggerBase } from "../../../src/common/logging/index.js";
 import { defaultCreateConnectionManager } from "../../../src/common/connectionManager.js";
 import { Keychain } from "../../../src/common/keychain.js";
-import { defaultTestConfig, InMemoryLogger, timeout } from "../helpers.js";
+import { defaultTestConfig, InMemoryLogger } from "../helpers.js";
 import { type UserConfig } from "../../../src/common/config/userConfig.js";
 import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { OperationType, ToolArgs, ToolCategory, ToolExecutionContext } from "../../../src/tools/tool.js";
@@ -22,6 +22,7 @@ import type { RequestContext } from "../../../src/transports/base.js";
 import type { AnyToolClass, Server } from "../../../src/lib.js";
 import type { IncomingMessage } from "node:http";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { sleep } from "../../../src/common/managedTimeout.js";
 
 describe("StreamableHttpRunner", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -474,7 +475,7 @@ describe("StreamableHttpRunner", () => {
 
                         const sessionBefore = await getSessionFromStore(sessionId);
                         expect(sessionBefore).toBeDefined();
-                        await timeout(1100);
+                        await sleep(1100);
 
                         const sessionAfter = await getSessionFromStore(sessionId);
                         expect(sessionAfter).toBeUndefined();

--- a/tests/unit/common/atlasLocal/connectionString.test.ts
+++ b/tests/unit/common/atlasLocal/connectionString.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Client } from "@mongodb-js/atlas-local";
-import { waitForConnectionString } from "../../../../src/common/atlasLocal/connectionString.js";
+import {
+    AtlasLocalDeploymentNotReadyError,
+    waitForConnectionString,
+} from "../../../../src/common/atlasLocal/connectionString.js";
+
+const portBindingError = new Error("get connection string\n\nCaused by:\n    Missing port binding information");
 
 describe("waitForConnectionString", () => {
     it("returns immediately when port bindings are already available", async () => {
@@ -18,12 +23,8 @@ describe("waitForConnectionString", () => {
         const client = {
             getConnectionString: vi
                 .fn()
-                .mockRejectedValueOnce(
-                    new Error("get connection string\n\nCaused by:\n    Missing port binding information")
-                )
-                .mockRejectedValueOnce(
-                    new Error("get connection string\n\nCaused by:\n    Missing port binding information")
-                )
+                .mockRejectedValueOnce(portBindingError)
+                .mockRejectedValueOnce(portBindingError)
                 .mockResolvedValue("mongodb://localhost:27017"),
         };
 
@@ -44,19 +45,15 @@ describe("waitForConnectionString", () => {
         expect(client.getConnectionString).toHaveBeenCalledTimes(1);
     });
 
-    it("retries up to maxAttempts then throws the last port-binding error", async () => {
+    it("throws AtlasLocalDeploymentNotReadyError after maxAttempts", async () => {
         const maxAttempts = 3;
         const client = {
-            getConnectionString: vi
-                .fn()
-                .mockRejectedValue(
-                    new Error("get connection string\n\nCaused by:\n    Missing port binding information")
-                ),
+            getConnectionString: vi.fn().mockRejectedValue(portBindingError),
         };
 
         await expect(
             waitForConnectionString(client as unknown as Client, "local1", { maxAttempts, intervalMs: 1 })
-        ).rejects.toThrow("Missing port binding information");
+        ).rejects.toBeInstanceOf(AtlasLocalDeploymentNotReadyError);
         expect(client.getConnectionString).toHaveBeenCalledTimes(maxAttempts);
     });
 });

--- a/tests/unit/common/atlasLocal/connectionString.test.ts
+++ b/tests/unit/common/atlasLocal/connectionString.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Client } from "@mongodb-js/atlas-local";
+import { waitForConnectionString } from "../../../../src/common/atlasLocal/connectionString.js";
+
+describe("waitForConnectionString", () => {
+    it("returns immediately when port bindings are already available", async () => {
+        const client = {
+            getConnectionString: vi.fn().mockResolvedValue("mongodb://localhost:27017"),
+        };
+
+        await expect(waitForConnectionString(client as unknown as Client, "local1")).resolves.toBe(
+            "mongodb://localhost:27017"
+        );
+        expect(client.getConnectionString).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries when port bindings are not yet published", async () => {
+        const client = {
+            getConnectionString: vi
+                .fn()
+                .mockRejectedValueOnce(
+                    new Error("get connection string\n\nCaused by:\n    Missing port binding information")
+                )
+                .mockRejectedValueOnce(
+                    new Error("get connection string\n\nCaused by:\n    Missing port binding information")
+                )
+                .mockResolvedValue("mongodb://localhost:27017"),
+        };
+
+        await expect(
+            waitForConnectionString(client as unknown as Client, "local1", { maxAttempts: 5, intervalMs: 1 })
+        ).resolves.toBe("mongodb://localhost:27017");
+        expect(client.getConnectionString).toHaveBeenCalledTimes(3);
+    });
+
+    it("rethrows non-port-binding errors without retrying", async () => {
+        const client = {
+            getConnectionString: vi.fn().mockRejectedValue(new Error("No such container: local1")),
+        };
+
+        await expect(
+            waitForConnectionString(client as unknown as Client, "local1", { maxAttempts: 3, intervalMs: 1 })
+        ).rejects.toThrow("No such container: local1");
+        expect(client.getConnectionString).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries up to maxAttempts then throws the last port-binding error", async () => {
+        const maxAttempts = 3;
+        const client = {
+            getConnectionString: vi
+                .fn()
+                .mockRejectedValue(
+                    new Error("get connection string\n\nCaused by:\n    Missing port binding information")
+                ),
+        };
+
+        await expect(
+            waitForConnectionString(client as unknown as Client, "local1", { maxAttempts, intervalMs: 1 })
+        ).rejects.toThrow("Missing port binding information");
+        expect(client.getConnectionString).toHaveBeenCalledTimes(maxAttempts);
+    });
+});

--- a/tests/unit/common/exportsManager.test.ts
+++ b/tests/unit/common/exportsManager.test.ts
@@ -8,10 +8,11 @@ import type { ExportsManagerConfig } from "../../../src/common/exportsManager.js
 import { ensureExtension, isExportExpired, ExportsManager } from "../../../src/common/exportsManager.js";
 import type { AvailableExport } from "../../../src/common/exportsManager.js";
 import { ROOT_DIR } from "../../accuracy/sdk/constants.js";
-import { defaultTestConfig, timeout } from "../../integration/helpers.js";
+import { defaultTestConfig } from "../../integration/helpers.js";
 import type { EJSONOptions } from "bson";
 import { EJSON, ObjectId } from "bson";
 import { CompositeLogger } from "../../../src/common/logging/index.js";
+import { sleep } from "../../../src/common/managedTimeout.js";
 
 const logger = new CompositeLogger();
 const exportsPath = path.join(ROOT_DIR, "tests", "tmp", `exports-${Date.now()}`);
@@ -75,7 +76,7 @@ function createDummyFindCursor(
     let notifyClose: () => Promise<void>;
     const cursorCloseNotification = new Promise<void>((resolve) => {
         notifyClose = async (): Promise<void> => {
-            await timeout(10);
+            await sleep(10);
             resolve();
         };
     });
@@ -98,7 +99,7 @@ function createDummyFindCursorWithDelay(
     dataArray: unknown[],
     delayMs: number
 ): { cursor: FindCursor; cursorCloseNotification: Promise<void> } {
-    return createDummyFindCursor(dataArray, () => timeout(delayMs));
+    return createDummyFindCursor(dataArray, () => sleep(delayMs));
 }
 
 async function fileExists(filePath: string): Promise<boolean> {
@@ -537,7 +538,7 @@ describe("ExportsManager unit test", () => {
             expect((manager as any).storedExports[exportName]?.exportStatus).toEqual("in-progress");
 
             // After clean up interval the export should still be there
-            await timeout(200);
+            await sleep(200);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
             expect((manager as any).storedExports[exportName]?.exportStatus).toEqual("in-progress");
         });
@@ -568,7 +569,7 @@ describe("ExportsManager unit test", () => {
                 })
             );
             expect(await fileExists(exportPath)).toEqual(true);
-            await timeout(200);
+            await sleep(200);
             expect(manager.availableExports).toEqual([]);
             expect(await fileExists(exportPath)).toEqual(false);
         });
@@ -585,7 +586,7 @@ describe("ExportsManager unit test", () => {
                 jsonExportFormat: "relaxed",
             });
             // Give the pipeline a brief moment to start and create the file
-            await timeout(50);
+            await sleep(50);
 
             await manager.close();
 


### PR DESCRIPTION
## Proposed changes

`atlas-local-create-deployment` would return as soon as the healthcheck returns healthy, even if the sample dataset isn't loaded yet. This caused connect-deployment to fail with a "missing binding port error". With this change, we're waiting for the connection string to become available before we return from create-deployment.
