### PR TITLE
feat: enhance validation when creating new db user - MCP-577

### DIFF
--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -481,7 +481,18 @@ export class CreateDBUserTool extends AtlasToolBase {
         username: z.ZodString;
         password: z.ZodOptional<z.ZodString>;
         roles: z.ZodArray<z.ZodObject<{
-            roleName: z.ZodString;
+            roleName: z.ZodUnion<readonly [z.ZodEnum<{
+                atlasAdmin: "atlasAdmin";
+                backup: "backup";
+                clusterMonitor: "clusterMonitor";
+                dbAdmin: "dbAdmin";
+                dbAdminAnyDatabase: "dbAdminAnyDatabase";
+                enableSharding: "enableSharding";
+                read: "read";
+                readAnyDatabase: "readAnyDatabase";
+                readWrite: "readWrite";
+                readWriteAnyDatabase: "readWriteAnyDatabase";
+            }>, z.ZodString]>;
             databaseName: z.ZodDefault<z.ZodString>;
             collectionName: z.ZodOptional<z.ZodString>;
         }, z.core.$strip>>;

--- a/src/common/atlas/roles.ts
+++ b/src/common/atlas/roles.ts
@@ -1,6 +1,25 @@
 import type { UserConfig } from "../config/userConfig.js";
 import type { DatabaseUserRole } from "./openapi.js";
 
+/**
+ * The built-in Atlas database user roles, per the Atlas Admin API
+ * (DatabaseUserRole.roleName). Any value outside this set must be a
+ * project-scoped custom role.
+ * https://www.mongodb.com/docs/atlas/mongodb-users-roles-and-privileges/
+ */
+export const BUILT_IN_DB_USER_ROLES = [
+    "atlasAdmin",
+    "backup",
+    "clusterMonitor",
+    "dbAdmin",
+    "dbAdminAnyDatabase",
+    "enableSharding",
+    "read",
+    "readAnyDatabase",
+    "readWrite",
+    "readWriteAnyDatabase",
+] as const;
+
 const readWriteRole: DatabaseUserRole = {
     roleName: "readWriteAnyDatabase",
     databaseName: "admin",

--- a/src/helpers/escapeMarkdown.ts
+++ b/src/helpers/escapeMarkdown.ts
@@ -1,0 +1,6 @@
+/**
+ * Escapes markdown and HTML metacharacters in a string.
+ */
+export function escapeMarkdown(value: string): string {
+    return value.replace(/[\\`*_{}[\]()<>#+\-.!|]/g, "\\$&");
+}

--- a/src/tools/args.ts
+++ b/src/tools/args.ts
@@ -8,10 +8,13 @@ const ALLOWED_USERNAME_CHARACTERS_REGEX = /^[a-zA-Z0-9._-]+$/;
 export const ALLOWED_USERNAME_CHARACTERS_ERROR =
     "Username can only contain letters, numbers, dots, hyphens, and underscores";
 
-const ALLOWED_REGION_CHARACTERS_REGEX = /^[a-zA-Z0-9_-]+$/;
+// Generic pattern for identifiers that permit only ASCII letters, numbers, hyphens, and underscores.
+export const ALPHANUMERIC_DASH_UNDERSCORE_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+const ALLOWED_REGION_CHARACTERS_REGEX = ALPHANUMERIC_DASH_UNDERSCORE_REGEX;
 export const ALLOWED_REGION_CHARACTERS_ERROR = "Region can only contain letters, numbers, hyphens, and underscores";
 
-const ALLOWED_CLUSTER_NAME_CHARACTERS_REGEX = /^[a-zA-Z0-9_-]+$/;
+const ALLOWED_CLUSTER_NAME_CHARACTERS_REGEX = ALPHANUMERIC_DASH_UNDERSCORE_REGEX;
 export const ALLOWED_CLUSTER_NAME_CHARACTERS_ERROR =
     "Cluster names can only contain ASCII letters, numbers, and hyphens.";
 

--- a/src/tools/atlas/create/createDBUser.ts
+++ b/src/tools/atlas/create/createDBUser.ts
@@ -3,8 +3,10 @@ import type { ToolArgs, OperationType, ToolExecutionContext, ToolResult } from "
 import { AtlasToolBase } from "../atlasTool.js";
 import type { CloudDatabaseUser, DatabaseUserRole } from "../../../common/atlas/openapi.js";
 import { generateSecurePassword } from "../../../helpers/generatePassword.js";
+import { escapeMarkdown } from "../../../helpers/escapeMarkdown.js";
 import { ensureCurrentIpInAccessList } from "../../../common/atlas/accessListUtils.js";
-import { AtlasArgs, CommonArgs } from "../../args.js";
+import { ALPHANUMERIC_DASH_UNDERSCORE_REGEX, AtlasArgs, CommonArgs } from "../../args.js";
+import { BUILT_IN_DB_USER_ROLES } from "../../../common/atlas/roles.js";
 
 export const CreateDBUserArgs = {
     projectId: AtlasArgs.projectId().describe("Atlas project ID"),
@@ -20,7 +22,17 @@ export const CreateDBUserArgs = {
     roles: z
         .array(
             z.object({
-                roleName: CommonArgs.string().describe("Role name"),
+                roleName: z
+                    .union([
+                        z.enum(BUILT_IN_DB_USER_ROLES),
+                        z
+                            .string()
+                            .regex(
+                                ALPHANUMERIC_DASH_UNDERSCORE_REGEX,
+                                "Custom role names can only contain letters, numbers, hyphens, and underscores"
+                            ),
+                    ])
+                    .describe("Role name"),
                 databaseName: CommonArgs.string().describe("Database name").default("admin"),
                 collectionName: CommonArgs.string().describe("Collection name").optional(),
             })
@@ -116,7 +128,14 @@ export class CreateDBUserTool extends AtlasToolBase {
             `You are about to create a database user in Atlas project \`${projectId}\`:\n\n` +
             `**Username**: \`${username}\`\n\n` +
             `**Password**: ${password ? "(User-provided password)" : "(Auto-generated secure password)"}\n\n` +
-            `**Roles**: ${roles.map((role) => `${role.roleName}${role.collectionName ? ` on ${role.databaseName}.${role.collectionName}` : ` on ${role.databaseName}`}`).join(", ")}\n\n` +
+            `**Roles**: ${roles
+                .map((role) => {
+                    const target = role.collectionName
+                        ? `${escapeMarkdown(role.databaseName)}.${escapeMarkdown(role.collectionName)}`
+                        : escapeMarkdown(role.databaseName);
+                    return `${escapeMarkdown(role.roleName)} on ${target}`;
+                })
+                .join(", ")}\n\n` +
             `**Cluster Access**: ${clusters?.length ? clusters.join(", ") : "All clusters in the project"}\n\n` +
             "This will create a new database user with the specified permissions. " +
             "**Do you confirm the execution of the action?**"

--- a/src/tools/mongodb/delete/deleteMany.ts
+++ b/src/tools/mongodb/delete/deleteMany.ts
@@ -1,6 +1,7 @@
 import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
 import { checkIndexUsage } from "../../../helpers/indexCheck.js";
+import { escapeMarkdown } from "../../../helpers/escapeMarkdown.js";
 import { EJSON } from "bson";
 import { zEJSON } from "../../args.js";
 import { z } from "zod";
@@ -79,12 +80,15 @@ export class DeleteManyTool extends MongoDBToolBase {
     }
 
     protected getConfirmationMessage({ database, collection, filter }: ToolArgs<typeof this.argsShape>): string {
+        // The filter is untrusted (model-supplied). It is not rendered inside a markdown code fence
+        // because fences/code-spans cannot be escaped with backslashes — a backtick sequence in the
+        // payload would break out. Rendering it as escapeMarkdown'd plain text neutralizes backticks too.
         const filterDescription =
             filter && Object.keys(filter).length > 0
-                ? "```json\n" + `{ "filter": ${EJSON.stringify(filter)} }\n` + "```\n\n"
+                ? `- **Filter**: ${escapeMarkdown(`{ "filter": ${EJSON.stringify(filter)} }`)}\n\n`
                 : "- **All documents** (No filter)\n\n";
         return (
-            `You are about to delete documents from the \`${collection}\` collection in the \`${database}\` database:\n\n` +
+            `You are about to delete documents from the **${escapeMarkdown(collection)}** collection in the **${escapeMarkdown(database)}** database:\n\n` +
             filterDescription +
             "This operation will permanently remove all documents matching the filter.\n\n" +
             "**Do you confirm the execution of the action?**"

--- a/src/tools/mongodb/delete/dropCollection.ts
+++ b/src/tools/mongodb/delete/dropCollection.ts
@@ -1,5 +1,6 @@
 import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
+import { escapeMarkdown } from "../../../helpers/escapeMarkdown.js";
 import { z } from "zod";
 
 const DropCollectionOutputSchema = {
@@ -44,7 +45,7 @@ export class DropCollectionTool extends MongoDBToolBase {
 
     protected getConfirmationMessage({ database, collection }: ToolArgs<typeof this.argsShape>): string {
         return (
-            `You are about to drop the \`${collection}\` collection from the \`${database}\` database:\n\n` +
+            `You are about to drop the **${escapeMarkdown(collection)}** collection from the **${escapeMarkdown(database)}** database:\n\n` +
             "This operation will permanently remove the collection and all its data, including indexes.\n\n" +
             "**Do you confirm the execution of the action?**"
         );

--- a/src/tools/mongodb/delete/dropDatabase.ts
+++ b/src/tools/mongodb/delete/dropDatabase.ts
@@ -1,5 +1,6 @@
 import { DBOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolResult } from "../../tool.js";
+import { escapeMarkdown } from "../../../helpers/escapeMarkdown.js";
 import { z } from "zod";
 
 const DropDatabaseOutputSchema = {
@@ -38,7 +39,7 @@ export class DropDatabaseTool extends MongoDBToolBase {
 
     protected getConfirmationMessage({ database }: ToolArgs<typeof this.argsShape>): string {
         return (
-            `You are about to drop the \`${database}\` database:\n\n` +
+            `You are about to drop the **${escapeMarkdown(database)}** database:\n\n` +
             "This operation will permanently remove the database and ALL its collections, documents, and indexes.\n\n" +
             "**Do you confirm the execution of the action?**"
         );

--- a/src/tools/mongodb/delete/dropIndex.ts
+++ b/src/tools/mongodb/delete/dropIndex.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import { CollOperationArgs, MongoDBToolBase } from "../mongodbTool.js";
 import { type ToolArgs, type OperationType, formatUntrustedData, type ToolResult } from "../../tool.js";
+import { escapeMarkdown } from "../../../helpers/escapeMarkdown.js";
 
 const DropIndexOutputSchema = {
     database: z.string(),
@@ -111,7 +112,7 @@ export class DropIndexTool extends MongoDBToolBase {
         type,
     }: ToolArgs<typeof this.argsShape>): string {
         return (
-            `You are about to drop the ${type === "search" ? "search index" : "index"} named \`${indexName}\` from the \`${database}.${collection}\` namespace:\n\n` +
+            `You are about to drop the ${type === "search" ? "search index" : "index"} named **${escapeMarkdown(indexName)}** from the **${escapeMarkdown(database)}.${escapeMarkdown(collection)}** namespace:\n\n` +
             "This operation will permanently remove the index and might affect the performance of queries relying on this index.\n\n" +
             "**Do you confirm the execution of the action?**"
         );

--- a/tests/integration/elicitation.test.ts
+++ b/tests/integration/elicitation.test.ts
@@ -37,7 +37,7 @@ describe("Elicitation Integration Tests", () => {
                     expect(mockElicitInput.mock).toHaveBeenCalledTimes(1);
                     expect(mockElicitInput.mock).toHaveBeenCalledWith(
                         {
-                            message: expect.stringContaining("You are about to drop the `test-db` database"),
+                            message: expect.stringContaining("You are about to drop the **test\\-db** database"),
                             requestedSchema: Elicitation.CONFIRMATION_SCHEMA,
                             mode: "form",
                         },
@@ -85,12 +85,30 @@ describe("Elicitation Integration Tests", () => {
                     expect(mockElicitInput.mock).toHaveBeenCalledTimes(1);
                     expect(mockElicitInput.mock).toHaveBeenCalledWith(
                         {
-                            message: expect.stringContaining("You are about to drop the `test-collection` collection"),
+                            message: expect.stringContaining(
+                                "You are about to drop the **test\\-collection** collection"
+                            ),
                             requestedSchema: expect.objectContaining(Elicitation.CONFIRMATION_SCHEMA),
                             mode: "form",
                         },
                         { timeout: 300000 }
                     );
+                });
+
+                it("escapes markdown special characters in drop-collection names", async () => {
+                    mockElicitInput.confirmYes();
+
+                    await integration.mcpClient().callTool({
+                        name: "drop-collection",
+                        arguments: { database: "test-db", collection: "orders`v2" },
+                    });
+
+                    const [firstCallArg] = (mockElicitInput.mock.mock.calls[0] ?? []) as unknown as [
+                        { message: string },
+                    ];
+                    const message = firstCallArg.message;
+                    expect(message).not.toContain("orders`v2");
+                    expect(message).toContain("orders\\`v2");
                 });
 
                 it("should request confirmation for delete-many tool", async () => {

--- a/tests/integration/tools/mongodb/delete/dropIndex.test.ts
+++ b/tests/integration/tools/mongodb/delete/dropIndex.test.ts
@@ -262,7 +262,7 @@ describe("drop-index tool", () => {
                     {
                         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                         message: expect.stringContaining(
-                            "You are about to drop the index named `year_1` from the `mflix.movies` namespace"
+                            "You are about to drop the index named **year\\_1** from the **mflix.movies** namespace"
                         ),
                         mode: "form",
                         requestedSchema: Elicitation.CONFIRMATION_SCHEMA,
@@ -289,7 +289,7 @@ describe("drop-index tool", () => {
                     {
                         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                         message: expect.stringContaining(
-                            "You are about to drop the index named `year_1` from the `mflix.movies` namespace"
+                            "You are about to drop the index named **year\\_1** from the **mflix.movies** namespace"
                         ),
                         mode: "form",
                         requestedSchema: Elicitation.CONFIRMATION_SCHEMA,
@@ -515,7 +515,7 @@ describe("drop-index tool", () => {
                         {
                             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                             message: expect.stringContaining(
-                                "You are about to drop the search index named `searchIdx` from the `mflix.movies` namespace"
+                                "You are about to drop the search index named **searchIdx** from the **mflix.movies** namespace"
                             ),
                             mode: "form",
                             requestedSchema: Elicitation.CONFIRMATION_SCHEMA,
@@ -542,7 +542,7 @@ describe("drop-index tool", () => {
                         {
                             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                             message: expect.stringContaining(
-                                "You are about to drop the search index named `searchIdx` from the `mflix.movies` namespace"
+                                "You are about to drop the search index named **searchIdx** from the **mflix.movies** namespace"
                             ),
                             mode: "form",
                             requestedSchema: Elicitation.CONFIRMATION_SCHEMA,

--- a/tests/unit/helpers/escapeMarkdown.test.ts
+++ b/tests/unit/helpers/escapeMarkdown.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { escapeMarkdown } from "../../../src/helpers/escapeMarkdown.js";
+
+describe("escapeMarkdown", () => {
+    it("leaves plain alphanumeric text untouched", () => {
+        expect(escapeMarkdown("readWrite on admin")).toBe("readWrite on admin");
+    });
+
+    it("returns an empty string unchanged", () => {
+        expect(escapeMarkdown("")).toBe("");
+    });
+
+    it.each([
+        ["*", "\\*"],
+        ["_", "\\_"],
+        ["`", "\\`"],
+        ["\\", "\\\\"],
+        ["[", "\\["],
+        ["]", "\\]"],
+        ["(", "\\("],
+        [")", "\\)"],
+        ["{", "\\{"],
+        ["}", "\\}"],
+        ["<", "\\<"],
+        [">", "\\>"],
+        ["#", "\\#"],
+        ["+", "\\+"],
+        ["-", "\\-"],
+        [".", "\\."],
+        ["!", "\\!"],
+        ["|", "\\|"],
+    ])("escapes the metacharacter %j", (input, expected) => {
+        expect(escapeMarkdown(input)).toBe(expected);
+    });
+
+    it("escapes every metacharacter in a mixed string", () => {
+        expect(escapeMarkdown("atlasAdmin`<!--")).toBe("atlasAdmin\\`\\<\\!\\-\\-");
+    });
+
+    it("neutralizes an HTML comment used to hide content", () => {
+        const escaped = escapeMarkdown("db<!--hidden-->");
+        expect(escaped).not.toContain("<!--");
+        expect(escaped).toBe("db\\<\\!\\-\\-hidden\\-\\-\\>");
+    });
+
+    it("escapes markdown emphasis so it cannot restyle text", () => {
+        expect(escapeMarkdown("**bold**")).toBe("\\*\\*bold\\*\\*");
+    });
+});

--- a/tests/unit/tools/atlas/create/createDBUser.test.ts
+++ b/tests/unit/tools/atlas/create/createDBUser.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod";
 import type { ToolConstructorParams } from "../../../../../src/tools/tool.js";
-import { CreateDBUserTool } from "../../../../../src/tools/atlas/create/createDBUser.js";
+import { CreateDBUserTool, CreateDBUserArgs } from "../../../../../src/tools/atlas/create/createDBUser.js";
 import type { Session } from "../../../../../src/common/session.js";
 import type { UserConfig } from "../../../../../src/common/config/userConfig.js";
 import type { Telemetry } from "../../../../../src/telemetry/telemetry.js";
@@ -108,6 +109,39 @@ describe("CreateDBUserTool", () => {
                 { type: "CLUSTER", name: "cluster-a" },
                 { type: "CLUSTER", name: "cluster-b" },
             ],
+        });
+    });
+
+    describe("roleName validation", () => {
+        const rolesSchema = z.object(CreateDBUserArgs).shape.roles;
+
+        it.each(["atlasAdmin", "readWrite", "readAnyDatabase"])("accepts the built-in role %s", (roleName) => {
+            expect(rolesSchema.safeParse([{ roleName, databaseName: "admin" }]).success).toBe(true);
+        });
+
+        it("accepts an alphanumeric custom role name", () => {
+            expect(rolesSchema.safeParse([{ roleName: "my_custom-role1", databaseName: "admin" }]).success).toBe(true);
+        });
+
+        it.each(["atlasAdmin`<!--", "read*write*", "admin|role", "<b>read</b>", "role name"])(
+            "rejects a role name containing markdown/HTML metacharacters: %j",
+            (roleName) => {
+                expect(rolesSchema.safeParse([{ roleName, databaseName: "admin" }]).success).toBe(false);
+            }
+        );
+    });
+
+    describe("getConfirmationMessage", () => {
+        it("escapes markdown metacharacters in role database and collection names", () => {
+            const message = tool["getConfirmationMessage"]({
+                ...baseArgs,
+                roles: [{ roleName: "readWrite", databaseName: "db<!--hidden", collectionName: "col*bold*" }],
+            } as never);
+
+            expect(message).not.toContain("db<!--hidden");
+            expect(message).not.toContain("col*bold*");
+            expect(message).toContain("db\\<\\!\\-\\-hidden");
+            expect(message).toContain("col\\*bold\\*");
         });
     });
 


### PR DESCRIPTION
Adding schema validation for Atlas user roles, enhancing validation for custom roles and escaping values when rendering markdown to request user confirmation.

Also escaping values inside markdown confirmation for delete mongodb tools.
## Proposed changes

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
