### PR TITLE
chore: Adds logging support to mongodb-atlas-mcp-remote MCP-537

### DIFF
--- a/packages/mongodb-atlas-mcp-remote/package.json
+++ b/packages/mongodb-atlas-mcp-remote/package.json
@@ -29,7 +29,9 @@
     "@cfworker/json-schema": "4.1.1",
     "@modelcontextprotocol/client": "2.0.0-alpha.2",
     "@modelcontextprotocol/server": "2.0.0-alpha.2",
-    "@mongodb-js/devtools-proxy-support": "^0.7.14"
+    "@mongodb-js/devtools-proxy-support": "^0.7.14",
+    "mongodb-log-writer": "^2.5.13",
+    "mongodb-redact": "^1.4.6"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/mongodb-atlas-mcp-remote/src/cli.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/cli.ts
@@ -111,9 +111,7 @@ async function main(): Promise<void> {
                     ...(code !== undefined ? { code } : {}),
                     ...(status !== undefined ? { status: String(status) } : {}),
                     // Only include the error text when there is no HTTP status (network/timeout errors carry no body).
-                    ...(status === undefined
-                        ? { error: error instanceof Error ? error.message : String(error) }
-                        : {}),
+                    ...(status === undefined ? { error: error instanceof Error ? error.message : String(error) } : {}),
                 },
             });
 
@@ -162,8 +160,8 @@ main().catch((error) => {
 // Builds redaction-safe log attributes from a JSON-RPC message: metadata only, no params/body.
 function messageAttributes(method: unknown, id: unknown): Record<string, string> {
     return {
-        ...(method !== undefined ? { method: String(method) } : {}),
-        ...(id !== undefined ? { id: String(id) } : {}),
+        ...(method !== undefined ? { method: String(method as string | number) } : {}),
+        ...(id !== undefined ? { id: String(id as string | number) } : {}),
     };
 }
 

--- a/packages/mongodb-atlas-mcp-remote/src/cli.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/cli.ts
@@ -91,13 +91,6 @@ async function main(): Promise<void> {
         const method = "method" in message ? message.method : undefined;
         const messageId = "id" in message ? message.id : undefined;
 
-        logger.debug({
-            id: LogId.messageForwarded,
-            context: "cli",
-            message: "Forwarding message to remote MCP server",
-            attributes: messageAttributes(method, messageId),
-        });
-
         // Catch errors at the send call so we can log the request context (method/id) and reply with the id.
         void httpTransport.send(message).catch((error: unknown) => {
             const { code, status } = extractSdkError(error);
@@ -116,10 +109,18 @@ async function main(): Promise<void> {
             });
 
             if (messageId !== undefined) {
+                // Mirror the log sanitization: when the SDK provides an HTTP status, error.message
+                // carries the raw (possibly large/sensitive) response body, so return status/code instead.
+                const clientMessage =
+                    status !== undefined
+                        ? `Remote request failed with status ${status}${code !== undefined ? ` (${code})` : ""}`
+                        : error instanceof Error
+                          ? error.message
+                          : String(error);
                 void stdioTransport.send({
                     jsonrpc: "2.0",
                     id: messageId,
-                    error: { code: -32603, message: error instanceof Error ? error.message : String(error) },
+                    error: { code: -32603, message: clientMessage },
                 });
             }
         });

--- a/packages/mongodb-atlas-mcp-remote/src/cli.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/cli.ts
@@ -16,8 +16,7 @@ async function main(): Promise<void> {
         config = loadConfig();
     } catch (error) {
         if (error instanceof ConfigurationError) {
-            // Logger not configured yet, write to stderr directly.
-            process.stderr.write(`${error.message}\n`);
+            logger.error({ id: LogId.configError, context: "cli", message: error.message });
             process.exit(1);
         }
         throw error;
@@ -73,17 +72,55 @@ async function main(): Promise<void> {
 
     const stdioTransport = new StdioServerTransport();
 
+    let sessionLogged = false;
     httpTransport.onmessage = (message: JSONRPCMessage): void => {
+        // The remote assigns the session id on the initialize response; log it once for correlation.
+        if (!sessionLogged && httpTransport.sessionId !== undefined) {
+            sessionLogged = true;
+            logger.debug({
+                id: LogId.sessionInfo,
+                context: "cli",
+                message: "Remote MCP session established",
+                attributes: { sessionId: httpTransport.sessionId },
+            });
+        }
         void stdioTransport.send(message);
     };
 
     stdioTransport.onmessage = (message: JSONRPCMessage): void => {
-        // Catch errors here rather than in httpTransport.onerror so we can access the message id.
+        const method = "method" in message ? message.method : undefined;
+        const messageId = "id" in message ? message.id : undefined;
+
+        logger.debug({
+            id: LogId.messageForwarded,
+            context: "cli",
+            message: "Forwarding message to remote MCP server",
+            attributes: messageAttributes(method, messageId),
+        });
+
+        // Catch errors at the send call so we can log the request context (method/id) and reply with the id.
         void httpTransport.send(message).catch((error: unknown) => {
-            if ("id" in message) {
+            const { code, status } = extractSdkError(error);
+            logger.error({
+                id: LogId.httpSendError,
+                context: "cli",
+                message: "Failed to forward message to remote MCP server",
+                attributes: {
+                    ...messageAttributes(method, messageId),
+                    // Prefer the structured code/status over error.message, which carries the raw response body.
+                    ...(code !== undefined ? { code } : {}),
+                    ...(status !== undefined ? { status: String(status) } : {}),
+                    // Only include the error text when there is no HTTP status (network/timeout errors carry no body).
+                    ...(status === undefined
+                        ? { error: error instanceof Error ? error.message : String(error) }
+                        : {}),
+                },
+            });
+
+            if (messageId !== undefined) {
                 void stdioTransport.send({
                     jsonrpc: "2.0",
-                    id: message.id,
+                    id: messageId,
                     error: { code: -32603, message: error instanceof Error ? error.message : String(error) },
                 });
             }
@@ -121,6 +158,26 @@ main().catch((error) => {
     process.stderr.write(`Fatal error: ${String(error)}\n`);
     process.exit(1);
 });
+
+// Builds redaction-safe log attributes from a JSON-RPC message: metadata only, no params/body.
+function messageAttributes(method: unknown, id: unknown): Record<string, string> {
+    return {
+        ...(method !== undefined ? { method: String(method) } : {}),
+        ...(id !== undefined ? { id: String(id) } : {}),
+    };
+}
+
+// Extracts the SDK error's code and HTTP status without touching error.message (which carries the response body).
+function extractSdkError(error: unknown): { code?: string; status?: number } {
+    if (typeof error === "object" && error !== null) {
+        const e = error as { code?: unknown; data?: { status?: unknown } };
+        return {
+            code: typeof e.code === "string" ? e.code : undefined,
+            status: typeof e.data?.status === "number" ? e.data.status : undefined,
+        };
+    }
+    return {};
+}
 
 // devtools-proxy-support uses node-fetch, which has a node Readable response body.
 // The SDK's SSE parser calls pipeThrough(), which only exists on Web ReadableStream.

--- a/packages/mongodb-atlas-mcp-remote/src/cli.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/cli.ts
@@ -7,7 +7,8 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/client";
 import { StdioServerTransport } from "@modelcontextprotocol/server";
 import { loadConfig, ConfigurationError } from "./config.js";
 import { TokenManager, TokenError } from "./tokenManager.js";
-import { logger } from "./logger.js";
+import { logger, addSecret } from "./logger.js";
+import { LogId } from "./logging/index.js";
 
 async function main(): Promise<void> {
     let config;
@@ -22,12 +23,17 @@ async function main(): Promise<void> {
         throw error;
     }
 
-    logger.setLevel(config.logLevel);
+    addSecret(config.clientId);
+    addSecret(config.clientSecret);
 
     try {
         await systemCA();
     } catch (error) {
-        logger.warning(`Failed to load system CA certificates: ${String(error)}`);
+        logger.warning({
+            id: LogId.systemCaWarning,
+            context: "cli",
+            message: `Failed to load system CA certificates: ${String(error)}`,
+        });
     }
 
     const proxyFetch = createFetch({ useEnvironmentVariableProxies: true }) as unknown as FetchLike;
@@ -52,7 +58,11 @@ async function main(): Promise<void> {
         await tokenManager.getToken();
     } catch (error) {
         const message = error instanceof TokenError ? error.message : String(error);
-        logger.error(`Failed to acquire access token: ${message}`);
+        logger.error({
+            id: LogId.tokenFetchError,
+            context: "cli",
+            message: `Failed to acquire access token: ${message}`,
+        });
         process.exit(1);
     }
 
@@ -80,14 +90,19 @@ async function main(): Promise<void> {
         });
     };
     stdioTransport.onerror = (error: Error): void => {
-        logger.error("Stdio transport error", { error: String(error) });
+        logger.error({
+            id: LogId.stdioTransportError,
+            context: "cli",
+            message: "Stdio transport error",
+            attributes: { error: String(error) },
+        });
     };
     stdioTransport.onclose = (): void => {
         process.exit(0);
     };
 
     const shutdown = (): void => {
-        logger.info("Shutting down");
+        logger.info({ id: LogId.shutdown, context: "cli", message: "Shutting down" });
         void httpTransport.close();
         void stdioTransport.close();
         process.exit(0);

--- a/packages/mongodb-atlas-mcp-remote/src/common.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/common.ts
@@ -9,14 +9,10 @@ export interface CachedToken {
     expiresAt: number;
 }
 
-export const LOG_LEVELS = ["debug", "info", "notice", "warning", "error", "critical", "alert", "emergency"] as const;
-export type LogLevel = (typeof LOG_LEVELS)[number];
-
 export interface AppConfig {
     remoteUrl: string;
     tokenUrl: string;
     clientId: string;
     clientSecret: string;
     tokenTimeoutMs: number;
-    logLevel: LogLevel;
 }

--- a/packages/mongodb-atlas-mcp-remote/src/config.test.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/config.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { loadConfig, ConfigurationError } from "./config.js";
-import { LOG_LEVELS } from "./common.js";
 import type { AppConfig } from "./common.js";
 
 const TEST_CLIENT_ID = "client-id";
@@ -10,7 +9,6 @@ const CONFIG_ENV_VARS = [
     "MDB_MCP_API_CLIENT_ID",
     "MDB_MCP_API_CLIENT_SECRET",
     "MDB_MCP_API_BASE_URL",
-    "MDB_MCP_LOG_LEVEL",
     "MDB_MCP_TOKEN_TIMEOUT_MS",
 ] as const;
 
@@ -34,7 +32,6 @@ const DEFAULT_CONFIG: AppConfig = {
     clientSecret: TEST_CLIENT_SECRET,
     tokenUrl: "https://cloud.mongodb.com/api/oauth/token",
     remoteUrl: "https://cloud.mongodb.com/api/private/mcp",
-    logLevel: "info",
     tokenTimeoutMs: 10_000,
 };
 
@@ -54,14 +51,6 @@ describe("loadConfig", () => {
         it("basic config", () => {
             stubSA();
             expect(loadConfig()).toEqual(DEFAULT_CONFIG);
-        });
-
-        it("accepts all valid log levels", () => {
-            stubSA();
-            for (const level of LOG_LEVELS) {
-                vi.stubEnv("MDB_MCP_LOG_LEVEL", level);
-                expect(loadConfig()).toEqual({ ...DEFAULT_CONFIG, logLevel: level });
-            }
         });
 
         it("accepts MDB_MCP_API_BASE_URL", () => {
@@ -100,15 +89,6 @@ describe("loadConfig", () => {
 
             const error = loadConfigExpectConfigurationError();
             expect(error.errors).toContain("MDB_MCP_API_CLIENT_SECRET is required");
-        });
-
-        it("throws ConfigurationError for invalid log levels", () => {
-            stubSA();
-            vi.stubEnv("MDB_MCP_LOG_LEVEL", "invalid");
-
-            const error = loadConfigExpectConfigurationError();
-            expect(error.errors[0]).toContain("MDB_MCP_LOG_LEVEL must be one of");
-            expect(error.errors[0]).toContain("got: invalid");
         });
 
         it("throws ConfigurationError for invalid token timeouts", () => {

--- a/packages/mongodb-atlas-mcp-remote/src/config.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/config.ts
@@ -1,9 +1,7 @@
-import { LOG_LEVELS } from "./common.js";
-import type { AppConfig, LogLevel } from "./common.js";
+import type { AppConfig } from "./common.js";
 
 const DEFAULT_BASE_URL = "https://cloud.mongodb.com";
 const DEFAULT_TOKEN_TIMEOUT_MS = 10_000;
-const DEFAULT_LOG_LEVEL: LogLevel = "info";
 
 function loadPosIntEnvVar(name: string, defaultValue: number, errors: string[]): number {
     const value = process.env[name];
@@ -36,14 +34,6 @@ export function loadConfig(): AppConfig {
 
     const tokenTimeoutMs = loadPosIntEnvVar("MDB_MCP_TOKEN_TIMEOUT_MS", DEFAULT_TOKEN_TIMEOUT_MS, errors);
 
-    let logLevel: LogLevel = DEFAULT_LOG_LEVEL;
-    if (process.env.MDB_MCP_LOG_LEVEL) {
-        logLevel = process.env.MDB_MCP_LOG_LEVEL.toLowerCase() as LogLevel;
-        if (!LOG_LEVELS.includes(logLevel)) {
-            errors.push(`MDB_MCP_LOG_LEVEL must be one of: ${LOG_LEVELS.join(", ")}, got: ${logLevel}`);
-        }
-    }
-
     if (errors.length > 0) {
         throw new ConfigurationError(errors);
     }
@@ -54,7 +44,6 @@ export function loadConfig(): AppConfig {
         tokenUrl: new URL("/api/oauth/token", baseUrl).toString(),
         remoteUrl: new URL("/api/private/mcp", baseUrl).toString(), // TODO: Switch to https://mcp.mongodb.com/mcp once available across all environments.
         tokenTimeoutMs,
-        logLevel,
     };
 }
 

--- a/packages/mongodb-atlas-mcp-remote/src/logger.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logger.ts
@@ -2,8 +2,16 @@ import type { Secret } from "mongodb-redact";
 import { CompositeLogger, ConsoleLogger } from "./logging/index.js";
 
 const secrets: Secret[] = [];
-export const logger = new CompositeLogger(new ConsoleLogger(() => secrets));
+let accessTokenSecret: Secret | null = null;
+
+export const logger = new CompositeLogger(
+    new ConsoleLogger(() => (accessTokenSecret ? [...secrets, accessTokenSecret] : [...secrets]))
+);
 
 export function addSecret(secret: string): void {
     secrets.push({ value: secret, kind: "password" });
+}
+
+export function setAccessToken(token: string): void {
+    accessTokenSecret = { value: token, kind: "password" };
 }

--- a/packages/mongodb-atlas-mcp-remote/src/logger.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logger.ts
@@ -1,56 +1,9 @@
-import { LOG_LEVELS } from "./common.js";
-import type { LogLevel } from "./common.js";
+import type { Secret } from "mongodb-redact";
+import { CompositeLogger, ConsoleLogger } from "./logging/index.js";
 
-export interface Logger {
-    setLevel(level: LogLevel): void;
-    debug(message: string, data?: unknown): void;
-    info(message: string, data?: unknown): void;
-    notice(message: string, data?: unknown): void;
-    warning(message: string, data?: unknown): void;
-    error(message: string, data?: unknown): void;
-    critical(message: string, data?: unknown): void;
-    alert(message: string, data?: unknown): void;
-    emergency(message: string, data?: unknown): void;
+const secrets: Secret[] = [];
+export const logger = new CompositeLogger(new ConsoleLogger(() => secrets));
+
+export function addSecret(secret: string): void {
+    secrets.push({ value: secret, kind: "password" });
 }
-
-// TODO: Tmp implementation, complete logger implementation in MCP-537
-class SimpleLogger implements Logger {
-    private level: LogLevel = "info";
-
-    setLevel(level: LogLevel): void {
-        this.level = level;
-    }
-
-    private log(level: LogLevel, message: string, data?: unknown): void {
-        if (LOG_LEVELS.indexOf(level) < LOG_LEVELS.indexOf(this.level)) return;
-        const dataStr = data !== undefined ? ` ${JSON.stringify(data)}` : "";
-        console.error(`[${level.toUpperCase()}] ${message}${dataStr}`);
-    }
-
-    debug(message: string, data?: unknown): void {
-        this.log("debug", message, data);
-    }
-    info(message: string, data?: unknown): void {
-        this.log("info", message, data);
-    }
-    notice(message: string, data?: unknown): void {
-        this.log("notice", message, data);
-    }
-    warning(message: string, data?: unknown): void {
-        this.log("warning", message, data);
-    }
-    error(message: string, data?: unknown): void {
-        this.log("error", message, data);
-    }
-    critical(message: string, data?: unknown): void {
-        this.log("critical", message, data);
-    }
-    alert(message: string, data?: unknown): void {
-        this.log("alert", message, data);
-    }
-    emergency(message: string, data?: unknown): void {
-        this.log("emergency", message, data);
-    }
-}
-
-export const logger: Logger = new SimpleLogger();

--- a/packages/mongodb-atlas-mcp-remote/src/logging/compositeLogger.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logging/compositeLogger.ts
@@ -1,0 +1,39 @@
+import type { LoggerType, LogLevel, LogPayload } from "./loggingTypes.js";
+import { LoggerBase } from "./loggerBase.js";
+
+export class CompositeLogger extends LoggerBase {
+    protected readonly type?: LoggerType;
+
+    private readonly loggers: LoggerBase[] = [];
+    private readonly attributes: Record<string, string> = {};
+
+    constructor(...loggers: LoggerBase[]) {
+        // composite logger does not redact, only the actual delegates do the work
+        super(undefined);
+
+        this.loggers = loggers;
+    }
+
+    public addLogger(logger: LoggerBase): void {
+        this.loggers.push(logger);
+    }
+
+    public log(level: LogLevel, payload: LogPayload): void {
+        // Override the public method to avoid the base logger redacting the message payload
+        for (const logger of this.loggers) {
+            const attributes =
+                Object.keys(this.attributes).length > 0 || payload.attributes
+                    ? { ...this.attributes, ...payload.attributes }
+                    : undefined;
+            logger.log(level, { ...payload, attributes });
+        }
+    }
+
+    protected logCore(): void {
+        throw new Error("logCore should never be invoked on CompositeLogger");
+    }
+
+    public setAttribute(key: string, value: string): void {
+        this.attributes[key] = value;
+    }
+}

--- a/packages/mongodb-atlas-mcp-remote/src/logging/consoleLogger.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logging/consoleLogger.ts
@@ -1,0 +1,28 @@
+import type { Secret } from "mongodb-redact";
+import type { LoggerType, LogLevel, LogPayload } from "./loggingTypes.js";
+import { LoggerBase } from "./loggerBase.js";
+
+export class ConsoleLogger extends LoggerBase {
+    protected readonly type: LoggerType = "console";
+
+    public constructor(getSecrets?: () => Secret[]) {
+        super(getSecrets);
+    }
+
+    protected logCore(level: LogLevel, payload: LogPayload): void {
+        const { id, context, message } = payload;
+        // eslint-disable-next-line no-console
+        console.error(
+            `[${level.toUpperCase()}] ${id.__value} - ${context}: ${message}${this.serializeAttributes(payload.attributes)}`
+        );
+    }
+
+    private serializeAttributes(attributes?: Record<string, string>): string {
+        if (!attributes || Object.keys(attributes).length === 0) {
+            return "";
+        }
+        return ` (${Object.entries(attributes)
+            .map(([key, value]) => `${key}=${value}`)
+            .join(", ")})`;
+    }
+}

--- a/packages/mongodb-atlas-mcp-remote/src/logging/consoleLogger.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logging/consoleLogger.ts
@@ -11,7 +11,6 @@ export class ConsoleLogger extends LoggerBase {
 
     protected logCore(level: LogLevel, payload: LogPayload): void {
         const { id, context, message } = payload;
-        // eslint-disable-next-line no-console
         console.error(
             `[${level.toUpperCase()}] ${id.__value} - ${context}: ${message}${this.serializeAttributes(payload.attributes)}`
         );

--- a/packages/mongodb-atlas-mcp-remote/src/logging/index.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logging/index.ts
@@ -1,0 +1,5 @@
+export { LogId } from "./loggingDefinitions.js";
+export type * from "./loggingTypes.js";
+export { LoggerBase } from "./loggerBase.js";
+export { CompositeLogger } from "./compositeLogger.js";
+export { ConsoleLogger } from "./consoleLogger.js";

--- a/packages/mongodb-atlas-mcp-remote/src/logging/loggerBase.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logging/loggerBase.ts
@@ -1,0 +1,114 @@
+import { EventEmitter } from "events";
+import { redact } from "mongodb-redact";
+import type { Secret } from "mongodb-redact";
+import type { LoggerType, LogLevel, LogPayload, EventMap, DefaultEventMap } from "./loggingTypes.js";
+
+export abstract class LoggerBase<T extends EventMap<T> = DefaultEventMap> extends EventEmitter<T> {
+    private readonly defaultUnredactedLogger: LoggerType = "mcp";
+
+    constructor(private readonly getSecrets?: () => Secret[]) {
+        super();
+    }
+
+    public log(level: LogLevel, payload: LogPayload): void {
+        // If no explicit value is supplied for unredacted loggers, default to "mcp"
+        const noRedaction = payload.noRedaction !== undefined ? payload.noRedaction : this.defaultUnredactedLogger;
+
+        this.logCore(level, {
+            ...payload,
+            message: this.redactIfNecessary(payload.message, noRedaction),
+            attributes: this.redactAttributes(payload.attributes, noRedaction),
+        });
+    }
+
+    protected abstract readonly type?: LoggerType;
+
+    protected abstract logCore(level: LogLevel, payload: LogPayload): void;
+
+    private redactAttributes(
+        attributes: Record<string, string> | undefined,
+        noRedaction: LogPayload["noRedaction"]
+    ): Record<string, string> | undefined {
+        if (!attributes) {
+            return undefined;
+        }
+        const redacted: Record<string, string> = {};
+        for (const [key, value] of Object.entries(attributes)) {
+            redacted[key] = this.redactIfNecessary(value, noRedaction);
+        }
+        return redacted;
+    }
+
+    private redactIfNecessary(message: string, noRedaction: LogPayload["noRedaction"]): string {
+        if (typeof noRedaction === "boolean" && noRedaction) {
+            return message;
+        }
+
+        if (typeof noRedaction === "string" && noRedaction === this.type) {
+            return message;
+        }
+
+        if (
+            typeof noRedaction === "object" &&
+            Array.isArray(noRedaction) &&
+            this.type &&
+            noRedaction.indexOf(this.type) !== -1
+        ) {
+            return message;
+        }
+
+        return redact(message, this.getSecrets?.() ?? []);
+    }
+
+    public info(payload: LogPayload): void {
+        this.log("info", payload);
+    }
+
+    public error(payload: LogPayload): void {
+        this.log("error", payload);
+    }
+
+    public debug(payload: LogPayload): void {
+        this.log("debug", payload);
+    }
+
+    public notice(payload: LogPayload): void {
+        this.log("notice", payload);
+    }
+
+    public warning(payload: LogPayload): void {
+        this.log("warning", payload);
+    }
+
+    public critical(payload: LogPayload): void {
+        this.log("critical", payload);
+    }
+
+    public alert(payload: LogPayload): void {
+        this.log("alert", payload);
+    }
+
+    public emergency(payload: LogPayload): void {
+        this.log("emergency", payload);
+    }
+
+    protected mapToMongoDBLogLevel(level: LogLevel): "info" | "warn" | "error" | "debug" | "fatal" {
+        switch (level) {
+            case "info":
+                return "info";
+            case "warning":
+                return "warn";
+            case "error":
+                return "error";
+            case "notice":
+            case "debug":
+                return "debug";
+            case "critical":
+            case "alert":
+            case "emergency":
+                return "fatal";
+            default:
+                return "info";
+        }
+    }
+}

--- a/packages/mongodb-atlas-mcp-remote/src/logging/loggingDefinitions.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logging/loggingDefinitions.ts
@@ -1,0 +1,10 @@
+import { mongoLogId } from "mongodb-log-writer";
+
+export const LogId = {
+    systemCaWarning: mongoLogId(1_014_001),
+    tokenFetch: mongoLogId(1_014_002),
+    tokenAcquired: mongoLogId(1_014_003),
+    tokenFetchError: mongoLogId(1_014_004),
+    stdioTransportError: mongoLogId(1_014_005),
+    shutdown: mongoLogId(1_014_006),
+} as const;

--- a/packages/mongodb-atlas-mcp-remote/src/logging/loggingDefinitions.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logging/loggingDefinitions.ts
@@ -9,7 +9,5 @@ export const LogId = {
     shutdown: mongoLogId(1_014_006),
     httpSendError: mongoLogId(1_014_007),
     sessionInfo: mongoLogId(1_014_008),
-    messageForwarded: mongoLogId(1_014_009),
-    tokenReused: mongoLogId(1_014_010),
     configError: mongoLogId(1_014_011),
 } as const;

--- a/packages/mongodb-atlas-mcp-remote/src/logging/loggingDefinitions.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logging/loggingDefinitions.ts
@@ -7,4 +7,9 @@ export const LogId = {
     tokenFetchError: mongoLogId(1_014_004),
     stdioTransportError: mongoLogId(1_014_005),
     shutdown: mongoLogId(1_014_006),
+    httpSendError: mongoLogId(1_014_007),
+    sessionInfo: mongoLogId(1_014_008),
+    messageForwarded: mongoLogId(1_014_009),
+    tokenReused: mongoLogId(1_014_010),
+    configError: mongoLogId(1_014_011),
 } as const;

--- a/packages/mongodb-atlas-mcp-remote/src/logging/loggingTypes.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/logging/loggingTypes.ts
@@ -1,0 +1,18 @@
+import type { MongoLogId } from "mongodb-log-writer";
+
+export type LogLevel = "debug" | "info" | "notice" | "warning" | "error" | "critical" | "alert" | "emergency";
+
+export type LoggerType = "console" | "disk" | "mcp";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type EventMap<T> = Record<keyof T, any[]>;
+
+export type DefaultEventMap = Record<string, never[]>;
+
+export type LogPayload = {
+    id: MongoLogId;
+    context: string;
+    message: string;
+    noRedaction?: boolean | LoggerType | LoggerType[];
+    attributes?: Record<string, string>;
+};

--- a/packages/mongodb-atlas-mcp-remote/src/tokenManager.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/tokenManager.ts
@@ -32,12 +32,6 @@ export class TokenManager {
 
     async getToken(): Promise<string> {
         if (this.cachedToken && Date.now() < this.cachedToken.expiresAt - TOKEN_EXPIRY_BUFFER_MS) {
-            logger.debug({
-                id: LogId.tokenReused,
-                context: "tokenManager",
-                message: "Reusing cached access token",
-                attributes: { expiresIn: `${Math.round((this.cachedToken.expiresAt - Date.now()) / 1000)}s` },
-            });
             return this.cachedToken.accessToken;
         }
 

--- a/packages/mongodb-atlas-mcp-remote/src/tokenManager.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/tokenManager.ts
@@ -1,7 +1,7 @@
 import type { FetchLike } from "@modelcontextprotocol/client";
 import type { CachedToken, TokenResponse } from "./common.js";
 import { packageInfo } from "./packageInfo.js";
-import { logger } from "./logger.js";
+import { logger, addSecret } from "./logger.js";
 import { LogId } from "./logging/index.js";
 
 const TOKEN_EXPIRY_BUFFER_MS = 10 * 60 * 1000; // 10 minutes
@@ -32,6 +32,12 @@ export class TokenManager {
 
     async getToken(): Promise<string> {
         if (this.cachedToken && Date.now() < this.cachedToken.expiresAt - TOKEN_EXPIRY_BUFFER_MS) {
+            logger.debug({
+                id: LogId.tokenReused,
+                context: "tokenManager",
+                message: "Reusing cached access token",
+                attributes: { expiresIn: `${Math.round((this.cachedToken.expiresAt - Date.now()) / 1000)}s` },
+            });
             return this.cachedToken.accessToken;
         }
 
@@ -98,6 +104,8 @@ export class TokenManager {
             accessToken: data.access_token,
             expiresAt: Date.now() + expiresInS * 1000,
         };
+
+        addSecret(token.accessToken);
 
         logger.debug({
             id: LogId.tokenAcquired,

--- a/packages/mongodb-atlas-mcp-remote/src/tokenManager.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/tokenManager.ts
@@ -1,7 +1,7 @@
 import type { FetchLike } from "@modelcontextprotocol/client";
 import type { CachedToken, TokenResponse } from "./common.js";
 import { packageInfo } from "./packageInfo.js";
-import { logger, addSecret } from "./logger.js";
+import { logger, setAccessToken } from "./logger.js";
 import { LogId } from "./logging/index.js";
 
 const TOKEN_EXPIRY_BUFFER_MS = 10 * 60 * 1000; // 10 minutes
@@ -105,7 +105,7 @@ export class TokenManager {
             expiresAt: Date.now() + expiresInS * 1000,
         };
 
-        addSecret(token.accessToken);
+        setAccessToken(token.accessToken);
 
         logger.debug({
             id: LogId.tokenAcquired,

--- a/packages/mongodb-atlas-mcp-remote/src/tokenManager.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/tokenManager.ts
@@ -2,6 +2,7 @@ import type { FetchLike } from "@modelcontextprotocol/client";
 import type { CachedToken, TokenResponse } from "./common.js";
 import { packageInfo } from "./packageInfo.js";
 import { logger } from "./logger.js";
+import { LogId } from "./logging/index.js";
 
 const TOKEN_EXPIRY_BUFFER_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -57,7 +58,7 @@ export class TokenManager {
     }
 
     private async fetchToken(): Promise<CachedToken> {
-        logger.debug("Fetching new access token");
+        logger.debug({ id: LogId.tokenFetch, context: "tokenManager", message: "Fetching new access token" });
 
         const credentials = Buffer.from(`${this.clientId}:${this.clientSecret}`).toString("base64");
 
@@ -98,7 +99,12 @@ export class TokenManager {
             expiresAt: Date.now() + expiresInS * 1000,
         };
 
-        logger.debug(`Token acquired, expires in ${expiresInS}s`);
+        logger.debug({
+            id: LogId.tokenAcquired,
+            context: "tokenManager",
+            message: "Token acquired",
+            attributes: { expiresIn: `${expiresInS}s` },
+        });
         return token;
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,13 +101,6 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
-    optionalDependencies:
-      '@mongodb-js/atlas-local':
-        specifier: ^1.3.0
-        version: 1.3.0
-      kerberos:
-        specifier: ^7.0.0
-        version: 7.0.0
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.71
@@ -189,7 +182,7 @@ importers:
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/eslint-plugin':
         specifier: ^1.6.19
-        version: 1.6.19(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.61.0(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.6.19(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.61.0(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)
       ai:
         specifier: ^6.0.175
         version: 6.0.175(zod@4.4.3)
@@ -286,6 +279,13 @@ importers:
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+    optionalDependencies:
+      '@mongodb-js/atlas-local':
+        specifier: ^1.3.0
+        version: 1.3.0
+      kerberos:
+        specifier: ^7.0.0
+        version: 7.0.0
 
   packages/metrics:
     dependencies:
@@ -317,6 +317,12 @@ importers:
       '@mongodb-js/devtools-proxy-support':
         specifier: ^0.7.14
         version: 0.7.14
+      mongodb-log-writer:
+        specifier: ^2.5.13
+        version: 2.5.13(bson@7.3.0)
+      mongodb-redact:
+        specifier: ^1.4.6
+        version: 1.4.7
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -353,7 +359,7 @@ importers:
         version: 25.6.0
       '@vitest/browser':
         specifier: ^4.1.8
-        version: 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+        version: 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/browser-playwright':
         specifier: ^4.1.8
         version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
@@ -702,16 +708,19 @@ packages:
     resolution: {integrity: sha512-J9/7f3EIMKmFmSSQHQnAQLpUgB8YJENrOlkABjlTprBgsIYVgz7tSH7yg2P3ur+2Jem7PpGnrDxHGh/UjRfjsg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@braintrust/bt-linux-x64-musl@0.12.0':
     resolution: {integrity: sha512-KnLgENOoztBXcH+mLFJe4bYzi67kSOuELOQrm4Hler35GjgaBMI1fFLIUjKRPAmyT9VIhBMhy1ICfGEFLueMEQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@braintrust/bt-linux-x64@0.12.0':
     resolution: {integrity: sha512-HJFbUl3HYYY1Ivw8OYBeIMcIsU9r7+fC9BzLWB5FdH7881ToKee2wbbLZssMCxFbMVeUxzEo+SzGD/1Z9Gk9CA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@braintrust/bt-win32-arm64@0.12.0':
     resolution: {integrity: sha512-+7PkdBAmiqEJsWteGHP/Zs62F75PkHPA8m/ej4TOz/mHGKulUU0bZibw91KRqIB7J7jGi5ItvCiqkiGaLKLnyw==}
@@ -1836,12 +1845,14 @@ packages:
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mongodb-js/atlas-local-linux-x64-gnu@1.3.0':
     resolution: {integrity: sha512-I+gCqMXTC5SG1GLUxhPprWb0MyiIhzsAKxi9/FsrB0XL9qrrDurY2W2PGBIFan5eloo8tti9uIMeZUQ4ov/X5w==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mongodb-js/atlas-local-win32-x64-msvc@1.3.0':
     resolution: {integrity: sha512-nGHHd3MlhQQixjguuMGwgG5OnMBxHOJY+wqGVDE72vGoY7YBbGwAucqhGU/UMCbppweMqZmykVnTWjmqVW9Yww==}
@@ -2120,48 +2131,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.133.0':
     resolution: {integrity: sha512-wJQGamIosQBoJHW9+S5XxrtKRo3eyJxsnS1XCPrqN0LHi8uw1pTqqTfn3t/NVuvbBg7Pumn4ez9Eidgcn0xbEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.133.0':
     resolution: {integrity: sha512-Koaz32/O5+abIfrNGdyndgRvdOZ9jEf5/z3Ep9h3h2QWpdDiUQpVwgH0OcMXCs+l9aXxPLtkupqyVig9W6FDKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.133.0':
     resolution: {integrity: sha512-R4vOjWzxhnNWHnVLeiB6jNuIifdy9vcMXZGPc7StXcxBovI+U2zg1QhZ9o8OjV80oGivs1lX5NfPLzk4IPqlRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.133.0':
     resolution: {integrity: sha512-iwgBNUTHiMdxARLYuM0SBlnYeb19iw1Ea5M+4ERZupCsBMLArti6FyZ6UfFjJxIiTDr2oW2DGQFxlQVQ/dW9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.133.0':
     resolution: {integrity: sha512-ZwZNo8FZmB/gVfboQl+wXilBigGl+6nQQs+nITOeAP/HcAOjiHl6XZJL9F/KXNEspODQcbjAiyjUbeCJd9a0fA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.133.0':
     resolution: {integrity: sha512-govCvWx1dBlED3uu4qXctxpRcouu9I8Kn+DBktGCl760JtlGJzc9l/OmPJKlYWSbrRqKkMZehNeZ/4Wfma7uSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.133.0':
     resolution: {integrity: sha512-ssTlpXD5Mq9uCssDJPzlRWqBt4Y7Zzd9i+XZhWmK/9Y6KUIuAxVYTYiI8lxcGWi0+3/Cz4A8q9UrD4NK9Y2j7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.133.0':
     resolution: {integrity: sha512-51aByfXhPtLEdWG4a2Ihdw6cPWV1ei1AarALpFdDP8MLWDLE2NuUMgbo3DERR2Kt8fT/ok1GUvBiLxVGke9uUQ==}
@@ -2234,41 +2253,49 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
@@ -2891,36 +2918,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -3013,76 +3046,91 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -5547,24 +5595,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -11449,7 +11501,7 @@ snapshots:
 
   '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
@@ -11463,7 +11515,7 @@ snapshots:
 
   '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
@@ -11474,7 +11526,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -11492,7 +11544,7 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))':
+  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -11521,11 +11573,11 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
 
-  '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.61.0(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.61.0(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/utils': 8.61.0(eslint@10.2.0(jiti@2.7.0))(typescript@5.9.3)


### PR DESCRIPTION
## Proposed changes

- Replaces the temporary SimpleLogger stub with a proper composite logger (LoggerBase → ConsoleLogger → CompositeLogger)
- Migrates all logging call sites in cli.ts and tokenManager.ts to structured LogPayload with log IDs
- Registers clientId and clientSecret as redacted secrets after config loads, so they are scrubbed from all log output
- Removes MDB_MCP_LOG_LEVEL / logLevel config — console output is unfiltered, consistent with how the main server's ConsoleLogger works


### Relationship to the main server's logger
LoggerBase, CompositeLogger, and ConsoleLogger in src/logging/ are direct ports of their counterparts in src/common/logging/ — identical output format, noRedaction payload logic, attribute serialization, and EventEmitter generics.

**One intentional deviation:** Keychain → getSecrets?: () => Secret[]

The main server's LoggerBase takes a Keychain object (from src/common/keychain.ts) to source secrets for redaction. The wrapper cannot import Keychain without coupling itself to the main package's internals. The replacement is a lazy getSecrets callback — semantically identical (Keychain.allSecrets is Secret[]) and called at the same point in the redaction logic. This difference goes away when PR #1122 moves Keychain to packages/core.

###  Why the logger was not extracted

- PR #1122 already does this properly — it creates packages/core (for LoggerBase, CompositeLogger, Keychain) and packages/logging (for concrete loggers)
- A partial extraction now would conflict with or duplicate that 606-file restructuring
  - Extraction also requires changes out of scope for this ticket:
  - Creating and publishing new workspace packages with their own package.json, tsconfig, build scripts, and CI integration
  - Updating the main server's imports across all files that depend on src/common/logging/
  - Decoupling Keychain from LoggerBase in the main server (or co-locating Keychain in packages/core)
  - Adding tests to the new shared packages


###  What's needed when PR #1122 lands

- Delete the local loggerBase.ts, compositeLogger.ts, consoleLogger.ts from the wrapper
- Update imports in logger.ts to packages/core and packages/logging
- Switch ConsoleLogger to accept Keychain from packages/core
- No changes needed in cli.ts or tokenManager.ts — same LogPayload API by design

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
