### PR TITLE
fix: make requestIdAttr case-insensitive CLOUDP-418875

### DIFF
--- a/src/helpers/requestIdAttr.ts
+++ b/src/helpers/requestIdAttr.ts
@@ -1,5 +1,9 @@
 /** Returns `{ "x-request-id": "..." }` when the headers carry one, else `{}`. Spread inside a LogPayload's `attributes` field. */
 export function requestIdAttr(headers: Record<string, unknown> | undefined): Record<string, string> {
-    const id = headers?.["x-request-id"];
+    if (!headers) {
+        return {};
+    }
+    const key = Object.keys(headers).find((k) => k.toLowerCase() === "x-request-id");
+    const id = key !== undefined ? headers[key] : undefined;
     return typeof id === "string" ? { "x-request-id": id } : {};
 }

--- a/tests/unit/helpers/requestIdAttr.test.ts
+++ b/tests/unit/helpers/requestIdAttr.test.ts
@@ -6,6 +6,11 @@ describe("requestIdAttr", () => {
         expect(requestIdAttr({ "x-request-id": "abc-123" })).toEqual({ "x-request-id": "abc-123" });
     });
 
+    it("matches the header case-insensitively", () => {
+        expect(requestIdAttr({ "X-Request-ID": "abc-123" })).toEqual({ "x-request-id": "abc-123" });
+        expect(requestIdAttr({ "X-REQUEST-ID": "abc-123" })).toEqual({ "x-request-id": "abc-123" });
+    });
+
     it("returns empty object when headers are undefined", () => {
         expect(requestIdAttr(undefined)).toEqual({});
     });


### PR DESCRIPTION
HTTP headers are case-insensitive.