### PR TITLE
feat: pass the request headers down when calling addSession() MCP-570

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -603,6 +603,7 @@ export interface ISessionStore<T extends CloseableTransport = CloseableTransport
         sessionId: string;
         transport: T;
         logger: LoggerBase;
+        headers?: Record<string, unknown>;
     }): Promise<void>;
     // (undocumented)
     closeAllSessions(): Promise<void>;
@@ -988,6 +989,7 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
         sessionId: string;
         transport: T;
         logger: LoggerBase;
+        headers?: Record<string, unknown>;
     }): Promise<void>;
     // (undocumented)
     closeAllSessions(): Promise<void>;

--- a/packages/types/src/sessionStore.ts
+++ b/packages/types/src/sessionStore.ts
@@ -9,7 +9,12 @@ export type SessionCloseReason = "idle_timeout" | "transport_closed" | "server_s
 
 export interface ISessionStore<T extends CloseableTransport = CloseableTransport> {
     getSession(sessionId: string): Promise<T | undefined>;
-    addSession(params: { sessionId: string; transport: T; logger: ILoggerBase }): Promise<void>;
+    addSession(params: {
+        sessionId: string;
+        transport: T;
+        logger: ILoggerBase;
+        headers?: Record<string, unknown>;
+    }): Promise<void>;
     closeSession(params: { sessionId: string; reason?: SessionCloseReason }): Promise<void>;
     closeAllSessions(): Promise<void>;
 }

--- a/src/common/sessionStore.ts
+++ b/src/common/sessionStore.ts
@@ -15,7 +15,12 @@ export type { CloseableTransport, SessionCloseReason };
  */
 export interface ISessionStore<T extends CloseableTransport = CloseableTransport> {
     getSession(sessionId: string): Promise<T | undefined>;
-    addSession(params: { sessionId: string; transport: T; logger: LoggerBase }): Promise<void>;
+    addSession(params: {
+        sessionId: string;
+        transport: T;
+        logger: LoggerBase;
+        headers?: Record<string, unknown>;
+    }): Promise<void>;
     closeSession(params: { sessionId: string; reason?: SessionCloseReason }): Promise<void>;
     closeAllSessions(): Promise<void>;
 }
@@ -90,7 +95,12 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
         });
     }
 
-    async addSession(params: { sessionId: string; transport: T; logger: LoggerBase }): Promise<void> {
+    async addSession(params: {
+        sessionId: string;
+        transport: T;
+        logger: LoggerBase;
+        headers?: Record<string, unknown>;
+    }): Promise<void> {
         const { sessionId, transport, logger } = params;
         const session = this.sessions[sessionId];
         if (session) {

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -283,7 +283,15 @@ export class MCPHttpServer<
 
             await server.connect(transport);
 
-            await this.sessionStore.addSession({ sessionId, transport, logger: server.session.logger });
+            await this.sessionStore.addSession({
+                sessionId,
+                transport,
+                logger: server.session.logger,
+                // Pass the incoming request headers to the session store so
+                // that we can trace the x-request-id and other headers in the
+                // resulting logs and downstream requests.
+                headers: req.headers,
+            });
         })();
 
         this.pendingInitializations.set(sessionId, initPromise);

--- a/tests/unit/transports/mcpHttpServer.test.ts
+++ b/tests/unit/transports/mcpHttpServer.test.ts
@@ -5,6 +5,7 @@ import { MockMetrics } from "../mocks/metrics.js";
 import { Keychain } from "../../../src/common/keychain.js";
 import type { ISessionStore } from "../../../src/common/sessionStore.js";
 import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { Server } from "../../../src/server.js";
 
 const INIT_BODY = JSON.stringify({
     jsonrpc: "2.0",
@@ -30,6 +31,22 @@ function makeSessionStore(
     };
 }
 
+function makeFakeServer(): Server {
+    return {
+        session: {
+            logger: {
+                setAttribute: vi.fn(),
+                debug: vi.fn(),
+                warning: vi.fn(),
+                info: vi.fn(),
+                error: vi.fn(),
+            },
+        },
+        connect: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Server;
+}
+
 describe("MCPHttpServer x-request-id logging", () => {
     let server: MCPHttpServer;
     let logger: InMemoryLogger;
@@ -38,11 +55,14 @@ describe("MCPHttpServer x-request-id logging", () => {
         await server?.stop();
     });
 
-    async function startServer(sessionStore: ISessionStore<StreamableHTTPServerTransport>): Promise<void> {
+    async function startServer(
+        sessionStore: ISessionStore<StreamableHTTPServerTransport>,
+        createServerForRequest: () => Promise<Server> = vi.fn()
+    ): Promise<void> {
         logger = new InMemoryLogger(Keychain.root);
         server = new MCPHttpServer({
             userConfig: { ...defaultTestConfig, httpPort: 0 },
-            createServerForRequest: vi.fn(),
+            createServerForRequest,
             logger,
             metrics: new MockMetrics(),
             sessionStore,
@@ -93,6 +113,23 @@ describe("MCPHttpServer x-request-id logging", () => {
             (m) => m.level === "debug" && m.payload.message.includes("externallyManagedSessions")
         );
         expect(log?.payload.attributes).toEqual(expect.objectContaining({ "x-request-id": "req-ext-sessions" }));
+    });
+
+    it("forwards the incoming request headers to sessionStore.addSession", async () => {
+        const addSession = vi.fn().mockResolvedValue(undefined);
+        const sessionStore: ISessionStore<StreamableHTTPServerTransport> = {
+            ...makeSessionStore(() => Promise.resolve(null)),
+            addSession,
+        };
+        await startServer(sessionStore, () => Promise.resolve(makeFakeServer()));
+
+        await post("/mcp", INIT_BODY, {
+            "x-request-id": "req-add-session",
+        });
+
+        expect(addSession).toHaveBeenCalledTimes(1);
+        const call = addSession.mock.calls[0]?.[0] as { headers?: Record<string, unknown> };
+        expect(call.headers).toEqual(expect.objectContaining({ "x-request-id": "req-add-session" }));
     });
 
     it("includes x-request-id in error log when handler throws", async () => {


### PR DESCRIPTION
Extend the interface(s) and base SessionStore class plus where we ultimately call addSession() to pass down the request's headers so that we can include the x-request-id in logs and downstream requests.

Will update downstream SessionStore implementation(s) once this is merged and released.
