### PR TITLE
chore: rename organizationId arg to orgId for consistency with other tools CLOUDP-419289

### DIFF
--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -652,7 +652,7 @@ export class CreateProjectTool extends AtlasToolBase {
     // (undocumented)
     argsShape: {
         projectName: z.ZodOptional<z.ZodString>;
-        organizationId: z.ZodOptional<z.ZodString>;
+        orgId: z.ZodOptional<z.ZodString>;
     };
     // (undocumented)
     description: string;
@@ -663,7 +663,7 @@ export class CreateProjectTool extends AtlasToolBase {
     // (undocumented)
     outputSchema: {
         projectName: z.ZodString;
-        organizationId: z.ZodOptional<z.ZodString>;
+        orgId: z.ZodOptional<z.ZodString>;
     };
     // (undocumented)
     static toolName: string;

--- a/src/tools/atlas/create/createProject.ts
+++ b/src/tools/atlas/create/createProject.ts
@@ -6,7 +6,7 @@ import { AtlasArgs } from "../../args.js";
 
 const CreateProjectOutputSchema = {
     projectName: z.string(),
-    organizationId: z.string().optional(),
+    orgId: z.string().optional(),
 };
 
 export class CreateProjectTool extends AtlasToolBase {
@@ -15,12 +15,12 @@ export class CreateProjectTool extends AtlasToolBase {
     static operationType: OperationType = "create";
     public argsShape = {
         projectName: AtlasArgs.projectName().optional().describe("Name for the new project"),
-        organizationId: AtlasArgs.organizationId().optional().describe("Organization ID for the new project"),
+        orgId: AtlasArgs.organizationId().optional().describe("Organization ID for the new project"),
     };
     public override outputSchema = CreateProjectOutputSchema;
 
     protected async execute(
-        { projectName, organizationId }: ToolArgs<typeof this.argsShape>,
+        { projectName, orgId }: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
         let assumedOrg = false;
@@ -29,7 +29,7 @@ export class CreateProjectTool extends AtlasToolBase {
             projectName = "Atlas Project";
         }
 
-        if (!organizationId) {
+        if (!orgId) {
             try {
                 const organizations = await this.apiClient.listOrgs(undefined, context);
                 if (!organizations?.results?.length) {
@@ -43,7 +43,7 @@ export class CreateProjectTool extends AtlasToolBase {
                         "The first organization found does not have an ID. Please check your Atlas account."
                     );
                 }
-                organizationId = firstOrg.id;
+                orgId = firstOrg.id;
                 assumedOrg = true;
             } catch {
                 throw new Error(
@@ -54,7 +54,7 @@ export class CreateProjectTool extends AtlasToolBase {
 
         const input = {
             name: projectName,
-            orgId: organizationId,
+            orgId: orgId,
         } as Group;
 
         const group = await this.apiClient.createGroup(
@@ -72,12 +72,12 @@ export class CreateProjectTool extends AtlasToolBase {
             content: [
                 {
                     type: "text",
-                    text: `Project "${projectName}" created successfully${assumedOrg ? ` (using organizationId ${organizationId}).` : ""}.`,
+                    text: `Project "${projectName}" created successfully${assumedOrg ? ` (using orgId ${orgId}).` : ""}.`,
                 },
             ],
             structuredContent: {
                 projectName,
-                ...(assumedOrg && { organizationId }),
+                ...(assumedOrg && { orgId }),
             },
         };
     }

--- a/tests/integration/tools/atlas/projects.test.ts
+++ b/tests/integration/tools/atlas/projects.test.ts
@@ -32,7 +32,7 @@ describeWithAtlas("projects", (integration) => {
             expect(createProject.inputSchema.type).toBe("object");
             expectDefined(createProject.inputSchema.properties);
             expect(createProject.inputSchema.properties).toHaveProperty("projectName");
-            expect(createProject.inputSchema.properties).toHaveProperty("organizationId");
+            expect(createProject.inputSchema.properties).toHaveProperty("orgId");
         });
 
         it("should create a project", async () => {
@@ -52,7 +52,7 @@ describeWithAtlas("projects", (integration) => {
             expect(response.structuredContent).toMatchObject({
                 projectName: projName,
             });
-            expect(response.structuredContent).toHaveProperty("organizationId");
+            expect(response.structuredContent).toHaveProperty("orgId");
         });
     });
 
@@ -71,7 +71,7 @@ describeWithAtlas("projects", (integration) => {
 
             await integration.mcpClient().callTool({
                 name: "atlas-create-project",
-                arguments: { projectName: projName, organizationId: orgId },
+                arguments: { projectName: projName, orgId: orgId },
             });
         });
 

--- a/tests/unit/tools/atlas/create/createProject.test.ts
+++ b/tests/unit/tools/atlas/create/createProject.test.ts
@@ -60,7 +60,7 @@ describe("CreateProjectTool", () => {
     it("creates a project with explicit organizationId", async () => {
         mockApiClient.createGroup!.mockResolvedValue({ id: "proj-123", name: "My Project", orgId: "org-1" });
 
-        const result = await exec({ projectName: "My Project", organizationId: "org-1" });
+        const result = await exec({ projectName: "My Project", orgId: "org-1" });
 
         expect((result.content[0] as { text: string }).text).toContain('Project "My Project" created successfully');
         expect(mockApiClient.listOrgs).not.toHaveBeenCalled();
@@ -76,10 +76,10 @@ describe("CreateProjectTool", () => {
         const result = await exec();
 
         expect(mockApiClient.listOrgs).toHaveBeenCalled();
-        expect((result.content[0] as { text: string }).text).toContain("using organizationId org-first");
+        expect((result.content[0] as { text: string }).text).toContain("using orgId org-first");
         expect(result.structuredContent).toEqual({
             projectName: "Atlas Project",
-            organizationId: "org-first",
+            orgId: "org-first",
         });
     });
 
@@ -87,7 +87,7 @@ describe("CreateProjectTool", () => {
         mockApiClient.listOrgs!.mockResolvedValue({ results: [{ id: "org-1", name: "Org" }] });
         mockApiClient.createGroup!.mockResolvedValue({ id: "proj-789", name: "Atlas Project", orgId: "org-1" });
 
-        const result = await exec({ organizationId: "org-1" });
+        const result = await exec({ orgId: "org-1" });
 
         expect(result.structuredContent?.projectName).toBe("Atlas Project");
     });
@@ -95,8 +95,6 @@ describe("CreateProjectTool", () => {
     it("throws when createGroup returns no id", async () => {
         mockApiClient.createGroup!.mockResolvedValue({});
 
-        await expect(exec({ projectName: "My Project", organizationId: "org-1" })).rejects.toThrow(
-            "Failed to create project"
-        );
+        await expect(exec({ projectName: "My Project", orgId: "org-1" })).rejects.toThrow("Failed to create project");
     });
 });


### PR DESCRIPTION
## Proposed changes

Aligns the arg name with other places that have org id. This is definitely a short-term quick fix, I think for the future we should figure out a way to keep these consistent between tools in a way that is enforced and doesn't rely on us just sort of keeping this in mind all the time

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
