### PR TITLE
chore: add session as an argument to addSession CLOUDP-418929

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -603,6 +603,7 @@ export interface ISessionStore<T extends CloseableTransport = CloseableTransport
         sessionId: string;
         transport: T;
         logger: LoggerBase;
+        session: Session;
         headers?: Record<string, unknown>;
     }): Promise<void>;
     // (undocumented)
@@ -613,7 +614,7 @@ export interface ISessionStore<T extends CloseableTransport = CloseableTransport
         reason?: SessionCloseReason;
     }): Promise<void>;
     // (undocumented)
-    getSession(sessionId: string): Promise<T | undefined>;
+    getSession(sessionId: string, headers?: Record<string, unknown>): Promise<T | undefined>;
 }
 
 // @public
@@ -989,6 +990,7 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
         sessionId: string;
         transport: T;
         logger: LoggerBase;
+        session: Session;
         headers?: Record<string, unknown>;
     }): Promise<void>;
     // (undocumented)
@@ -999,7 +1001,7 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
         reason?: SessionCloseReason;
     }): Promise<void>;
     // (undocumented)
-    getSession(sessionId: string): Promise<T | undefined>;
+    getSession(sessionId: string, _headers?: Record<string, unknown>): Promise<T | undefined>;
 }
 
 // @public

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -1005,6 +1005,7 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
     }): Promise<void>;
     // (undocumented)
     getSession(sessionId: string, _headers?: Record<string, unknown>): Promise<T | undefined>;
+    hasSession(sessionId: string): boolean;
 }
 
 // @public

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -598,7 +598,6 @@ export { Histogram }
 
 // @public
 export interface ISessionStore<T extends CloseableTransport = CloseableTransport> {
-    // (undocumented)
     addSession(params: {
         sessionId: string;
         transport: T;
@@ -613,7 +612,6 @@ export interface ISessionStore<T extends CloseableTransport = CloseableTransport
         sessionId: string;
         reason?: SessionCloseReason;
     }): Promise<void>;
-    // (undocumented)
     getSession(sessionId: string, headers?: Record<string, unknown>): Promise<T | undefined>;
 }
 
@@ -973,6 +971,11 @@ export interface SessionOptions<TUserConfig extends UserConfig = UserConfig> {
     logger: CompositeLogger;
     // (undocumented)
     userConfig: TUserConfig;
+}
+
+// @public
+export class SessionRejectedError extends Error {
+    constructor(message: string);
 }
 
 // @public (undocumented)

--- a/packages/types/src/sessionStore.ts
+++ b/packages/types/src/sessionStore.ts
@@ -1,5 +1,6 @@
 import type { ILoggerBase } from "./logging.js";
 import type { IMetrics, MetricDefinitions } from "./metrics.js";
+import type { ISession } from "./session.js";
 
 export type CloseableTransport = {
     close(): Promise<void>;
@@ -8,11 +9,34 @@ export type CloseableTransport = {
 export type SessionCloseReason = "idle_timeout" | "transport_closed" | "server_stop" | "unknown";
 
 export interface ISessionStore<T extends CloseableTransport = CloseableTransport> {
-    getSession(sessionId: string): Promise<T | undefined>;
+    /**
+     * Returns the transport for the given session id or `undefined` if the
+     * session does not exist.
+     *
+     * @param headers The headers of the incoming request. Implementations can
+     * use them to validate the caller's identity before returning the session.
+     * To reject a request for an existing session, throw a
+     * `SessionRejectedError` rather than returning `undefined` — the latter is
+     * treated as "session not found" and may trigger implicit session
+     * initialization.
+     */
+    getSession(sessionId: string, headers?: Record<string, unknown>): Promise<T | undefined>;
+    /**
+     * Stores a newly initialized session.
+     *
+     * @param params.session The server session, exposing session-level state
+     * (e.g. the logger or the connection manager) to implementations that
+     * need it.
+     * @param params.headers The headers of the request that initiated the
+     * session (e.g. for tracing the x-request-id in logs and downstream
+     * requests).
+     */
     addSession(params: {
         sessionId: string;
         transport: T;
+        /** TODO: Remove in v2 — redundant with `session.logger`. */
         logger: ILoggerBase;
+        session: ISession;
         headers?: Record<string, unknown>;
     }): Promise<void>;
     closeSession(params: { sessionId: string; reason?: SessionCloseReason }): Promise<void>;

--- a/src/common/sessionStore.ts
+++ b/src/common/sessionStore.ts
@@ -108,6 +108,18 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
         return Promise.resolve(this.sessions[sessionId]?.transport);
     }
 
+    /**
+     * Returns whether a session with the given id exists in this store.
+     *
+     * Unlike `getSession`, this does not reset the session's idle
+     * timeout, so it is safe to call when probing on behalf of requests that
+     * may not be served (e.g. authorization checks) without extending the
+     * session's lifetime.
+     */
+    hasSession(sessionId: string): boolean {
+        return this.sessions[sessionId] !== undefined;
+    }
+
     private resetTimeout(sessionId: string): void {
         const session = this.sessions[sessionId];
         if (!session) {

--- a/src/common/sessionStore.ts
+++ b/src/common/sessionStore.ts
@@ -9,16 +9,54 @@ import type { CloseableTransport, SessionCloseReason } from "@mongodb-js/mcp-typ
 export type { CloseableTransport, SessionCloseReason };
 
 /**
+ * Error that `ISessionStore` implementations can throw from `getSession` to
+ * reject a request (e.g. when identity validation against the request headers
+ * fails). Unlike returning `undefined`, which means the session does not exist
+ * and may trigger implicit session initialization, throwing this error fails
+ * the request without creating a session. To avoid leaking whether the
+ * session exists, the response is indistinguishable from "session not found";
+ * the error message is only logged server-side.
+ */
+export class SessionRejectedError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "SessionRejectedError";
+    }
+}
+
+/**
  * Interface for managing MCP transport sessions.
  *
  * Implement this interface to provide custom session storage and lifecycle
  * management (e.g. database-based session storage).
  */
 export interface ISessionStore<T extends CloseableTransport = CloseableTransport> {
+    /**
+     * Returns the transport for the given session id or `undefined` if the
+     * session does not exist.
+     *
+     * @param headers The headers of the incoming request. Implementations can
+     * use them to validate the caller's identity before returning the session.
+     * To reject a request for an existing session, throw a
+     * {@link SessionRejectedError} rather than returning `undefined` — the
+     * latter is treated as "session not found" and may trigger implicit
+     * session initialization.
+     */
     getSession(sessionId: string, headers?: Record<string, unknown>): Promise<T | undefined>;
+    /**
+     * Stores a newly initialized session.
+     *
+     * @param params.session The server session, exposing session-level state
+     * (e.g. the logger or the connection manager) to implementations that
+     * need it.
+     * @param params.headers The headers of the request that initiated the
+     * session (e.g. for tracing the x-request-id in logs and downstream
+     * requests).
+     */
     addSession(params: {
         sessionId: string;
         transport: T;
+        /** TODO: Remove in v2 — redundant with `session.logger`. */
         logger: LoggerBase;
         session: Session;
         headers?: Record<string, unknown>;
@@ -64,6 +102,7 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async getSession(sessionId: string, _headers?: Record<string, unknown>): Promise<T | undefined> {
         this.resetTimeout(sessionId);
         return Promise.resolve(this.sessions[sessionId]?.transport);
@@ -100,13 +139,13 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
     async addSession(params: {
         sessionId: string;
         transport: T;
+        /** TODO: Remove in v2 — redundant with `session.logger`. */
         logger: LoggerBase;
         session: Session;
         headers?: Record<string, unknown>;
     }): Promise<void> {
         const { sessionId, transport, logger } = params;
-        const session = this.sessions[sessionId];
-        if (session) {
+        if (this.sessions[sessionId]) {
             throw new Error(`Session ${sessionId} already exists`);
         }
         const abortTimeout = setManagedTimeout(async () => {

--- a/src/common/sessionStore.ts
+++ b/src/common/sessionStore.ts
@@ -1,5 +1,6 @@
 import type { LoggerBase } from "./logging/index.js";
 import { LogId } from "./logging/index.js";
+import type { Session } from "./session.js";
 import type { ManagedTimeout } from "./managedTimeout.js";
 import { setManagedTimeout } from "./managedTimeout.js";
 import type { Metrics, DefaultMetrics } from "@mongodb-js/mcp-metrics";
@@ -14,11 +15,12 @@ export type { CloseableTransport, SessionCloseReason };
  * management (e.g. database-based session storage).
  */
 export interface ISessionStore<T extends CloseableTransport = CloseableTransport> {
-    getSession(sessionId: string): Promise<T | undefined>;
+    getSession(sessionId: string, headers?: Record<string, unknown>): Promise<T | undefined>;
     addSession(params: {
         sessionId: string;
         transport: T;
         logger: LoggerBase;
+        session: Session;
         headers?: Record<string, unknown>;
     }): Promise<void>;
     closeSession(params: { sessionId: string; reason?: SessionCloseReason }): Promise<void>;
@@ -62,7 +64,7 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
         }
     }
 
-    async getSession(sessionId: string): Promise<T | undefined> {
+    async getSession(sessionId: string, _headers?: Record<string, unknown>): Promise<T | undefined> {
         this.resetTimeout(sessionId);
         return Promise.resolve(this.sessions[sessionId]?.transport);
     }
@@ -99,6 +101,7 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
         sessionId: string;
         transport: T;
         logger: LoggerBase;
+        session: Session;
         headers?: Record<string, unknown>;
     }): Promise<void> {
         const { sessionId, transport, logger } = params;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -92,6 +92,7 @@ export { Elicitation } from "./elicitation.js";
 export { applyConfigOverrides, ConfigOverrideError } from "./common/config/configOverrides.js";
 export {
     SessionStore,
+    SessionRejectedError,
     createDefaultSessionStore,
     type ISessionStore,
     type CloseableTransport,

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -12,6 +12,7 @@ import {
     type LoggerBase,
 } from "../lib.js";
 import { ConfigOverrideError } from "../common/config/configOverrides.js";
+import { SessionRejectedError } from "../common/sessionStore.js";
 import type { CustomizableServerOptions, CustomizableSessionOptions, TransportRequestContext } from "./base.js";
 import { ExpressBasedHttpServer } from "./expressBasedHttpServer.js";
 import { requestIdAttr } from "../helpers/requestIdAttr.js";
@@ -442,6 +443,13 @@ export class MCPHttpServer<
                     message: `Error handling request: ${error instanceof Error ? error.message : String(error)}`,
                     attributes: requestIdAttr(req.headers),
                 });
+
+                if (error instanceof SessionRejectedError) {
+                    // Respond exactly as if the session doesn't exist so that
+                    // callers can't probe whether a session id is valid; the
+                    // rejection reason is only visible in the log above.
+                    return this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND);
+                }
 
                 const message = error instanceof ConfigOverrideError ? error.message : `failed to handle request`;
 

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -196,7 +196,7 @@ export class MCPHttpServer<
         const requestIdAttrs = requestIdAttr(req.headers);
 
         // Check if session already exists
-        if (await this.sessionStore.getSession(sessionId)) {
+        if (await this.sessionStore.getSession(sessionId, req.headers)) {
             return sessionId;
         }
 
@@ -287,6 +287,7 @@ export class MCPHttpServer<
                 sessionId,
                 transport,
                 logger: server.session.logger,
+                session: server.session,
                 // Pass the incoming request headers to the session store so
                 // that we can trace the x-request-id and other headers in the
                 // resulting logs and downstream requests.
@@ -348,7 +349,7 @@ export class MCPHttpServer<
 
             const requestIdAttrs = requestIdAttr(req.headers);
 
-            let transport = await this.sessionStore.getSession(sessionId);
+            let transport = await this.sessionStore.getSession(sessionId, req.headers);
             if (!transport) {
                 if (!this.userConfig.externallyManagedSessions) {
                     this.logger.debug({
@@ -366,7 +367,7 @@ export class MCPHttpServer<
                     sessionId,
                     isImplicitInitialization: true,
                 });
-                transport = await this.sessionStore.getSession(resolvedSessionId);
+                transport = await this.sessionStore.getSession(resolvedSessionId, req.headers);
                 if (!transport) {
                     return this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND);
                 }
@@ -400,7 +401,7 @@ export class MCPHttpServer<
                         sessionId,
                         isImplicitInitialization: false,
                     });
-                    const transport = await this.sessionStore.getSession(resolvedSessionId);
+                    const transport = await this.sessionStore.getSession(resolvedSessionId, req.headers);
                     if (!transport) {
                         return this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND);
                     }

--- a/tests/integration/transports/streamableHttp.test.ts
+++ b/tests/integration/transports/streamableHttp.test.ts
@@ -9,6 +9,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { LogId, type LoggerBase } from "../../../src/common/logging/index.js";
+import type { Session } from "../../../src/common/session.js";
 import { defaultCreateConnectionManager } from "../../../src/common/connectionManager.js";
 import { Keychain } from "../../../src/common/keychain.js";
 import { defaultTestConfig, InMemoryLogger } from "../helpers.js";
@@ -597,6 +598,7 @@ describe("StreamableHttpRunner", () => {
                         sessionId: string;
                         transport: StreamableHTTPServerTransport;
                         logger: LoggerBase;
+                        session: Session;
                     }): Promise<void> {
                         await this.inner.addSession(params);
                         const caller = ownerStorage.getStore();

--- a/tests/unit/sessionStore.test.ts
+++ b/tests/unit/sessionStore.test.ts
@@ -185,3 +185,61 @@ describe("SessionStore metrics", () => {
         expect(values.find((v) => v.labels.reason === "server_stop")?.value).toBe(1);
     });
 });
+
+describe("SessionStore.hasSession", () => {
+    let store: SessionStore;
+
+    beforeEach(() => {
+        store = new SessionStore({
+            options: { idleTimeoutMS: 60_000, notificationTimeoutMS: 30_000 },
+            logger: createMockLogger(),
+            metrics: new MockMetrics(),
+        });
+    });
+
+    it("returns whether the session exists", async () => {
+        expect(store.hasSession("s1")).toBe(false);
+
+        await store.addSession({
+            sessionId: "s1",
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
+
+        expect(store.hasSession("s1")).toBe(true);
+
+        await store.closeSession({ sessionId: "s1" });
+        expect(store.hasSession("s1")).toBe(false);
+    });
+
+    it("does not reset the idle timeout, unlike getSession", async () => {
+        vi.useFakeTimers();
+        try {
+            await store.addSession({
+                sessionId: "probed",
+                transport: createMockTransport(),
+                logger: createMockLogger(),
+                session: createMockSession(),
+            });
+            await store.addSession({
+                sessionId: "accessed",
+                transport: createMockTransport(),
+                logger: createMockLogger(),
+                session: createMockSession(),
+            });
+
+            await vi.advanceTimersByTimeAsync(30_000);
+            store.hasSession("probed");
+            await store.getSession("accessed");
+            await vi.advanceTimersByTimeAsync(30_001);
+
+            // "probed" idled out 60s after creation; "accessed" got a fresh
+            // 60s window when getSession reset its timeout.
+            expect(store.hasSession("probed")).toBe(false);
+            expect(store.hasSession("accessed")).toBe(true);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/tests/unit/sessionStore.test.ts
+++ b/tests/unit/sessionStore.test.ts
@@ -37,22 +37,42 @@ describe("SessionStore metrics", () => {
     });
 
     it("increments sessionCreated when a session is added", async () => {
-        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({
+            sessionId: "s1",
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
 
         const { values } = await metrics.get("sessionCreated").get();
         expect(values[0]?.value).toBe(1);
     });
 
     it("increments sessionCreated for each new session", async () => {
-        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
-        await store.addSession({ sessionId: "s2", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({
+            sessionId: "s1",
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
+        await store.addSession({
+            sessionId: "s2",
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
 
         const { values } = await metrics.get("sessionCreated").get();
         expect(values[0]?.value).toBe(2);
     });
 
     it("increments sessionClosed with reason when a session is closed", async () => {
-        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({
+            sessionId: "s1",
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
         await store.closeSession({ sessionId: "s1", reason: "transport_closed" });
 
         const { values } = await metrics.get("sessionClosed").get();
@@ -61,8 +81,18 @@ describe("SessionStore metrics", () => {
     });
 
     it("records reason 'server_stop' when closeAllSessions is called", async () => {
-        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
-        await store.addSession({ sessionId: "s2", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({
+            sessionId: "s1",
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
+        await store.addSession({
+            sessionId: "s2",
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
         await store.closeAllSessions();
 
         const { values } = await metrics.get("sessionClosed").get();
@@ -73,7 +103,12 @@ describe("SessionStore metrics", () => {
     it("records reason 'idle_timeout' when session times out", async () => {
         vi.useFakeTimers();
         try {
-            await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
+            await store.addSession({
+                sessionId: "s1",
+                transport: createMockTransport(),
+                logger: createMockLogger(),
+                session: createMockSession(),
+            });
 
             await vi.advanceTimersByTimeAsync(60_001);
 
@@ -87,7 +122,12 @@ describe("SessionStore metrics", () => {
 
     it("does not call transport.close() when reason is transport_closed", async () => {
         const closeFn = vi.fn().mockResolvedValue(undefined);
-        await store.addSession({ sessionId: "s1", transport: { close: closeFn }, logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({
+            sessionId: "s1",
+            transport: { close: closeFn },
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
         await store.closeSession({ sessionId: "s1", reason: "transport_closed" });
 
         expect(closeFn).not.toHaveBeenCalled();
@@ -96,8 +136,18 @@ describe("SessionStore metrics", () => {
     it("calls transport.close() for server-initiated close reasons", async () => {
         const closeFn1 = vi.fn().mockResolvedValue(undefined);
         const closeFn2 = vi.fn().mockResolvedValue(undefined);
-        await store.addSession({ sessionId: "s1", transport: { close: closeFn1 }, logger: createMockLogger(), session: createMockSession() });
-        await store.addSession({ sessionId: "s2", transport: { close: closeFn2 }, logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({
+            sessionId: "s1",
+            transport: { close: closeFn1 },
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
+        await store.addSession({
+            sessionId: "s2",
+            transport: { close: closeFn2 },
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
 
         await store.closeSession({ sessionId: "s1", reason: "server_stop" });
         await store.closeSession({ sessionId: "s2", reason: "idle_timeout" });
@@ -107,9 +157,24 @@ describe("SessionStore metrics", () => {
     });
 
     it("tracks separate reasons independently", async () => {
-        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
-        await store.addSession({ sessionId: "s2", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
-        await store.addSession({ sessionId: "s3", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({
+            sessionId: "s1",
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
+        await store.addSession({
+            sessionId: "s2",
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
+        await store.addSession({
+            sessionId: "s3",
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
 
         await store.closeSession({ sessionId: "s1", reason: "transport_closed" });
         await store.closeSession({ sessionId: "s2", reason: "transport_closed" });

--- a/tests/unit/sessionStore.test.ts
+++ b/tests/unit/sessionStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SessionStore, type CloseableTransport } from "../../src/common/sessionStore.js";
 import type { LoggerBase } from "../../src/common/logging/index.js";
+import type { Session } from "../../src/common/session.js";
 import { MockMetrics } from "./mocks/metrics.js";
 
 function createMockTransport(): CloseableTransport {
@@ -14,6 +15,10 @@ function createMockLogger(): LoggerBase {
         warning: vi.fn(),
         error: vi.fn(),
     } as unknown as LoggerBase;
+}
+
+function createMockSession(): Session {
+    return { logger: createMockLogger() } as unknown as Session;
 }
 
 describe("SessionStore metrics", () => {
@@ -32,22 +37,22 @@ describe("SessionStore metrics", () => {
     });
 
     it("increments sessionCreated when a session is added", async () => {
-        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger() });
+        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
 
         const { values } = await metrics.get("sessionCreated").get();
         expect(values[0]?.value).toBe(1);
     });
 
     it("increments sessionCreated for each new session", async () => {
-        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger() });
-        await store.addSession({ sessionId: "s2", transport: createMockTransport(), logger: createMockLogger() });
+        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({ sessionId: "s2", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
 
         const { values } = await metrics.get("sessionCreated").get();
         expect(values[0]?.value).toBe(2);
     });
 
     it("increments sessionClosed with reason when a session is closed", async () => {
-        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger() });
+        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
         await store.closeSession({ sessionId: "s1", reason: "transport_closed" });
 
         const { values } = await metrics.get("sessionClosed").get();
@@ -56,8 +61,8 @@ describe("SessionStore metrics", () => {
     });
 
     it("records reason 'server_stop' when closeAllSessions is called", async () => {
-        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger() });
-        await store.addSession({ sessionId: "s2", transport: createMockTransport(), logger: createMockLogger() });
+        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({ sessionId: "s2", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
         await store.closeAllSessions();
 
         const { values } = await metrics.get("sessionClosed").get();
@@ -68,7 +73,7 @@ describe("SessionStore metrics", () => {
     it("records reason 'idle_timeout' when session times out", async () => {
         vi.useFakeTimers();
         try {
-            await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger() });
+            await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
 
             await vi.advanceTimersByTimeAsync(60_001);
 
@@ -82,7 +87,7 @@ describe("SessionStore metrics", () => {
 
     it("does not call transport.close() when reason is transport_closed", async () => {
         const closeFn = vi.fn().mockResolvedValue(undefined);
-        await store.addSession({ sessionId: "s1", transport: { close: closeFn }, logger: createMockLogger() });
+        await store.addSession({ sessionId: "s1", transport: { close: closeFn }, logger: createMockLogger(), session: createMockSession() });
         await store.closeSession({ sessionId: "s1", reason: "transport_closed" });
 
         expect(closeFn).not.toHaveBeenCalled();
@@ -91,8 +96,8 @@ describe("SessionStore metrics", () => {
     it("calls transport.close() for server-initiated close reasons", async () => {
         const closeFn1 = vi.fn().mockResolvedValue(undefined);
         const closeFn2 = vi.fn().mockResolvedValue(undefined);
-        await store.addSession({ sessionId: "s1", transport: { close: closeFn1 }, logger: createMockLogger() });
-        await store.addSession({ sessionId: "s2", transport: { close: closeFn2 }, logger: createMockLogger() });
+        await store.addSession({ sessionId: "s1", transport: { close: closeFn1 }, logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({ sessionId: "s2", transport: { close: closeFn2 }, logger: createMockLogger(), session: createMockSession() });
 
         await store.closeSession({ sessionId: "s1", reason: "server_stop" });
         await store.closeSession({ sessionId: "s2", reason: "idle_timeout" });
@@ -102,9 +107,9 @@ describe("SessionStore metrics", () => {
     });
 
     it("tracks separate reasons independently", async () => {
-        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger() });
-        await store.addSession({ sessionId: "s2", transport: createMockTransport(), logger: createMockLogger() });
-        await store.addSession({ sessionId: "s3", transport: createMockTransport(), logger: createMockLogger() });
+        await store.addSession({ sessionId: "s1", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({ sessionId: "s2", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
+        await store.addSession({ sessionId: "s3", transport: createMockTransport(), logger: createMockLogger(), session: createMockSession() });
 
         await store.closeSession({ sessionId: "s1", reason: "transport_closed" });
         await store.closeSession({ sessionId: "s2", reason: "transport_closed" });

--- a/tests/unit/transports/mcpHttpServer.test.ts
+++ b/tests/unit/transports/mcpHttpServer.test.ts
@@ -3,7 +3,7 @@ import { MCPHttpServer } from "../../../src/transports/mcpHttpServer.js";
 import { defaultTestConfig, InMemoryLogger } from "../../integration/helpers.js";
 import { MockMetrics } from "../mocks/metrics.js";
 import { Keychain } from "../../../src/common/keychain.js";
-import type { ISessionStore } from "../../../src/common/sessionStore.js";
+import { SessionRejectedError, type ISessionStore } from "../../../src/common/sessionStore.js";
 import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { Server } from "../../../src/server.js";
 
@@ -130,6 +130,49 @@ describe("MCPHttpServer x-request-id logging", () => {
         expect(addSession).toHaveBeenCalledTimes(1);
         const call = addSession.mock.calls[0]?.[0] as { headers?: Record<string, unknown> };
         expect(call.headers).toEqual(expect.objectContaining({ "x-request-id": "req-add-session" }));
+    });
+
+    it("passes the server session to sessionStore.addSession", async () => {
+        const addSession = vi.fn().mockResolvedValue(undefined);
+        const sessionStore: ISessionStore<StreamableHTTPServerTransport> = {
+            ...makeSessionStore(() => Promise.resolve(null)),
+            addSession,
+        };
+        const fakeServer = makeFakeServer();
+        await startServer(sessionStore, () => Promise.resolve(fakeServer));
+
+        await post("/mcp", INIT_BODY, {});
+
+        expect(addSession).toHaveBeenCalledTimes(1);
+        const call = addSession.mock.calls[0]?.[0] as { session?: unknown };
+        expect(call.session).toBe(fakeServer.session);
+    });
+
+    it("responds as session-not-found when sessionStore.getSession throws SessionRejectedError", async () => {
+        await startServer(makeSessionStore(() => Promise.reject(new SessionRejectedError("identity mismatch"))));
+
+        const rejectedRes = await post("/mcp", NON_INIT_BODY, { "mcp-session-id": "sess-rejected" });
+        const rejectedBody = (await rejectedRes.json()) as unknown;
+
+        await server.stop();
+        await startServer(makeSessionStore(() => Promise.resolve(null)));
+
+        const notFoundRes = await post("/mcp", NON_INIT_BODY, { "mcp-session-id": "sess-missing" });
+        const notFoundBody = (await notFoundRes.json()) as unknown;
+
+        // The rejected response must be indistinguishable from session-not-found
+        // so that callers can't probe whether a session id is valid.
+        expect(rejectedRes.status).toBe(notFoundRes.status);
+        expect(rejectedBody).toEqual(notFoundBody);
+    });
+
+    it("logs the SessionRejectedError reason server-side", async () => {
+        await startServer(makeSessionStore(() => Promise.reject(new SessionRejectedError("identity mismatch"))));
+
+        await post("/mcp", NON_INIT_BODY, { "mcp-session-id": "sess-rejected" });
+
+        const log = logger.messages.find((m) => m.level === "error" && m.payload.message.includes("identity mismatch"));
+        expect(log).toBeDefined();
     });
 
     it("includes x-request-id in error log when handler throws", async () => {


### PR DESCRIPTION
## Proposed changes

This is required for consumers who need to access session-level fields (such as connection manager) on adding. Additionally, pass headers to getSession so that consumers are able to validate user identity before session is returned to the client.