### PR TITLE
fix: enforce redaction of sensitive information in mcp logger by default - MCP-574

### DIFF
--- a/src/common/logging/loggerBase.ts
+++ b/src/common/logging/loggerBase.ts
@@ -4,15 +4,16 @@ import type { Keychain } from "../keychain.js";
 import type { DefaultEventMap, EventMap, LoggerType, LogLevel, LogPayload } from "./loggingTypes.js";
 
 export abstract class LoggerBase<T extends EventMap<T> = DefaultEventMap> extends EventEmitter<T> {
-    private readonly defaultUnredactedLogger: LoggerType = "mcp";
-
     constructor(private readonly keychain: Keychain | undefined) {
         super();
     }
 
     public log(level: LogLevel, payload: LogPayload): void {
-        // If no explicit value is supplied for unredacted loggers, default to "mcp"
-        const noRedaction = payload.noRedaction !== undefined ? payload.noRedaction : this.defaultUnredactedLogger;
+        // Redact by default for every logger. Skipping redaction must be an explicit,
+        // per-call opt-out via `noRedaction` — never a default. This matters most for the
+        // MCP logger, whose messages are sent to the (untrusted) MCP client and downstream
+        // agent/LLM toolchain, so secrets must never be emitted there unless explicitly allowed.
+        const noRedaction = payload.noRedaction !== undefined ? payload.noRedaction : false;
 
         this.logCore(level, {
             ...payload,

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -87,12 +87,24 @@ describe("Logger", () => {
             expectLogMessageRedaction(getLastConsoleMessage(), true);
         });
 
-        it("does not redact sensitive information for mcp logger by default", () => {
+        it("redacts sensitive information for mcp logger by default", () => {
             mcpLogger.info(mockSensitivePayload);
 
             expect(mcpLoggerSpy).toHaveBeenCalledOnce();
 
-            expectLogMessageRedaction(getLastMcpLogMessage(), false);
+            expectLogMessageRedaction(getLastMcpLogMessage(), true);
+        });
+
+        it("redacts keychain secrets from mcp logger by default", () => {
+            keychain.register("SuperSecretPass123", "password");
+            mcpLogger.error({
+                id: LogId.serverInitialized,
+                context: "test",
+                message: 'Failed to connect: "mongodb://admin:SuperSecretPass123@/db"',
+            });
+
+            expect(mcpLoggerSpy).toHaveBeenCalledOnce();
+            expect(getLastMcpLogMessage()).not.toContain("SuperSecretPass123");
         });
 
         it("redacts sensitive information from the keychain", () => {


### PR DESCRIPTION
## Proposed changes

Changing logs to default for redacted mode, so we avoid to potentially include more information than necessary. No redaction needs to be opted in now.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
