### PR TITLE
docs(azure): remove stale tested image version

### DIFF
--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -8,7 +8,7 @@ This directory contains an Azure Bicep template (`bicep/main.bicep`) and support
 
 - Azure CLI (2.55.0 or later) installed and signed in (`az login`).
 - Azure subscription with permissions to deploy the required resources.
-- MongoDB MCP server container image available in dockerhub registry (mongodb/mongodb-mcp-server:1.10.0). This bicep is tested with version 1.10.0. Please change the parameter files to use other versions of the MongoDB MCP server docker image.
+- MongoDB MCP server container image available in dockerhub registry. Use the parameter files (`bicep/params.json` or `bicep/paramsWithAuthEnabled.json`) to select the version.
 
 ## Parameter Files
 


### PR DESCRIPTION
## Summary

Remove a stale tested image version from the Azure deployment README.

The Bicep template already defines the default container image version, so the README should avoid repeating a version that can drift.

## Testing

Docs-only change.