### PR TITLE
fix: update messages to use "requested collection" and keep collection name along with other parsed content - MCP-580

### DIFF
--- a/src/tools/mongodb/metadata/collectionIndexes.ts
+++ b/src/tools/mongodb/metadata/collectionIndexes.ts
@@ -80,7 +80,7 @@ export class CollectionIndexesTool extends MongoDBToolBase {
             return {
                 content: [
                     {
-                        text: `The indexes for "${args.database}.${args.collection}" cannot be determined because the collection does not exist.`,
+                        text: "The indexes for the requested namespace cannot be determined because the collection does not exist.",
                         type: "text",
                     },
                 ],

--- a/src/tools/mongodb/metadata/collectionIndexes.ts
+++ b/src/tools/mongodb/metadata/collectionIndexes.ts
@@ -56,12 +56,12 @@ export class CollectionIndexesTool extends MongoDBToolBase {
         return {
             content: [
                 ...formatUntrustedData(
-                    `Found ${classicIndexes.length} classic indexes in the collection "${collection}":`,
+                    `Found ${classicIndexes.length} classic indexes in the requested collection:`,
                     JSON.stringify(classicIndexes)
                 ),
                 ...(searchIndexes.length > 0
                     ? formatUntrustedData(
-                          `Found ${searchIndexes.length} search and vector search indexes in the collection "${collection}":`,
+                          `Found ${searchIndexes.length} search and vector search indexes in the requested collection:`,
                           JSON.stringify(searchIndexes)
                       )
                     : []),

--- a/src/tools/mongodb/metadata/collectionSchema.ts
+++ b/src/tools/mongodb/metadata/collectionSchema.ts
@@ -59,7 +59,7 @@ export class CollectionSchemaTool extends MongoDBToolBase {
             return {
                 content: [
                     {
-                        text: `Could not deduce the schema for "${database}.${collection}". This may be because it doesn't exist or is empty.`,
+                        text: "Could not deduce the schema for the requested namespace. This may be because it doesn't exist or is empty.",
                         type: "text",
                     },
                 ],
@@ -71,10 +71,10 @@ export class CollectionSchemaTool extends MongoDBToolBase {
         }
 
         const fieldsCount = Object.keys(schema).length;
-        const header = `Found ${fieldsCount} fields in the schema for "${database}.${collection}". Note that this schema is inferred from a sample and may not represent the full schema of the collection.`;
+        const header = `Found ${fieldsCount} fields in the sampled schema. Note that this schema is inferred from a sample and may not represent the full schema of the collection.`;
 
         return {
-            content: formatUntrustedData(`${header}`, JSON.stringify(schema)),
+            content: formatUntrustedData(header, JSON.stringify({ database, collection, schema })),
             structuredContent: {
                 schema,
                 fieldsCount,

--- a/src/tools/mongodb/metadata/collectionStorageSize.ts
+++ b/src/tools/mongodb/metadata/collectionStorageSize.ts
@@ -42,7 +42,7 @@ export class CollectionStorageSizeTool extends MongoDBToolBase {
         return {
             content: [
                 {
-                    text: `The size of "${database}.${collection}" is \`${scaledValue.toFixed(2)} ${units}\``,
+                    text: `The size of the requested namespace is \`${scaledValue.toFixed(2)} ${units}\``,
                     type: "text",
                 },
             ],
@@ -58,7 +58,7 @@ export class CollectionStorageSizeTool extends MongoDBToolBase {
             return {
                 content: [
                     {
-                        text: `The size of "${args.database}.${args.collection}" cannot be determined because the collection does not exist.`,
+                        text: "The size of the requested namespace cannot be determined because the collection does not exist.",
                         type: "text",
                     },
                 ],

--- a/src/tools/mongodb/metadata/dbStats.ts
+++ b/src/tools/mongodb/metadata/dbStats.ts
@@ -36,7 +36,7 @@ export class DbStatsTool extends MongoDBToolBase {
         const stats = bsonToJson(result);
 
         return {
-            content: formatUntrustedData(`Statistics for database ${database}`, JSON.stringify(stats)),
+            content: formatUntrustedData("Statistics for database:", JSON.stringify({ database, stats })),
             structuredContent: {
                 stats,
             },

--- a/src/tools/mongodb/metadata/explain.ts
+++ b/src/tools/mongodb/metadata/explain.ts
@@ -123,8 +123,8 @@ export class ExplainTool extends MongoDBToolBase {
 
         return {
             content: formatUntrustedData(
-                `Here is some information about the winning plan chosen by the query optimizer for running the given \`${method.name}\` operation in "${database}.${collection}". The execution plan was run with the following verbosity: "${verbosity}". This information can be used to understand how the query was executed and to optimize the query performance.`,
-                JSON.stringify(result)
+                `Here is some information about the winning plan chosen by the query optimizer for running the given \`${method.name}\` operation on the requested namespace. The execution plan was run with the following verbosity: "${verbosity}". This information can be used to understand how the query was executed and to optimize the query performance.`,
+                JSON.stringify({ database, collection, plan: result })
             ),
             structuredContent: {
                 explainResult: result,

--- a/src/tools/mongodb/metadata/listCollections.ts
+++ b/src/tools/mongodb/metadata/listCollections.ts
@@ -36,7 +36,7 @@ export class ListCollectionsTool extends MongoDBToolBase {
                 content: [
                     {
                         type: "text",
-                        text: `Found 0 collections for database "${database}". To create a collection, use the "create-collection" tool.`,
+                        text: `Found 0 collections for the requested database. To create a collection, use the "create-collection" tool.`,
                     },
                 ],
                 structuredContent: {
@@ -48,8 +48,8 @@ export class ListCollectionsTool extends MongoDBToolBase {
 
         return {
             content: formatUntrustedData(
-                `Found ${collections.length} collections for database "${database}".`,
-                JSON.stringify(collections)
+                `Found ${collections.length} collections in the requested database.`,
+                JSON.stringify({ database, collections })
             ),
             structuredContent: {
                 collections,

--- a/src/tools/mongodb/update/renameCollection.ts
+++ b/src/tools/mongodb/update/renameCollection.ts
@@ -48,7 +48,7 @@ export class RenameCollectionTool extends MongoDBToolBase {
         return {
             content: [
                 {
-                    text: `Collection "${collection}" renamed to "${result.collectionName}" in database "${database}".`,
+                    text: "The collection was renamed successfully in the requested database.",
                     type: "text",
                 },
             ],
@@ -71,7 +71,7 @@ export class RenameCollectionTool extends MongoDBToolBase {
                     return {
                         content: [
                             {
-                                text: `Cannot rename "${args.database}.${args.collection}" because it doesn't exist.`,
+                                text: "Cannot rename the requested collection because it doesn't exist.",
                                 type: "text",
                             },
                         ],
@@ -87,7 +87,7 @@ export class RenameCollectionTool extends MongoDBToolBase {
                     return {
                         content: [
                             {
-                                text: `Cannot rename "${args.database}.${args.collection}" to "${args.newName}" because the target collection already exists. If you want to overwrite it, set the "dropTarget" argument to true.`,
+                                text: 'Cannot rename the requested collection because the target collection already exists. If you want to overwrite it, set the "dropTarget" argument to true.',
                                 type: "text",
                             },
                         ],

--- a/tests/accuracy/aggregate.autoEmbeddings.test.ts
+++ b/tests/accuracy/aggregate.autoEmbeddings.test.ts
@@ -12,7 +12,7 @@ describeAccuracyTests(
                         content: [
                             {
                                 type: "text",
-                                text: 'Found 1 search and vector search indexes in the collection "movies"',
+                                text: "Found 1 search and vector search indexes in the requested collection",
                             },
                             {
                                 type: "text",

--- a/tests/accuracy/createIndex.autoEmbeddings.test.ts
+++ b/tests/accuracy/createIndex.autoEmbeddings.test.ts
@@ -41,7 +41,7 @@ If not present then create an auto embed vector search index on the 'plot' field
                         content: [
                             {
                                 type: "text",
-                                text: 'Found 1 search and vector search indexes in the collection "movies"',
+                                text: "Found 1 search and vector search indexes in the requested collection",
                             },
                             {
                                 type: "text",

--- a/tests/accuracy/insertMany.autoEmbeddings.test.ts
+++ b/tests/accuracy/insertMany.autoEmbeddings.test.ts
@@ -20,7 +20,7 @@ plot: "Pre-historic creatures come to life in this epic thrilling drama" \
                         content: [
                             {
                                 type: "text",
-                                text: 'Found 1 search and vector search indexes in the collection "movies"',
+                                text: "Found 1 search and vector search indexes in the requested collection",
                             },
                             {
                                 type: "text",

--- a/tests/integration/tools/mongodb/metadata/collectionIndexes.test.ts
+++ b/tests/integration/tools/mongodb/metadata/collectionIndexes.test.ts
@@ -45,7 +45,7 @@ describeWithMongoDB("collectionIndexes tool", (integration) => {
         const elements = getResponseElements(response.content);
         expect(elements).toHaveLength(1);
         expect(elements[0]?.text).toEqual(
-            'The indexes for the requested namespace cannot be determined because the collection does not exist.'
+            "The indexes for the requested namespace cannot be determined because the collection does not exist."
         );
     });
 
@@ -168,7 +168,7 @@ describeWithMongoDB(
                 });
                 const responseContent = getResponseContent(response.content);
                 expect(responseContent).toContain(
-                    'The indexes for the requested namespace cannot be determined because the collection does not exist.'
+                    "The indexes for the requested namespace cannot be determined because the collection does not exist."
                 );
 
                 expect(response.structuredContent).toBeUndefined();

--- a/tests/integration/tools/mongodb/metadata/collectionIndexes.test.ts
+++ b/tests/integration/tools/mongodb/metadata/collectionIndexes.test.ts
@@ -45,7 +45,7 @@ describeWithMongoDB("collectionIndexes tool", (integration) => {
         const elements = getResponseElements(response.content);
         expect(elements).toHaveLength(1);
         expect(elements[0]?.text).toEqual(
-            'The indexes for "non-existent.people" cannot be determined because the collection does not exist.'
+            'The indexes for the requested namespace cannot be determined because the collection does not exist.'
         );
     });
 
@@ -143,7 +143,7 @@ describeWithMongoDB("collectionIndexes tool", (integration) => {
     validateAutoConnectBehavior(integration, "collection-indexes", () => {
         return {
             args: { database: integration.randomDbName(), collection: "coll1" },
-            expectedResponse: `The indexes for "${integration.randomDbName()}.coll1" cannot be determined because the collection does not exist.`,
+            expectedResponse: `The indexes for the requested namespace cannot be determined because the collection does not exist.`,
         };
     });
 });
@@ -168,7 +168,7 @@ describeWithMongoDB(
                 });
                 const responseContent = getResponseContent(response.content);
                 expect(responseContent).toContain(
-                    'The indexes for "any.foo" cannot be determined because the collection does not exist.'
+                    'The indexes for the requested namespace cannot be determined because the collection does not exist.'
                 );
 
                 expect(response.structuredContent).toBeUndefined();

--- a/tests/integration/tools/mongodb/metadata/collectionIndexes.test.ts
+++ b/tests/integration/tools/mongodb/metadata/collectionIndexes.test.ts
@@ -63,7 +63,7 @@ describeWithMongoDB("collectionIndexes tool", (integration) => {
 
         const elements = getResponseElements(response.content);
         expect(elements).toHaveLength(2);
-        expect(elements[0]?.text).toEqual('Found 1 classic indexes in the collection "people":');
+        expect(elements[0]?.text).toEqual("Found 1 classic indexes in the requested collection:");
         const indexDefinitions = getIndexesFromContent(elements[1]?.text);
         expect(indexDefinitions).toEqual([{ name: "_id_", key: { _id: 1 } }]);
         // Validate structured content matches
@@ -101,7 +101,9 @@ describeWithMongoDB("collectionIndexes tool", (integration) => {
         const elements = getResponseElements(response.content);
         expect(elements).toHaveLength(2);
 
-        expect(elements[0]?.text).toEqual(`Found ${indexTypes.length + 1} classic indexes in the collection "people":`);
+        expect(elements[0]?.text).toEqual(
+            `Found ${indexTypes.length + 1} classic indexes in the requested collection:`
+        );
         const indexDefinitions = getIndexesFromContent(elements[1]?.text);
         expect(indexDefinitions).toContainEqual({ name: "_id_", key: { _id: 1 } });
 
@@ -187,7 +189,7 @@ describeWithMongoDB(
                 const responseElements = getResponseElements(response.content);
                 expect(responseElements).toHaveLength(2);
                 // Expect 2 indexes - _id_ and foo_1
-                expect(responseElements[0]?.text).toContain('Found 2 classic indexes in the collection "foo"');
+                expect(responseElements[0]?.text).toContain("Found 2 classic indexes in the requested collection");
 
                 const responseContent = getResponseContent(response.content);
                 expect(responseContent).not.toContain("search and vector search indexes");
@@ -246,9 +248,9 @@ describeWithMongoDB(
                 expect(elements).toHaveLength(4);
 
                 // Expect 1 regular index - _id_
-                expect(elements[0]?.text).toContain(`Found 1 classic indexes in the collection "foo":`);
+                expect(elements[0]?.text).toContain(`Found 1 classic indexes in the requested collection:`);
                 expect(elements[2]?.text).toContain(
-                    `Found 2 search and vector search indexes in the collection "foo":`
+                    `Found 2 search and vector search indexes in the requested collection:`
                 );
 
                 const indexDefinitions = getIndexesFromContent(elements[3]?.text) as {
@@ -344,9 +346,9 @@ describeWithMongoDB(
                 const elements = getResponseElements(response.content);
                 expect(elements).toHaveLength(4);
                 // Expect 1 regular index - _id_
-                expect(elements[0]?.text).toContain(`Found 1 classic indexes in the collection "foo":`);
+                expect(elements[0]?.text).toContain(`Found 1 classic indexes in the requested collection:`);
                 expect(elements[2]?.text).toContain(
-                    `Found 1 search and vector search indexes in the collection "foo":`
+                    `Found 1 search and vector search indexes in the requested collection:`
                 );
 
                 const indexDefinitions = getIndexesFromContent(elements[3]?.text) as {
@@ -423,8 +425,10 @@ describeWithMongoDB(
             expect(elements).toHaveLength(4);
 
             // Expect 1 regular index - _id_
-            expect(elements[0]?.text).toContain(`Found 1 classic indexes in the collection "foo":`);
-            expect(elements[2]?.text).toContain(`Found 2 search and vector search indexes in the collection "foo":`);
+            expect(elements[0]?.text).toContain(`Found 1 classic indexes in the requested collection:`);
+            expect(elements[2]?.text).toContain(
+                `Found 2 search and vector search indexes in the requested collection:`
+            );
 
             const indexDefinitions = getIndexesFromContent(elements[3]?.text) as {
                 name: string;
@@ -499,8 +503,8 @@ describeWithMongoDB(
             const elements = getResponseElements(response.content);
             expect(elements).toHaveLength(4);
             // Expect 1 regular index - _id_
-            expect(elements[0]?.text).toContain(`Found 1 classic indexes in the collection "foo"`);
-            expect(elements[2]?.text).toContain(`Found 1 search and vector search indexes in the collection "foo"`);
+            expect(elements[0]?.text).toContain(`Found 1 classic indexes in the requested collection`);
+            expect(elements[2]?.text).toContain(`Found 1 search and vector search indexes in the requested collection`);
         });
     },
     {

--- a/tests/integration/tools/mongodb/metadata/collectionSchema.test.ts
+++ b/tests/integration/tools/mongodb/metadata/collectionSchema.test.ts
@@ -43,7 +43,7 @@ describeWithMongoDB("collectionSchema tool", (integration) => {
             });
             const content = getResponseContent(response.content);
             expect(content).toEqual(
-                `Could not deduce the schema for "non-existent.foo". This may be because it doesn't exist or is empty.`
+                `Could not deduce the schema for the requested namespace. This may be because it doesn't exist or is empty.`
             );
 
             // Structured content should have empty schema for empty collection
@@ -150,10 +150,12 @@ describeWithMongoDB("collectionSchema tool", (integration) => {
 
                 // Expect to find _id, name, age
                 expect(items[0]?.text).toEqual(
-                    `Found ${Object.entries(testCase.expectedSchema).length} fields in the schema for "${integration.randomDbName()}.foo". Note that this schema is inferred from a sample and may not represent the full schema of the collection.`
+                    `Found ${Object.entries(testCase.expectedSchema).length} fields in the sampled schema. Note that this schema is inferred from a sample and may not represent the full schema of the collection.`
                 );
 
-                const schema = JSON.parse(getDataFromUntrustedContent(items[1]?.text ?? "{}")) as SimplifiedSchema;
+                const { schema } = JSON.parse(getDataFromUntrustedContent(items[1]?.text ?? "{}")) as {
+                    schema: SimplifiedSchema;
+                };
                 expect(schema).toEqual(testCase.expectedSchema);
 
                 // Validate structured content matches
@@ -162,6 +164,26 @@ describeWithMongoDB("collectionSchema tool", (integration) => {
                 expect(structuredContent.fieldsCount).toBe(Object.entries(testCase.expectedSchema).length);
             });
         }
+
+        it("returns the collection name only inside the untrusted-data block, not the description", async () => {
+            const collectionName = "my sentences collection";
+            const mongoClient = integration.mongoClient();
+            await mongoClient.db(integration.randomDbName()).collection(collectionName).insertOne({ a: 1 });
+
+            await integration.connectMcpClient();
+            const response = await integration.mcpClient().callTool({
+                name: "collection-schema",
+                arguments: { database: integration.randomDbName(), collection: collectionName },
+            });
+            const items = getResponseElements(response.content);
+            expect(items).toHaveLength(2);
+
+            // The description is a static header and does not echo the collection name...
+            expect(items[0]?.text).not.toContain(collectionName);
+            // ...the name is surfaced within the untrusted-data section instead.
+            expect(items[1]?.text).toContain("<untrusted-user-data-");
+            expect(items[1]?.text).toContain(collectionName);
+        });
     });
 
     validateAutoConnectBehavior(integration, "collection-schema", () => {
@@ -170,7 +192,7 @@ describeWithMongoDB("collectionSchema tool", (integration) => {
                 database: integration.randomDbName(),
                 collection: "new-collection",
             },
-            expectedResponse: `Could not deduce the schema for "${integration.randomDbName()}.new-collection". This may be because it doesn't exist or is empty.`,
+            expectedResponse: `Could not deduce the schema for the requested namespace. This may be because it doesn't exist or is empty.`,
         };
     });
 });

--- a/tests/integration/tools/mongodb/metadata/collectionStorageSize.test.ts
+++ b/tests/integration/tools/mongodb/metadata/collectionStorageSize.test.ts
@@ -32,7 +32,7 @@ describeWithMongoDB("collectionStorageSize tool", (integration) => {
             });
             const content = getResponseContent(response.content);
             expect(content).toEqual(
-                `The size of "${integration.randomDbName()}.foo" cannot be determined because the collection does not exist.`
+                `The size of the requested namespace cannot be determined because the collection does not exist.`
             );
 
             // For error case, structured content is not required (isError: true)
@@ -69,7 +69,7 @@ describeWithMongoDB("collectionStorageSize tool", (integration) => {
                     arguments: { database: integration.randomDbName(), collection: "foo" },
                 });
                 const content = getResponseContent(response.content);
-                expect(content).toContain(`The size of "${integration.randomDbName()}.foo" is`);
+                expect(content).toContain(`The size of the requested namespace is`);
                 const size = /is `(\d+\.\d+) ([a-zA-Z]*)`/.exec(content);
 
                 expectDefined(size?.[1]);
@@ -94,7 +94,7 @@ describeWithMongoDB("collectionStorageSize tool", (integration) => {
                 database: integration.randomDbName(),
                 collection: "foo",
             },
-            expectedResponse: `The size of "${integration.randomDbName()}.foo" cannot be determined because the collection does not exist.`,
+            expectedResponse: `The size of the requested namespace cannot be determined because the collection does not exist.`,
         };
     });
 });

--- a/tests/integration/tools/mongodb/metadata/dbStats.test.ts
+++ b/tests/integration/tools/mongodb/metadata/dbStats.test.ts
@@ -32,13 +32,15 @@ describeWithMongoDB("dbStats tool", (integration) => {
             });
             const elements = getResponseElements(response.content);
             expect(elements).toHaveLength(2);
-            expect(elements[0]?.text).toBe(`Statistics for database ${integration.randomDbName()}`);
+            expect(elements[0]?.text).toBe(`Statistics for database:`);
 
             const json = getDataFromUntrustedContent(elements[1]?.text ?? "{}");
-            const stats = JSON.parse(json) as {
-                db: string;
-                collections: unknown;
-                storageSize: unknown;
+            const { stats } = JSON.parse(json) as {
+                stats: {
+                    db: string;
+                    collections: unknown;
+                    storageSize: unknown;
+                };
             };
             expect(stats.db).toBe(integration.randomDbName());
             expectIdiomaticNumber(stats.collections, 0);
@@ -84,13 +86,15 @@ describeWithMongoDB("dbStats tool", (integration) => {
                 });
                 const elements = getResponseElements(response.content);
                 expect(elements).toHaveLength(2);
-                expect(elements[0]?.text).toBe(`Statistics for database ${integration.randomDbName()}`);
+                expect(elements[0]?.text).toBe(`Statistics for database:`);
 
-                const stats = JSON.parse(getDataFromUntrustedContent(elements[1]?.text ?? "{}")) as {
-                    db: string;
-                    collections: unknown;
-                    storageSize: unknown;
-                    objects: unknown;
+                const { stats } = JSON.parse(getDataFromUntrustedContent(elements[1]?.text ?? "{}")) as {
+                    stats: {
+                        db: string;
+                        collections: unknown;
+                        storageSize: unknown;
+                        objects: unknown;
+                    };
                 };
                 expect(stats.db).toBe(integration.randomDbName());
                 expectIdiomaticNumber(stats.collections, Object.entries(test.collections).length);
@@ -113,7 +117,7 @@ describeWithMongoDB("dbStats tool", (integration) => {
                 database: integration.randomDbName(),
                 collection: "foo",
             },
-            expectedResponse: `Statistics for database ${integration.randomDbName()}`,
+            expectedResponse: `Statistics for database:`,
         };
     });
 

--- a/tests/integration/tools/mongodb/metadata/explain.test.ts
+++ b/tests/integration/tools/mongodb/metadata/explain.test.ts
@@ -101,7 +101,7 @@ describeWithMongoDB("explain tool", (integration) => {
                     const content = getResponseElements(response.content);
                     expect(content).toHaveLength(2);
                     expect(content[0]?.text).toEqual(
-                        `Here is some information about the winning plan chosen by the query optimizer for running the given \`${testCase.method}\` operation in "${integration.randomDbName()}.coll1". The execution plan was run with the following verbosity: "queryPlanner". This information can be used to understand how the query was executed and to optimize the query performance.`
+                        `Here is some information about the winning plan chosen by the query optimizer for running the given \`${testCase.method}\` operation on the requested namespace. The execution plan was run with the following verbosity: "queryPlanner". This information can be used to understand how the query was executed and to optimize the query performance.`
                     );
 
                     expect(content[1]?.text).toContain("queryPlanner");
@@ -155,7 +155,7 @@ describeWithMongoDB("explain tool", (integration) => {
                     const content = getResponseElements(response.content);
                     expect(content).toHaveLength(2);
                     expect(content[0]?.text).toEqual(
-                        `Here is some information about the winning plan chosen by the query optimizer for running the given \`${testCase.method}\` operation in "${integration.randomDbName()}.coll1". The execution plan was run with the following verbosity: "executionStats". This information can be used to understand how the query was executed and to optimize the query performance.`
+                        `Here is some information about the winning plan chosen by the query optimizer for running the given \`${testCase.method}\` operation on the requested namespace. The execution plan was run with the following verbosity: "executionStats". This information can be used to understand how the query was executed and to optimize the query performance.`
                     );
 
                     expect(content[1]?.text).toContain("queryPlanner");
@@ -213,7 +213,7 @@ describeWithMongoDB("explain tool", (integration) => {
                         const content = getResponseElements(response.content);
                         expect(content).toHaveLength(2);
                         expect(content[0]?.text).toEqual(
-                            `Here is some information about the winning plan chosen by the query optimizer for running the given \`${testCase.method}\` operation in "${integration.randomDbName()}.people". The execution plan was run with the following verbosity: "queryPlanner". This information can be used to understand how the query was executed and to optimize the query performance.`
+                            `Here is some information about the winning plan chosen by the query optimizer for running the given \`${testCase.method}\` operation on the requested namespace. The execution plan was run with the following verbosity: "queryPlanner". This information can be used to understand how the query was executed and to optimize the query performance.`
                         );
 
                         expect(content[1]?.text).toContain("queryPlanner");

--- a/tests/integration/tools/mongodb/metadata/listCollections.test.ts
+++ b/tests/integration/tools/mongodb/metadata/listCollections.test.ts
@@ -32,7 +32,7 @@ describeWithMongoDB("listCollections tool", (integration) => {
             });
             const content = getResponseContent(response.content);
             expect(content).toEqual(
-                'Found 0 collections for database "non-existent". To create a collection, use the "create-collection" tool.'
+                'Found 0 collections for the requested database. To create a collection, use the "create-collection" tool.'
             );
 
             // Structured content should have empty array for empty database
@@ -54,11 +54,11 @@ describeWithMongoDB("listCollections tool", (integration) => {
             });
             const items = getResponseElements(response.content);
             expect(items).toHaveLength(2);
-            expect(items[0]?.text).toEqual(`Found 1 collections for database "${integration.randomDbName()}".`);
+            expect(items[0]?.text).toEqual("Found 1 collections in the requested database.");
 
-            const contentData = JSON.parse(
-                getDataFromUntrustedContent(items[1]?.text ?? "")
-            ) as ListCollectionsOutput["collections"];
+            const { collections: contentData } = JSON.parse(getDataFromUntrustedContent(items[1]?.text ?? "")) as {
+                collections: ListCollectionsOutput["collections"];
+            };
             expect(contentData).toEqual([{ name: "collection-1" }]);
 
             const structuredContent = response.structuredContent as ListCollectionsOutput;
@@ -74,11 +74,11 @@ describeWithMongoDB("listCollections tool", (integration) => {
             const items2 = getResponseElements(response2.content);
             expect(items2).toHaveLength(2);
 
-            expect(items2[0]?.text).toEqual(`Found 2 collections for database "${integration.randomDbName()}".`);
+            expect(items2[0]?.text).toEqual("Found 2 collections in the requested database.");
 
-            const contentData2 = JSON.parse(
-                getDataFromUntrustedContent(items2[1]?.text ?? "")
-            ) as ListCollectionsOutput["collections"];
+            const { collections: contentData2 } = JSON.parse(getDataFromUntrustedContent(items2[1]?.text ?? "")) as {
+                collections: ListCollectionsOutput["collections"];
+            };
             expect(contentData2.map((c: { name: string }) => c.name)).toIncludeSameMembers([
                 "collection-1",
                 "collection-2",
@@ -100,7 +100,7 @@ describeWithMongoDB("listCollections tool", (integration) => {
         () => {
             return {
                 args: { database: integration.randomDbName() },
-                expectedResponse: `Found 0 collections for database "${integration.randomDbName()}". To create a collection, use the "create-collection" tool.`,
+                expectedResponse: `Found 0 collections for the requested database. To create a collection, use the "create-collection" tool.`,
             };
         }
     );

--- a/tests/integration/tools/mongodb/update/renameCollection.test.ts
+++ b/tests/integration/tools/mongodb/update/renameCollection.test.ts
@@ -43,7 +43,7 @@ describeWithMongoDB("renameCollection tool", (integration) => {
                 arguments: { database: "non-existent", collection: "foos", newName: "bar" },
             });
             const content = getResponseContent(response.content);
-            expect(content).toEqual(`Cannot rename "non-existent.foos" because it doesn't exist.`);
+            expect(content).toEqual(`Cannot rename the requested collection because it doesn't exist.`);
         });
     });
 
@@ -57,9 +57,7 @@ describeWithMongoDB("renameCollection tool", (integration) => {
                 arguments: { database: integration.randomDbName(), collection: "non-existent", newName: "foo" },
             });
             const content = getResponseContent(response.content);
-            expect(content).toEqual(
-                `Cannot rename "${integration.randomDbName()}.non-existent" because it doesn't exist.`
-            );
+            expect(content).toEqual(`Cannot rename the requested collection because it doesn't exist.`);
         });
     });
 
@@ -77,9 +75,7 @@ describeWithMongoDB("renameCollection tool", (integration) => {
                 arguments: { database: integration.randomDbName(), collection: "before", newName: "after" },
             });
             const content = getResponseContent(response.content);
-            expect(content).toEqual(
-                `Collection "before" renamed to "after" in database "${integration.randomDbName()}".`
-            );
+            expect(content).toEqual(`The collection was renamed successfully in the requested database.`);
 
             const structuredContent = response.structuredContent as RenameCollectionOutput;
             expect(structuredContent.database).toBe(integration.randomDbName());
@@ -120,7 +116,7 @@ describeWithMongoDB("renameCollection tool", (integration) => {
             });
             const content = getResponseContent(response.content);
             expect(content).toEqual(
-                `Cannot rename "${integration.randomDbName()}.before" to "after" because the target collection already exists. If you want to overwrite it, set the "dropTarget" argument to true.`
+                `Cannot rename the requested collection because the target collection already exists. If you want to overwrite it, set the "dropTarget" argument to true.`
             );
 
             const structuredContent = response.structuredContent as RenameCollectionOutput;
@@ -168,9 +164,7 @@ describeWithMongoDB("renameCollection tool", (integration) => {
                 },
             });
             const content = getResponseContent(response.content);
-            expect(content).toEqual(
-                `Collection "before" renamed to "after" in database "${integration.randomDbName()}".`
-            );
+            expect(content).toEqual(`The collection was renamed successfully in the requested database.`);
 
             // Ensure the data was moved
             const docsInBefore = await integration
@@ -259,9 +253,7 @@ describeWithMongoDB("renameCollection tool", (integration) => {
                 },
             });
             const content = getResponseContent(response.content);
-            expect(content).toEqual(
-                `Collection "before" renamed to "after" in database "${integration.randomDbName()}".`
-            );
+            expect(content).toEqual(`The collection was renamed successfully in the requested database.`);
         });
     });
 
@@ -271,7 +263,7 @@ describeWithMongoDB("renameCollection tool", (integration) => {
         () => {
             return {
                 args: { database: integration.randomDbName(), collection: "coll1", newName: "coll2" },
-                expectedResponse: `Collection "coll1" renamed to "coll2" in database "${integration.randomDbName()}".`,
+                expectedResponse: `The collection was renamed successfully in the requested database.`,
             };
         },
         async () => {


### PR DESCRIPTION
MCP-580

## Proposed changes
We are removing the interpolated collection name and keeping the text generic. When necessary, the name is added to the untrusted content tag. This is also part of the tool argument, so the agent have access to the collection name even if we are not explicit returning it. 

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
