### PR TITLE
fix: update cluster listing output to include project name inside untrusted tag - MCP-576

### DIFF
--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -1205,6 +1205,7 @@ export class ListClustersTool extends AtlasToolBase {
     // (undocumented)
     outputSchema: {
         projectId: z.ZodOptional<z.ZodString>;
+        projectName: z.ZodOptional<z.ZodString>;
         clusters: z.ZodArray<z.ZodUnion<readonly [z.ZodObject<{
             clusterName: z.ZodOptional<z.ZodString>;
             projectId: z.ZodOptional<z.ZodString>;

--- a/src/tools/atlas/read/listClusters.ts
+++ b/src/tools/atlas/read/listClusters.ts
@@ -38,6 +38,7 @@ export const ListClusterItemOutputSchema = z.union([ClusterSummaryOutputSchema, 
 
 const ListClustersOutputSchema = {
     projectId: z.string().optional(),
+    projectName: z.string().optional(),
     clusters: z.array(ListClusterItemOutputSchema),
     totalCount: z.number(),
 };
@@ -157,6 +158,7 @@ export class ListClustersTool extends AtlasToolBase {
                 content: [{ type: "text", text: "No clusters found." }],
                 structuredContent: {
                     projectId: project.id,
+                    projectName: project.name,
                     clusters: [],
                     totalCount: 0,
                 },
@@ -173,6 +175,7 @@ export class ListClustersTool extends AtlasToolBase {
             ),
             structuredContent: {
                 projectId: project.id,
+                projectName: project.name,
                 clusters: allClusters,
                 totalCount: allClusters.length,
             },

--- a/src/tools/atlas/read/listClusters.ts
+++ b/src/tools/atlas/read/listClusters.ts
@@ -168,8 +168,8 @@ export class ListClustersTool extends AtlasToolBase {
 
         return {
             content: formatUntrustedData(
-                `Found ${allClusters.length} clusters in project "${project.name}" (${project.id}):`,
-                JSON.stringify(allClusters)
+                `Found ${allClusters.length} clusters in project ${project.id}:`,
+                JSON.stringify({ projectName: project.name, clusters: allClusters })
             ),
             structuredContent: {
                 projectId: project.id,

--- a/tests/unit/tools/atlas/read/listClusters.test.ts
+++ b/tests/unit/tools/atlas/read/listClusters.test.ts
@@ -193,6 +193,7 @@ describe("ListClustersTool", () => {
 
                 expect(result.structuredContent).toEqual({
                     projectId,
+                    projectName: "My Project",
                     clusters: [
                         {
                             name: "free-cluster",
@@ -219,6 +220,7 @@ describe("ListClustersTool", () => {
 
                 expect(result.structuredContent).toEqual({
                     projectId,
+                    projectName: "My Project",
                     clusters: [],
                     totalCount: 0,
                 });
@@ -242,6 +244,11 @@ describe("ListClustersTool", () => {
 
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
             expect(text).toContain("Found 1 clusters across all projects");
+            // The (untrusted) project name is included inside the untrusted-data block, not the description.
+            const [description, untrusted] = result.content.map((c) => (c as { text: string }).text);
+            expect(description).not.toContain("Project A");
+            expect(untrusted).toContain("<untrusted-user-data-");
+            expect(untrusted).toContain("Project A");
             expect(mockApiClient.listClusterDetails).toHaveBeenCalledWith(undefined, expect.anything());
             expect(mockApiClient.getGroup).not.toHaveBeenCalled();
         });

--- a/tests/unit/tools/atlas/read/listClusters.test.ts
+++ b/tests/unit/tools/atlas/read/listClusters.test.ts
@@ -115,9 +115,12 @@ describe("ListClustersTool", () => {
             const result = await exec();
 
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain('Found 2 clusters in project "My Project"');
-            expect(text).toContain(projectId);
+            expect(text).toContain(`Found 2 clusters in project ${projectId}`);
             expect(text).toContain("<untrusted-user-data-");
+            // The untrusted project name is wrapped inside the untrusted-data block, not the description.
+            const [description, untrusted] = result.content.map((c) => (c as { text: string }).text);
+            expect(description).not.toContain("My Project");
+            expect(untrusted).toContain("My Project");
         });
 
         it("calls getGroup, listClusters, and listFlexClusters", async () => {


### PR DESCRIPTION
## Proposed changes

Moving project name to be returned in the output inside the untrusted tag section.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
