### PR TITLE
fix: do not interpolate names in note for StreamsDiscoverTool output - MCP-578

### DIFF
--- a/src/tools/atlas/streams/discover.ts
+++ b/src/tools/atlas/streams/discover.ts
@@ -417,7 +417,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
         const output = format === "concise" ? conciseWorkspace : data;
 
         return {
-            content: formatUntrustedData(`Workspace '${workspaceName}' details:`, JSON.stringify(output, null, 2)),
+            content: formatUntrustedData("Details for the requested workspace:", JSON.stringify(output, null, 2)),
             structuredContent: { workspace: conciseWorkspace },
         };
     }
@@ -458,7 +458,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
 
         return {
             content: formatUntrustedData(
-                `Found ${data.results.length} connection(s) in workspace '${workspaceName}':`,
+                `Found ${data.results.length} connection(s) in the requested workspace:`,
                 JSON.stringify(connections, null, 2)
             ),
             structuredContent: { connections: conciseConnections },
@@ -478,7 +478,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
             context
         )) as Record<string, unknown>;
 
-        let header = `Connection '${connectionName}' in workspace '${workspaceName}':`;
+        let header = "Details for the requested connection:";
 
         if (data.type === "Cluster" && typeof data.clusterName === "string" && data.clusterName !== data.name) {
             header +=
@@ -534,7 +534,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
 
         return {
             content: formatUntrustedData(
-                `Found ${data.results.length} processor(s) in workspace '${workspaceName}':`,
+                `Found ${data.results.length} processor(s) in the requested workspace:`,
                 JSON.stringify(processors, null, 2)
             ),
             structuredContent: { processors: conciseProcessors },
@@ -556,10 +556,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
         const structuredContent = buildProcessorStructuredContent(data, { includePipeline: true });
 
         return {
-            content: formatUntrustedData(
-                `Processor '${processorName}' in workspace '${workspaceName}':`,
-                JSON.stringify(data, null, 2)
-            ),
+            content: formatUntrustedData("Details for the requested processor:", JSON.stringify(data, null, 2)),
             ...(Object.keys(structuredContent).length > 0 && { structuredContent }),
         };
     }
@@ -664,10 +661,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
         }
 
         return {
-            content: formatUntrustedData(
-                `Diagnostic report for processor '${processorName}' in workspace '${workspaceName}':`,
-                sections.join("\n\n")
-            ),
+            content: formatUntrustedData("Diagnostic report for the requested processor:", sections.join("\n\n")),
             ...(Object.keys(structuredContent).length > 0 && { structuredContent }),
         };
     }

--- a/src/tools/atlas/streams/discover.ts
+++ b/src/tools/atlas/streams/discover.ts
@@ -482,8 +482,8 @@ export class StreamsDiscoverTool extends StreamsToolBase {
 
         if (data.type === "Cluster" && typeof data.clusterName === "string" && data.clusterName !== data.name) {
             header +=
-                `\n\nNote: This connection is named '${String(data.name)}' but targets cluster '${data.clusterName}'. ` +
-                `Use the connection name '${String(data.name)}' (not the cluster name) when referencing it in pipeline stages.`;
+                "\n\nNote: This connection's name differs from its target cluster name. " +
+                "Use the connection name (not the cluster name) when referencing it in pipeline stages.";
         }
 
         const connection = toConnectionInspect(data);

--- a/tests/unit/tools/atlas/streams/discover.test.ts
+++ b/tests/unit/tools/atlas/streams/discover.test.ts
@@ -454,7 +454,7 @@ describe("StreamsDiscoverTool", () => {
             });
         });
 
-        it("should add note when Cluster connection name differs from clusterName", async () => {
+        it("should add a generic note when Cluster connection name differs from clusterName", async () => {
             mockApiClient.getStreamConnection!.mockResolvedValue({
                 name: "my-conn",
                 type: "Cluster",
@@ -468,10 +468,10 @@ describe("StreamsDiscoverTool", () => {
                 resourceName: "my-conn",
             });
 
-            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Note");
-            expect(text).toContain("my-conn");
-            expect(text).toContain("actual-cluster");
+            const [description, untrusted] = result.content.map((c) => (c as { text: string }).text);
+            expect(description).toContain("Note");
+            expect(description).not.toContain("actual-cluster");
+            expect(untrusted).toContain("actual-cluster");
             expect(result.structuredContent).toEqual({
                 connection: { type: "Cluster", clusterName: "actual-cluster" },
             });

--- a/tests/unit/tools/atlas/streams/discover.test.ts
+++ b/tests/unit/tools/atlas/streams/discover.test.ts
@@ -175,8 +175,9 @@ describe("StreamsDiscoverTool", () => {
                 workspaceName: "ws1",
             });
 
-            const text = (result.content[0] as { text: string }).text;
-            expect(text).toContain("ws1");
+            const [description, untrusted] = result.content.map((c) => (c as { text: string }).text);
+            expect(description).not.toContain("ws1");
+            expect(untrusted).toContain("ws1");
             expect(result.structuredContent).toEqual({
                 workspace: {
                     name: "ws1",
@@ -446,9 +447,9 @@ describe("StreamsDiscoverTool", () => {
                 resourceName: "kafka-in",
             });
 
-            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("kafka-in");
-            expect(text).toContain("ws1");
+            const [description, untrusted] = result.content.map((c) => (c as { text: string }).text);
+            expect(description).not.toContain("kafka-in");
+            expect(untrusted).toContain("kafka-in");
             expect(result.structuredContent).toEqual({
                 connection: { type: "Kafka", bootstrapServers: "broker:9092" },
             });
@@ -543,9 +544,9 @@ describe("StreamsDiscoverTool", () => {
                 resourceName: "proc1",
             });
 
-            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("proc1");
-            expect(text).toContain("ws1");
+            const [description, untrusted] = result.content.map((c) => (c as { text: string }).text);
+            expect(description).not.toContain("proc1");
+            expect(untrusted).toContain("proc1");
             expect(result.structuredContent).toEqual({
                 processorState: "STARTED",
                 tier: "SP10",


### PR DESCRIPTION
MCP-578

## Proposed changes

Do not include interpolated names in the note section. The connection name is already included in the untrusted data section and the llm should take from there.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
