### PR TITLE
chore: pin nodejs to v22 for braintrust CLOUDP-367319

### DIFF
--- a/.github/workflows/braintrust-evals.yml
+++ b/.github/workflows/braintrust-evals.yml
@@ -39,8 +39,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Push eval to Braintrust
-        # TODO: uncomment after testing
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: pnpm run eval:push
       - name: Start local MongoDB
         run: pnpm run eval:db-start

--- a/.github/workflows/braintrust-evals.yml
+++ b/.github/workflows/braintrust-evals.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
       VOYAGE_API_KEY: ${{ secrets.TEST_MDB_MCP_VOYAGE_API_KEY }}
+      EMBEDDING_PROVIDER_ENDPOINT: "https://api.voyageai.com/v1/embeddings"
       GIT_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       # Limits concurrent evals to avoid slowdowns from simultaneous database or text/vector index creation per eval case
       EVAL_MAX_CONCURRENCY: 10

--- a/.github/workflows/braintrust-evals.yml
+++ b/.github/workflows/braintrust-evals.yml
@@ -32,12 +32,15 @@ jobs:
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
-          node-version-file: package.json
+          # Braintrust push accepts Node 18–22 only
+          # https://www.braintrust.dev/docs/evaluate/remote-evals#2-register-your-sandbox
+          node-version: "22"
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Push eval to Braintrust
-        if: github.ref == 'refs/heads/main'
+        # TODO: uncomment after testing
+        # if: github.ref == 'refs/heads/main'
         run: pnpm run eval:push
       - name: Start local MongoDB
         run: pnpm run eval:db-start

--- a/.github/workflows/braintrust-evals.yml
+++ b/.github/workflows/braintrust-evals.yml
@@ -24,7 +24,7 @@ jobs:
       EMBEDDING_PROVIDER_ENDPOINT: "https://api.voyageai.com/v1/embeddings"
       GIT_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       # Limits concurrent evals to avoid slowdowns from simultaneous database or text/vector index creation per eval case
-      EVAL_MAX_CONCURRENCY: 10
+      EVAL_MAX_CONCURRENCY: 25
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       - uses: actions/checkout@v6

--- a/tests/eval/lib/seeding.ts
+++ b/tests/eval/lib/seeding.ts
@@ -7,7 +7,7 @@ import { sleep } from "../../../src/common/managedTimeout.js";
 // │   ↘️ Seeding Constants                       │
 // ╰──────────────────────────────────────────────╯
 
-const DEFAULT_INDEX_READY_TIMEOUT_MS = 120_000;
+const DEFAULT_INDEX_READY_TIMEOUT_MS = 300_000;
 const DEFAULT_INDEX_READY_INTERVAL_MS = 1_000;
 
 /**

--- a/tests/eval/scripts/evalDb.sh
+++ b/tests/eval/scripts/evalDb.sh
@@ -8,6 +8,7 @@ IMAGE_TAG=preview
 start() {
 
 	if [ -z "$VOYAGE_API_KEY" ]; then
+		echo "⚠️ EMBEDDING_PROVIDER_ENDPOINT environment variable is not set using default value"
 		echo "⚠️ VOYAGE_API_KEY environment variable is not set"
 		echo "   without it, the local MongoDB instance will not be able to use auto-embed vector search."
 		echo "   You can get it from the Voyage AI dashboard"
@@ -21,6 +22,7 @@ start() {
 		--name="$CONTAINER_NAME" \
 		--publish=27017:27017 \
 		--env VOYAGE_API_KEY="$VOYAGE_API_KEY" \
+		--env EMBEDDING_PROVIDER_ENDPOINT="$EMBEDDING_PROVIDER_ENDPOINT" \
 		"$IMAGE:$IMAGE_TAG"
     docker logs -f "$CONTAINER_NAME" &
     LOG_PID=$!

--- a/tests/eval/scripts/evalDb.sh
+++ b/tests/eval/scripts/evalDb.sh
@@ -7,8 +7,12 @@ IMAGE_TAG=preview
 
 start() {
 
-	if [ -z "$VOYAGE_API_KEY" ]; then
+	if [ -z "$EMBEDDING_PROVIDER_ENDPOINT" ]; then
+		EMBEDDING_PROVIDER_ENDPOINT="https://api.voyageai.com/v1/embeddings"
 		echo "⚠️ EMBEDDING_PROVIDER_ENDPOINT environment variable is not set using default value"
+	fi
+
+	if [ -z "$VOYAGE_API_KEY" ]; then
 		echo "⚠️ VOYAGE_API_KEY environment variable is not set"
 		echo "   without it, the local MongoDB instance will not be able to use auto-embed vector search."
 		echo "   You can get it from the Voyage AI dashboard"


### PR DESCRIPTION
1. `braintrust push` rejects the Node version inherited from `package.json`'s `engines` field (Node 24), because Braintrust's upload API only accepts Node 18, 20, 21, or 22. This pins the Braintrust Evals workflow to Node 22 to avoid this issue.

2. 🔌 Set `EMBEDDING_PROVIDER_ENDPOINT` to `https://api.voyageai.com/v1/embeddings` (Voyage API legacy endpoint) and passes it through to the local MongoDB container so auto-embed vector search can use `TEST_MDB_MCP_VOYAGE_API_KEY` secret. Prior to this PR, auto-embed tests were failing with a timeout error (waiting indefinitely for the indexing to complete and index to be queryable).