### PR TITLE
fix: validate streams resourceName/peeringId to block path traversal STREAMS-2485

### DIFF
--- a/src/tools/atlas/streams/discover.ts
+++ b/src/tools/atlas/streams/discover.ts
@@ -214,8 +214,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
         workspaceName: StreamsArgs.workspaceName()
             .optional()
             .describe("Workspace name. Required for all actions except 'list-workspaces' and 'get-networking'."),
-        resourceName: z
-            .string()
+        resourceName: StreamsArgs.resourceName()
             .optional()
             .describe(
                 "Connection or processor name. Required for 'inspect-connection', 'inspect-processor', and 'diagnose-processor'."

--- a/src/tools/atlas/streams/manage.ts
+++ b/src/tools/atlas/streams/manage.ts
@@ -58,8 +58,7 @@ export class StreamsManageTool extends StreamsToolBase {
                 "'reject-peering' — reject a VPC peering request (requires peeringId). " +
                 "For peering actions, workspaceName can be any workspace in the project (peering is project-level)."
         ),
-        resourceName: z
-            .string()
+        resourceName: StreamsArgs.resourceName()
             .optional()
             .describe("Processor or connection name. Required for processor and connection actions."),
 
@@ -124,8 +123,7 @@ export class StreamsManageTool extends StreamsToolBase {
         ),
 
         // peering options
-        peeringId: z
-            .string()
+        peeringId: StreamsArgs.peeringId()
             .optional()
             .describe("VPC peering connection ID. Required for 'accept-peering' and 'reject-peering'."),
         requesterAccountId: z

--- a/src/tools/atlas/streams/streamsArgs.ts
+++ b/src/tools/atlas/streams/streamsArgs.ts
@@ -166,4 +166,21 @@ export const StreamsArgs = {
             .min(1, "Connection name is required")
             .max(64, "Connection name must be 64 characters or less")
             .regex(ALLOWED_STREAMS_NAME_REGEX, ALLOWED_STREAMS_NAME_ERROR),
+
+    // Used where resourceName refers to a processor, connection, PrivateLink connection ID, or peering ID
+    // depending on the calling tool's action/resource — all of these are path-safe alphanumeric identifiers,
+    // and must be constrained here since the value is substituted directly into Atlas Admin API URL paths.
+    resourceName: (): z.ZodString =>
+        z
+            .string()
+            .min(1, "Resource name is required")
+            .max(64, "Resource name must be 64 characters or less")
+            .regex(ALLOWED_STREAMS_NAME_REGEX, ALLOWED_STREAMS_NAME_ERROR),
+
+    peeringId: (): z.ZodString =>
+        z
+            .string()
+            .min(1, "Peering ID is required")
+            .max(64, "Peering ID must be 64 characters or less")
+            .regex(ALLOWED_STREAMS_NAME_REGEX, ALLOWED_STREAMS_NAME_ERROR),
 };

--- a/src/tools/atlas/streams/streamsArgs.ts
+++ b/src/tools/atlas/streams/streamsArgs.ts
@@ -167,9 +167,6 @@ export const StreamsArgs = {
             .max(64, "Connection name must be 64 characters or less")
             .regex(ALLOWED_STREAMS_NAME_REGEX, ALLOWED_STREAMS_NAME_ERROR),
 
-    // Used where resourceName refers to a processor, connection, PrivateLink connection ID, or peering ID
-    // depending on the calling tool's action/resource — all of these are path-safe alphanumeric identifiers,
-    // and must be constrained here since the value is substituted directly into Atlas Admin API URL paths.
     resourceName: (): z.ZodString =>
         z
             .string()

--- a/src/tools/atlas/streams/teardown.ts
+++ b/src/tools/atlas/streams/teardown.ts
@@ -49,7 +49,7 @@ export class StreamsTeardownTool extends StreamsToolBase {
         workspaceName: StreamsArgs.workspaceName()
             .optional()
             .describe("Workspace name. Required for workspace, connection, and processor deletion."),
-        resourceName: z.string().optional().describe("Name or ID of the specific resource to delete."),
+        resourceName: StreamsArgs.resourceName().optional().describe("Name or ID of the specific resource to delete."),
     };
 
     public override outputSchema = TeardownOutputSchema.shape;

--- a/tests/unit/tools/atlas/streams/streamsArgs.test.ts
+++ b/tests/unit/tools/atlas/streams/streamsArgs.test.ts
@@ -64,6 +64,47 @@ describe("StreamsArgs", () => {
             expect(schema.safeParse("c".repeat(65)).success).toBe(false);
         });
     });
+
+    describe("resourceName", () => {
+        const schema = StreamsArgs.resourceName();
+
+        it("should accept valid names", () => {
+            expect(schema.safeParse("my-processor").success).toBe(true);
+            expect(schema.safeParse("507f1f77bcf86cd799439011").success).toBe(true);
+        });
+
+        it("should reject empty string", () => {
+            expect(schema.safeParse("").success).toBe(false);
+        });
+
+        it("should reject path traversal payloads", () => {
+            expect(schema.safeParse("../../../clusters/Prod").success).toBe(false);
+            expect(schema.safeParse("..").success).toBe(false);
+        });
+
+        it("should reject values containing path or query separators", () => {
+            expect(schema.safeParse("foo/bar").success).toBe(false);
+            expect(schema.safeParse("foo?bar").success).toBe(false);
+            expect(schema.safeParse("foo:stop").success).toBe(false);
+        });
+    });
+
+    describe("peeringId", () => {
+        const schema = StreamsArgs.peeringId();
+
+        it("should accept valid ids", () => {
+            expect(schema.safeParse("507f1f77bcf86cd799439011").success).toBe(true);
+        });
+
+        it("should reject empty string", () => {
+            expect(schema.safeParse("").success).toBe(false);
+        });
+
+        it("should reject path traversal payloads", () => {
+            expect(schema.safeParse("../../../groups/123").success).toBe(false);
+            expect(schema.safeParse("foo/bar").success).toBe(false);
+        });
+    });
 });
 
 describe("ConnectionConfig", () => {


### PR DESCRIPTION
STREAMS-2485

## Summary

The Atlas Streams manage, teardown, and discover tools accepted resource identifiers (resourceName and peeringId) as free form strings. Those values are placed directly into Atlas Admin API URL paths, so a crafted name containing path separators or dot segments could point a credentialed request at an unintended Atlas endpoint. This change validates those identifiers at the tool boundary so only well formed names are accepted.

## What changed

Resource identifiers in atlas-streams-manage, atlas-streams-teardown, and atlas-streams-discover now go through the existing streams name allowlist (letters, numbers, hyphen, and underscore, up to 64 characters). Anything containing slashes, dot segments, query characters, or other unexpected input is rejected with a clear validation error before any API call is made. Legitimate identifiers such as processor names, connection names, and VPC peering IDs continue to work unchanged.

## Security finding this addresses

This resolves the path traversal and authorization concern raised by the Aegis finding. Specifically:

* The unvalidated resourceName and peeringId inputs flagged in manage, teardown, and discover are now constrained by the allowlist, so a caller can no longer shape a resource name to escape the streams path.
* An audit of the wider Atlas tool surface confirmed no other Atlas API path parameter is fed by an unvalidated string. Every other path value already flows through a validated helper.

One correction worth noting for the finding record. The report assumed the HTTP client substitutes raw path values without encoding. In practice the client library in use (openapi-fetch 0.17.0) percent encodes path parameters by default, so the traversal payload described in the report resolves to an encoded segment rather than a redirected request. The verification is below. Input validation is still the right fix and is what this PR delivers, but the exploit as written was not reachable through the real client.

Verified with the installed library:

```
input:  ../../../clusters/Prod?foo
output: /api/atlas/v2/groups/g1/streams/t1/processor/..%2F..%2F..%2Fclusters%2FProd%3Ffoo
```

## Scope note

The confirmation gate behavior mentioned in the finding (a client without elicitation support bypassing confirmation) is a cross cutting change that affects all confirmation required tools, not just streams. It is handled separately so it can be reviewed and released on its own.

## Testing

Added unit coverage for accepted and rejected identifier inputs. Existing streams tool tests pass.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)