### PR TITLE
chore: mongodb-atlas-mcp-remote e2e tests MCP-539

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -86,6 +86,29 @@ jobs:
           name: atlas-test-results
           path: coverage/lcov.info
 
+  run-atlas-mcp-remote:
+    name: Run Atlas MCP Remote E2E tests
+    if: github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run Remote MCP E2E tests
+        env:
+          REMOTE_MCP_E2E_CLIENT_ID: ${{ secrets.TEST_REMOTE_MCP_CLIENT_ID }}
+          REMOTE_MCP_E2E_CLIENT_SECRET: ${{ secrets.TEST_REMOTE_MCP_CLIENT_SECRET }}
+          REMOTE_MCP_E2E_BASE_URL: ${{ vars.TEST_REMOTE_MCP_BASE_URL }}
+        run: pnpm --filter mongodb-atlas-mcp-remote test src/e2e.test.ts
+
   run-atlas-local-tests:
     name: Run Atlas Local tests
     if: github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)

--- a/packages/mongodb-atlas-mcp-remote/src/e2e.test.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/e2e.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client, StdioClientTransport } from "@modelcontextprotocol/client";
+
+/**
+ * E2E tests are skipped unless Service Account credentials are set.
+ */
+const shouldSkip = !process.env.REMOTE_MCP_E2E_CLIENT_ID || !process.env.REMOTE_MCP_E2E_CLIENT_SECRET;
+
+const CLI_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "dist", "cli.js");
+
+describe.skipIf(shouldSkip)("mongodb-atlas-mcp-remote wrapper e2e tests", () => {
+    let client: Client;
+
+    beforeAll(async () => {
+        client = new Client({ name: "e2e-test", version: "0.0.0" });
+        const transport = new StdioClientTransport({
+            command: process.execPath,
+            args: [CLI_PATH],
+            stderr: "pipe",
+            env: {
+                MDB_MCP_API_CLIENT_ID: process.env.REMOTE_MCP_E2E_CLIENT_ID ?? "",
+                MDB_MCP_API_CLIENT_SECRET: process.env.REMOTE_MCP_E2E_CLIENT_SECRET ?? "",
+                MDB_MCP_API_BASE_URL: process.env.REMOTE_MCP_E2E_BASE_URL ?? "",
+            },
+        });
+        await client.connect(transport);
+    }, 15_000);
+
+    afterAll(async () => {
+        await client?.close();
+    });
+
+    it("acquires a token and lists Atlas tools", async () => {
+        const result = await client.listTools();
+        expect(result.tools.map((t) => t.name)).toContain("atlas-list-projects");
+    }, 10_000);
+
+    it("calls atlas-list-projects and returns a non-error response", async () => {
+        const result = await client.callTool({ name: "atlas-list-projects", arguments: {} });
+        expect(result.isError).toBeFalsy();
+        // Simple check to verify that the response content is forwarded.
+        expect((result.content[0] as { text: string }).text).toContain("projects");
+    }, 10_000);
+});

--- a/packages/mongodb-atlas-mcp-remote/src/e2e.test.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/e2e.test.ts
@@ -20,6 +20,7 @@ describe.skipIf(shouldSkip)("mongodb-atlas-mcp-remote wrapper e2e tests", () => 
             args: [CLI_PATH],
             stderr: "pipe",
             env: {
+                ...process.env,
                 MDB_MCP_API_CLIENT_ID: process.env.REMOTE_MCP_E2E_CLIENT_ID ?? "",
                 MDB_MCP_API_CLIENT_SECRET: process.env.REMOTE_MCP_E2E_CLIENT_SECRET ?? "",
                 MDB_MCP_API_BASE_URL: process.env.REMOTE_MCP_E2E_BASE_URL ?? "",


### PR DESCRIPTION
## Description

Adding sanity e2e tests for the mongodb-atlas-mcp-remote package

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
