### PR TITLE
feat: implement redaction of sensitive information in config resource output - MCP-589

### DIFF
--- a/src/common/keychain.ts
+++ b/src/common/keychain.ts
@@ -1,3 +1,4 @@
+import { redact } from "mongodb-redact";
 import type { Secret } from "mongodb-redact";
 export type { Secret } from "mongodb-redact";
 
@@ -37,4 +38,22 @@ export class Keychain {
 
 export function registerGlobalSecretToRedact(value: Secret["value"], kind: Secret["kind"]): void {
     Keychain.root.register(value, kind);
+}
+
+/**
+ * Recursively redacts registered secrets from every string value of a value, leaving the structure
+ * intact. Redaction is applied per-value (not on serialized JSON) so it can never corrupt the
+ * resulting JSON, regardless of what the redactor substitutes.
+ */
+export function redactValues(value: unknown, secrets: Secret[]): unknown {
+    if (typeof value === "string") {
+        return redact(value, secrets);
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => redactValues(item, secrets));
+    }
+    if (value && typeof value === "object") {
+        return Object.fromEntries(Object.entries(value).map(([key, val]) => [key, redactValues(val, secrets)]));
+    }
+    return value;
 }

--- a/src/resources/common/config.ts
+++ b/src/resources/common/config.ts
@@ -3,8 +3,7 @@ import type { UserConfig } from "../../common/config/userConfig.js";
 import type { Telemetry } from "../../telemetry/telemetry.js";
 import type { Session } from "../../lib.js";
 import { generateConnectionInfoFromCliArgs } from "@mongosh/arg-parser";
-import { redact } from "mongodb-redact";
-import { Keychain } from "../../common/keychain.js";
+import { Keychain, redactValues } from "../../common/keychain.js";
 
 /**
  * Removes secret material from the driver options before exposing them via the config resource.
@@ -63,8 +62,8 @@ export class ConfigResource extends ReactiveResource<UserConfig, readonly []> {
         };
 
         // Backstop: redact any remaining registered secrets (keychain) before egress, matching
-        // the redaction applied on every logging path. Prefer session secrets, fall back to root.
+        // the redaction applied on every logging path. Redact per-value so JSON stays valid.
         const secrets = [...this.session.keychain.allSecrets, ...Keychain.root.allSecrets];
-        return redact(JSON.stringify(result), secrets);
+        return JSON.stringify(redactValues(result, secrets));
     }
 }

--- a/src/resources/common/config.ts
+++ b/src/resources/common/config.ts
@@ -3,6 +3,22 @@ import type { UserConfig } from "../../common/config/userConfig.js";
 import type { Telemetry } from "../../telemetry/telemetry.js";
 import type { Session } from "../../lib.js";
 import { generateConnectionInfoFromCliArgs } from "@mongosh/arg-parser";
+import { redact } from "mongodb-redact";
+import { Keychain } from "../../common/keychain.js";
+
+/**
+ * Removes secret material from the driver options before exposing them via the config resource.
+ * The mongosh arg-mapper places KMS credentials under `autoEncryption.kmsProviders` (e.g. the AWS
+ * access key / secret / session token), so the whole `autoEncryption` block is replaced with a
+ * non-sensitive summary rather than emitted verbatim.
+ */
+function redactDriverOptions(driverOptions: Record<string, unknown>): Record<string, unknown> {
+    const { autoEncryption, ...rest } = driverOptions;
+    if (autoEncryption === undefined) {
+        return rest;
+    }
+    return { ...rest, autoEncryption: "set; client-side field level encryption is configured" };
+}
 
 export class ConfigResource extends ReactiveResource<UserConfig, readonly []> {
     constructor(session: Session, config: UserConfig, telemetry: Telemetry) {
@@ -39,13 +55,16 @@ export class ConfigResource extends ReactiveResource<UserConfig, readonly []> {
             connectionString: connectionInfo.connectionString
                 ? "set; access to MongoDB tools are currently available to use"
                 : "not set; before using any MongoDB tool, you need to configure a connection string, alternatively you can setup MongoDB Atlas access, more info at 'https://github.com/mongodb-js/mongodb-mcp-server'.",
-            connectOptions: connectionInfo.driverOptions,
+            connectOptions: redactDriverOptions(connectionInfo.driverOptions),
             atlas:
                 this.current.apiClientId && this.current.apiClientSecret
                     ? "set; MongoDB Atlas tools are currently available to use"
                     : "not set; MongoDB Atlas tools are currently unavailable, to have access to MongoDB Atlas tools like creating clusters or connecting to clusters make sure to setup credentials, more info at 'https://github.com/mongodb-js/mongodb-mcp-server'.",
         };
 
-        return JSON.stringify(result);
+        // Backstop: redact any remaining registered secrets (keychain) before egress, matching
+        // the redaction applied on every logging path. Prefer session secrets, fall back to root.
+        const secrets = [...this.session.keychain.allSecrets, ...Keychain.root.allSecrets];
+        return redact(JSON.stringify(result), secrets);
     }
 }

--- a/src/resources/common/config.ts
+++ b/src/resources/common/config.ts
@@ -7,9 +7,8 @@ import { Keychain, redactValues } from "../../common/keychain.js";
 
 /**
  * Removes secret material from the driver options before exposing them via the config resource.
- * The mongosh arg-mapper places KMS credentials under `autoEncryption.kmsProviders` (e.g. the AWS
- * access key / secret / session token), so the whole `autoEncryption` block is replaced with a
- * non-sensitive summary rather than emitted verbatim.
+ * The `autoEncryption` block can carry a variety of sensitive values, so the whole block is
+ * replaced with a non-sensitive summary rather than emitted verbatim.
  */
 function redactDriverOptions(driverOptions: Record<string, unknown>): Record<string, unknown> {
     const { autoEncryption, ...rest } = driverOptions;

--- a/tests/unit/common/keychain.test.ts
+++ b/tests/unit/common/keychain.test.ts
@@ -1,4 +1,5 @@
-import { Keychain, registerGlobalSecretToRedact } from "../../../src/common/keychain.js";
+import { Keychain, redactValues, registerGlobalSecretToRedact } from "../../../src/common/keychain.js";
+import type { Secret } from "../../../src/common/keychain.js";
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
 
 describe("Keychain", () => {
@@ -32,5 +33,56 @@ describe("Keychain", () => {
             registerGlobalSecretToRedact("123456", "password");
             expect(keychain.allSecrets).toEqual([{ value: "123456", kind: "password" }]);
         });
+    });
+});
+
+describe("redactValues", () => {
+    const secrets: Secret[] = [{ value: "s3cr3t-value", kind: "password" }];
+
+    it("redacts a registered secret in a top-level string", () => {
+        expect(redactValues("token is s3cr3t-value here", secrets)).not.toContain("s3cr3t-value");
+    });
+
+    it("redacts secrets in nested object string values while preserving structure", () => {
+        const input = {
+            a: "s3cr3t-value",
+            nested: { b: "prefix s3cr3t-value suffix", c: 42 },
+        };
+        const result = redactValues(input, secrets) as typeof input;
+
+        expect(result.a).not.toContain("s3cr3t-value");
+        expect(result.nested.b).not.toContain("s3cr3t-value");
+        expect(result.nested.c).toBe(42);
+        expect(Object.keys(result)).toEqual(["a", "nested"]);
+        expect(Object.keys(result.nested)).toEqual(["b", "c"]);
+    });
+
+    it("redacts secrets inside arrays", () => {
+        const result = redactValues(["s3cr3t-value", "clean", { x: "s3cr3t-value" }], secrets) as [
+            string,
+            string,
+            { x: string },
+        ];
+
+        expect(result[0]).not.toContain("s3cr3t-value");
+        expect(result[1]).toBe("clean");
+        expect(result[2].x).not.toContain("s3cr3t-value");
+    });
+
+    it("leaves non-string primitives untouched", () => {
+        expect(redactValues(42, secrets)).toBe(42);
+        expect(redactValues(true, secrets)).toBe(true);
+        expect(redactValues(null, secrets)).toBe(null);
+        expect(redactValues(undefined, secrets)).toBe(undefined);
+    });
+
+    it("produces output that remains valid JSON", () => {
+        const input = { connectionString: "mongodb://user:s3cr3t-value@localhost:27017" };
+        const output = JSON.stringify(redactValues(input, secrets));
+
+        expect(() => {
+            JSON.parse(output);
+        }).not.toThrow();
+        expect(output).not.toContain("s3cr3t-value");
     });
 });

--- a/tests/unit/resources/common/config.test.ts
+++ b/tests/unit/resources/common/config.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { ConfigResource } from "../../../../src/resources/common/config.js";
+import { Session } from "../../../../src/common/session.js";
+import { CompositeLogger } from "../../../../src/common/logging/index.js";
+import { MCPConnectionManager } from "../../../../src/common/connectionManager.js";
+import { ExportsManager } from "../../../../src/common/exportsManager.js";
+import { DeviceId } from "../../../../src/helpers/deviceId.js";
+import { Keychain } from "../../../../src/common/keychain.js";
+import { defaultTestConfig } from "../../../integration/helpers.js";
+import { connectionErrorHandler } from "../../../../src/common/connectionErrorHandler.js";
+import { defaultCreateApiClient, Telemetry } from "../../../../src/lib.js";
+import type { UserConfig } from "../../../../src/common/config/userConfig.js";
+
+describe("config resource", () => {
+    const logger = new CompositeLogger();
+    const deviceId = DeviceId.create(logger);
+
+    function createResource(config: UserConfig): ConfigResource {
+        const connectionManager = new MCPConnectionManager(config, logger, deviceId);
+        const keychain = new Keychain();
+        const session = vi.mocked(
+            new Session({
+                userConfig: config,
+                logger,
+                exportsManager: ExportsManager.init(config, logger),
+                connectionManager,
+                keychain,
+                connectionErrorHandler,
+                apiClient: defaultCreateApiClient(
+                    {
+                        baseUrl: config.apiBaseUrl,
+                        credentials: {
+                            clientId: config.apiClientId,
+                            clientSecret: config.apiClientSecret,
+                        },
+                    },
+                    logger
+                ),
+            })
+        );
+        const telemetry = Telemetry.create({
+            logger,
+            deviceId,
+            apiClient: session.apiClient,
+            keychain: session.keychain,
+            enabled: false,
+        });
+        return new ConfigResource(session, config, telemetry);
+    }
+
+    it("should not leak AWS KMS credentials in connectOptions", () => {
+        const config = {
+            ...defaultTestConfig,
+            connectionString: "mongodb://localhost:27017",
+            awsAccessKeyId: "AKIAIOSFODNN7EXAMPLE",
+            awsSecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            awsSessionToken: "FwoGZXIvYXdzEXAMPLESESSIONTOKEN",
+        } as unknown as UserConfig;
+
+        const output = createResource(config).toOutput();
+
+        expect(output).not.toContain("AKIAIOSFODNN7EXAMPLE");
+        expect(output).not.toContain("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+        expect(output).not.toContain("FwoGZXIvYXdzEXAMPLESESSIONTOKEN");
+        expect(output).not.toContain("kmsProviders");
+    });
+
+    it("should summarize autoEncryption instead of emitting it verbatim", () => {
+        const config = {
+            ...defaultTestConfig,
+            connectionString: "mongodb://localhost:27017",
+            awsAccessKeyId: "AKIAIOSFODNN7EXAMPLE",
+            awsSecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        } as unknown as UserConfig;
+
+        const output = createResource(config).toOutput();
+        const parsed = JSON.parse(output) as { connectOptions: { autoEncryption?: unknown } };
+
+        expect(parsed.connectOptions.autoEncryption).toBe("set; client-side field level encryption is configured");
+    });
+
+    it("should redact keychain-registered secrets as a backstop", () => {
+        const config = {
+            ...defaultTestConfig,
+            connectionString: "mongodb://localhost:27017",
+        } as unknown as UserConfig;
+
+        const resource = createResource(config);
+        // Register a secret that would otherwise appear in the output (logPath).
+        resource["session"].keychain.register(config.logPath, "url");
+
+        const output = resource.toOutput();
+        expect(output).not.toContain(config.logPath);
+    });
+});


### PR DESCRIPTION
## Proposed changes

Applying redaction for connectOptions and redacting any secret still present in the output

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
