### PR TITLE
feat: allow consumers to disable automatic IP access list creation CLOUDP-422265

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -179,6 +179,8 @@ export class ApiClient {
     // (undocumented)
     stopStreamProcessor(options: FetchOptions<operations["stopGroupStreamProcessor"]>, context?: ApiClientRequestContext): Promise<void>;
     // (undocumented)
+    get supportsCurrentIpLookup(): boolean;
+    // (undocumented)
     tenantUpgrade(options: FetchOptions<operations["tenantGroupFlexClusterUpgrade"]>, context?: ApiClientRequestContext): Promise<components["schemas"]["FlexClusterDescription20241113"]>;
     // (undocumented)
     updateCluster(options: FetchOptions<operations["updateGroupCluster"]>, context?: ApiClientRequestContext): Promise<components["schemas"]["ClusterDescription20240805"]>;
@@ -207,6 +209,7 @@ export interface ApiClientOptions {
     credentials?: Credentials;
     // (undocumented)
     requestContext?: RequestContext;
+    supportsCurrentIpLookup?: boolean;
     // (undocumented)
     userAgent?: string;
 }

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -333,13 +333,7 @@ export class CountTool extends MongoDBToolBase {
 // @public (undocumented)
 export class CreateAccessListTool extends AtlasToolBase {
     // (undocumented)
-    argsShape: {
-        projectId: z.ZodString;
-        ipAddresses: z.ZodOptional<z.ZodArray<z.ZodString>>;
-        cidrBlocks: z.ZodOptional<z.ZodArray<z.ZodString>>;
-        currentIpAddress: z.ZodDefault<z.ZodBoolean>;
-        comment: z.ZodOptional<z.ZodDefault<z.ZodString>>;
-    };
+    get argsShape(): typeof CreateAccessListArgs;
     // (undocumented)
     description: string;
     // (undocumented)

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -167,6 +167,8 @@ export class ApiClient {
     // (undocumented)
     stopStreamProcessor(options: FetchOptions<operations["stopGroupStreamProcessor"]>, context?: ApiClientRequestContext): Promise<void>;
     // (undocumented)
+    get supportsCurrentIpLookup(): boolean;
+    // (undocumented)
     tenantUpgrade(options: FetchOptions<operations["tenantGroupFlexClusterUpgrade"]>, context?: ApiClientRequestContext): Promise<components["schemas"]["FlexClusterDescription20241113"]>;
     // (undocumented)
     updateCluster(options: FetchOptions<operations["updateGroupCluster"]>, context?: ApiClientRequestContext): Promise<components["schemas"]["ClusterDescription20240805"]>;
@@ -195,6 +197,7 @@ export interface ApiClientOptions {
     credentials?: Credentials;
     // (undocumented)
     requestContext?: RequestContext;
+    supportsCurrentIpLookup?: boolean;
     // (undocumented)
     userAgent?: string;
 }

--- a/src/common/atlas/accessListUtils.ts
+++ b/src/common/atlas/accessListUtils.ts
@@ -16,10 +16,19 @@ export const ACCESS_LIST_ADDED_NOTE =
  * Note appended to tool results when automatic IP access list setup was skipped
  * because the deployment cannot determine the caller's public IP address.
  */
-export const ACCESS_LIST_NOT_MODIFIED_NOTE =
+export const ACCESS_LIST_SKIPPED_NOTE =
     "No IP access list changes were made because this server cannot determine your public IP address. " +
     "To connect from your own machine, add its public IP address to the project's IP access list — " +
     "for example with the atlas-create-access-list tool or through the Atlas UI.";
+
+/**
+ * Note appended to tool results when the attempt to add the current public IP
+ * to the project's IP access list failed (IP lookup or entry creation error).
+ */
+export const ACCESS_LIST_FAILED_NOTE =
+    "No IP access list changes were made because the attempt to add your current IP address " +
+    "to the project's IP access list did not succeed. To connect from your own machine, " +
+    "retry with the atlas-create-access-list tool or add your IP through the Atlas UI.";
 
 /**
  * Maps an {@link EnsureCurrentIpResult} to the note a tool should append to its
@@ -33,8 +42,9 @@ export function getAccessListNote(result: EnsureCurrentIpResult): string | undef
         case "already-present":
             return undefined;
         case "skipped":
+            return ACCESS_LIST_SKIPPED_NOTE;
         case "failed":
-            return ACCESS_LIST_NOT_MODIFIED_NOTE;
+            return ACCESS_LIST_FAILED_NOTE;
     }
 }
 

--- a/src/common/atlas/accessListUtils.ts
+++ b/src/common/atlas/accessListUtils.ts
@@ -5,6 +5,39 @@ import { ApiClientError } from "./apiClientError.js";
 
 export const DEFAULT_ACCESS_LIST_COMMENT = "Added by MongoDB MCP Server to enable tool access";
 
+/**
+ * Note appended to tool results when the current public IP was added to the
+ * project's IP access list as part of the tool's execution.
+ */
+export const ACCESS_LIST_ADDED_NOTE =
+    "Note: Your current IP address has been added to the Atlas project's IP access list to enable secure connection.";
+
+/**
+ * Note appended to tool results when automatic IP access list setup was skipped
+ * because the deployment cannot determine the caller's public IP address.
+ */
+export const ACCESS_LIST_NOT_MODIFIED_NOTE =
+    "No IP access list changes were made because this server cannot determine your public IP address. " +
+    "To connect from your own machine, add its public IP address to the project's IP access list — " +
+    "for example with the atlas-create-access-list tool or through the Atlas UI.";
+
+/**
+ * Maps an {@link EnsureCurrentIpResult} to the note a tool should append to its
+ * result, or `undefined` when there is nothing worth reporting (the current IP
+ * can already connect).
+ */
+export function getAccessListNote(result: EnsureCurrentIpResult): string | undefined {
+    switch (result) {
+        case "added":
+            return ACCESS_LIST_ADDED_NOTE;
+        case "already-present":
+            return undefined;
+        case "skipped":
+        case "failed":
+            return ACCESS_LIST_NOT_MODIFIED_NOTE;
+    }
+}
+
 export async function makeCurrentIpAccessListEntry(
     apiClient: ApiClient,
     projectId: string,
@@ -19,19 +52,40 @@ export async function makeCurrentIpAccessListEntry(
 }
 
 /**
+ * Outcome of {@link ensureCurrentIpInAccessList}:
+ * - `added` - a new access list entry was created for the current IP
+ * - `already-present` - the current IP was already in the access list
+ * - `skipped` - the deployment does not support current IP detection
+ * - `failed` - the IP could not be determined or the entry could not be created
+ */
+export type EnsureCurrentIpResult = "added" | "already-present" | "skipped" | "failed";
+
+/**
  * Ensures the current public IP is in the access list for the given Atlas project.
- * If the IP is already present, this is a no-op.
+ * If the IP is already present, this is a no-op. Never throws - failures are
+ * reported through the returned {@link EnsureCurrentIpResult}.
  * @param apiClient The Atlas API client instance
  * @param projectId The Atlas project ID
- * @returns Promise<boolean> - true if a new IP access list entry was created, false if it already existed
  */
 export async function ensureCurrentIpInAccessList(
     apiClient: ApiClient,
     projectId: string,
     context?: ApiClientRequestContext
-): Promise<boolean> {
-    const entry = await makeCurrentIpAccessListEntry(apiClient, projectId, DEFAULT_ACCESS_LIST_COMMENT);
+): Promise<EnsureCurrentIpResult> {
+    if (!apiClient.supportsCurrentIpLookup) {
+        apiClient.logger.debug({
+            id: LogId.atlasIpAccessListAddFailure,
+            context: "accessListUtils",
+            message: `Skipping IP access list setup for project ${projectId}: this deployment does not support current IP detection.`,
+            attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
+        });
+
+        return "skipped";
+    }
+
+    let entry: { groupId: string; ipAddress: string; comment: string } | undefined;
     try {
+        entry = await makeCurrentIpAccessListEntry(apiClient, projectId, DEFAULT_ACCESS_LIST_COMMENT);
         await apiClient.createAccessListEntry(
             {
                 params: { path: { groupId: projectId } },
@@ -45,9 +99,9 @@ export async function ensureCurrentIpInAccessList(
             message: `IP access list created: ${JSON.stringify(entry)}`,
             attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
         });
-        return true;
+        return "added";
     } catch (err) {
-        if (err instanceof ApiClientError && err.response?.status === 409) {
+        if (entry && err instanceof ApiClientError && err.response?.status === 409) {
             // 409 Conflict: entry already exists, log info
             apiClient.logger.debug({
                 id: LogId.atlasIpAccessListAdded,
@@ -55,8 +109,10 @@ export async function ensureCurrentIpInAccessList(
                 message: `IP address ${entry.ipAddress} is already present in the access list for project ${projectId}.`,
                 attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
             });
-            return false;
+
+            return "already-present";
         }
+
         apiClient.logger.warning({
             id: LogId.atlasIpAccessListAddFailure,
             context: "accessListUtils",
@@ -64,5 +120,6 @@ export async function ensureCurrentIpInAccessList(
             attributes: { ...requestIdAttr(context?.requestInfo?.headers) },
         });
     }
-    return false;
+
+    return "failed";
 }

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -28,6 +28,15 @@ export interface ApiClientOptions {
     userAgent?: string;
     credentials?: Credentials;
     requestContext?: RequestContext;
+    /**
+     * Whether this deployment can determine the caller's public IP address via the
+     * `api/private/ipinfo` endpoint. Embedders whose network position makes the
+     * lookup unavailable or meaningless (e.g. the Atlas-hosted MCP server, where the
+     * "current IP" would be the server pod's egress IP rather than the end user's
+     * machine) should set this to `false` so tools skip automatic IP access list
+     * setup and direct users to provide IP addresses explicitly.
+     */
+    supportsCurrentIpLookup?: boolean;
 }
 
 export type RequestContext = {
@@ -64,6 +73,7 @@ export class ApiClient {
     private readonly options: {
         baseUrl: string;
         userAgent: string;
+        supportsCurrentIpLookup: boolean;
     };
 
     private customFetch: typeof fetch;
@@ -102,6 +112,7 @@ export class ApiClient {
             userAgent:
                 options.userAgent ??
                 `AtlasMCP/${packageInfo.version} (${isNodeRuntime() ? `${process.platform}; ${process.arch}` : "browser"})`,
+            supportsCurrentIpLookup: options.supportsCurrentIpLookup ?? true,
         };
 
         this.authProvider =
@@ -192,9 +203,19 @@ export class ApiClient {
         } as Options;
     }
 
+    public get supportsCurrentIpLookup(): boolean {
+        return this.options.supportsCurrentIpLookup;
+    }
+
     public async getIpInfo(): Promise<{
         currentIpv4Address: string;
     }> {
+        if (!this.supportsCurrentIpLookup) {
+            throw new Error(
+                "This deployment does not support current IP detection. Provide the IP addresses to allow explicitly."
+            );
+        }
+
         const authHeaders = (await this.authProvider?.getAuthHeaders()) ?? {};
 
         const endpoint = "api/private/ipinfo";

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -5,7 +5,7 @@ import { AtlasToolBase } from "../atlasTool.js";
 import { generateSecurePassword } from "../../../helpers/generatePassword.js";
 import { LogId } from "../../../common/logging/index.js";
 import { getConnectionString, inspectCluster } from "../../../common/atlas/cluster.js";
-import { ensureCurrentIpInAccessList } from "../../../common/atlas/accessListUtils.js";
+import { ensureCurrentIpInAccessList, ACCESS_LIST_ADDED_NOTE } from "../../../common/atlas/accessListUtils.js";
 import { runSharedTierAlertsHook } from "../../../common/atlas/sharedTierAlertsHook.js";
 import type { AtlasClusterConnectionInfo } from "../../../common/connectionManager.js";
 import { getDefaultRoleFromConfig } from "../../../common/atlas/roles.js";
@@ -13,9 +13,6 @@ import { AtlasArgs } from "../../args.js";
 import { SHARED_TIER_METRIC_NAMES } from "../../../telemetry/types.js";
 import type { ConnectionMetadata, SharedTierTier, SharedTierMetricName } from "../../../telemetry/types.js";
 import { sleep } from "../../../common/managedTimeout.js";
-
-const addedIpAccessListMessage =
-    "Note: Your current IP address has been added to the Atlas project's IP access list to enable secure connection.";
 
 const createdUserMessage =
     "Note: A temporary user has been created to enable secure connection to the cluster. For more information, see https://dochub.mongodb.org/core/mongodb-mcp-server-tools-considerations\n\nNote to LLM Agent: it is important to include the following link in your response to the user in case they want to get more information about the temporary user created: https://dochub.mongodb.org/core/mongodb-mcp-server-tools-considerations";
@@ -244,7 +241,7 @@ export class ConnectClusterTool extends AtlasToolBase {
         { projectId, clusterName, connectionType }: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
-        const ipAccessListUpdated = await ensureCurrentIpInAccessList(this.apiClient, projectId, context);
+        const ipAccessListUpdated = (await ensureCurrentIpInAccessList(this.apiClient, projectId, context)) === "added";
         let createdUser = false;
 
         const state = this.queryConnection(projectId, clusterName);
@@ -295,7 +292,7 @@ export class ConnectClusterTool extends AtlasToolBase {
                     if (ipAccessListUpdated) {
                         content.push({
                             type: "text" as const,
-                            text: addedIpAccessListMessage,
+                            text: ACCESS_LIST_ADDED_NOTE,
                         });
                     }
 
@@ -346,7 +343,7 @@ export class ConnectClusterTool extends AtlasToolBase {
         if (ipAccessListUpdated) {
             content.push({
                 type: "text" as const,
-                text: addedIpAccessListMessage,
+                text: ACCESS_LIST_ADDED_NOTE,
             });
         }
 

--- a/src/tools/atlas/create/createAccessList.ts
+++ b/src/tools/atlas/create/createAccessList.ts
@@ -23,9 +23,19 @@ export class CreateAccessListTool extends AtlasToolBase {
     static toolName = "atlas-create-access-list";
     public description = "Allow Ip/CIDR ranges to access your MongoDB Atlas clusters.";
     static operationType: OperationType = "create";
-    public argsShape = {
-        ...CreateAccessListArgs,
-    };
+    // The currentIpAddress arg is omitted on deployments that can't determine the
+    // caller's public IP (e.g. the Atlas-hosted MCP server), so models are never
+    // offered an option that cannot work there. Typed as the full shape because
+    // execute() still receives currentIpAddress as optional either way.
+    public get argsShape(): typeof CreateAccessListArgs {
+        if (this.session.apiClient?.supportsCurrentIpLookup === false) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { currentIpAddress, ...rest } = CreateAccessListArgs;
+            return rest as typeof CreateAccessListArgs;
+        }
+
+        return CreateAccessListArgs;
+    }
     public override outputSchema = CreateAccessListOutputSchema;
 
     protected async execute(
@@ -33,7 +43,11 @@ export class CreateAccessListTool extends AtlasToolBase {
         context: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
         if (!ipAddresses?.length && !cidrBlocks?.length && !currentIpAddress) {
-            throw new Error("One of  ipAddresses, cidrBlocks, currentIpAddress must be provided.");
+            if (!this.apiClient.supportsCurrentIpLookup) {
+                throw new Error("Either ipAddresses or cidrBlocks must be provided.");
+            }
+
+            throw new Error("One of ipAddresses, cidrBlocks, currentIpAddress must be provided.");
         }
 
         const ipInputs = (ipAddresses || []).map((ipAddress) => ({

--- a/src/tools/atlas/create/createCluster.ts
+++ b/src/tools/atlas/create/createCluster.ts
@@ -5,6 +5,7 @@ import type { ClusterDescription20240805 } from "../../../common/atlas/openapi.j
 import { AtlasArgs } from "../../args.js";
 import type { CreateClusterMetadata } from "../../../telemetry/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { ensureCurrentIpInAccessList, getAccessListNote } from "../../../common/atlas/accessListUtils.js";
 
 /** @public */
 export const ATLAS_CREATE_CLUSTER_README_DESCRIPTION =
@@ -246,6 +247,8 @@ export class CreateClusterTool extends AtlasToolBase {
             ...versionConfig,
         } as unknown as ClusterDescription20240805;
 
+        const ipAccessListResult = await ensureCurrentIpInAccessList(this.apiClient, projectId, context);
+
         const result = await this.apiClient.createCluster(
             {
                 params: { path: { groupId: projectId } },
@@ -253,6 +256,8 @@ export class CreateClusterTool extends AtlasToolBase {
             },
             context
         );
+
+        const ipAccessListNote = getAccessListNote(ipAccessListResult);
 
         return {
             content: [
@@ -263,6 +268,7 @@ export class CreateClusterTool extends AtlasToolBase {
                         `Use the atlas-inspect-cluster tool with projectId "${projectId}" and clusterName "${clusterName}" to poll for readiness. ` +
                         `The cluster is ready when its state is IDLE, connection strings are unavailable until then.`,
                 },
+                ...(ipAccessListNote ? [{ type: "text" as const, text: ipAccessListNote }] : []),
             ],
             structuredContent: {
                 clusterId: result.id,

--- a/src/tools/atlas/create/createDBUser.ts
+++ b/src/tools/atlas/create/createDBUser.ts
@@ -4,7 +4,7 @@ import { AtlasToolBase } from "../atlasTool.js";
 import type { CloudDatabaseUser, DatabaseUserRole } from "../../../common/atlas/openapi.js";
 import { generateSecurePassword } from "../../../helpers/generatePassword.js";
 import { escapeMarkdown } from "../../../helpers/escapeMarkdown.js";
-import { ensureCurrentIpInAccessList } from "../../../common/atlas/accessListUtils.js";
+import { ensureCurrentIpInAccessList, getAccessListNote } from "../../../common/atlas/accessListUtils.js";
 import { ALPHANUMERIC_DASH_UNDERSCORE_REGEX, AtlasArgs, CommonArgs } from "../../args.js";
 import { BUILT_IN_DB_USER_ROLES } from "../../../common/atlas/roles.js";
 
@@ -62,7 +62,7 @@ export class CreateDBUserTool extends AtlasToolBase {
         { projectId, username, password, roles, clusters }: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
-        await ensureCurrentIpInAccessList(this.apiClient, projectId, context);
+        const ipAccessListResult = await ensureCurrentIpInAccessList(this.apiClient, projectId, context);
         const shouldGeneratePassword = !password;
         if (shouldGeneratePassword) {
             password = await generateSecurePassword();
@@ -103,12 +103,15 @@ export class CreateDBUserTool extends AtlasToolBase {
             this.session.keychain.register(password, "password");
         }
 
+        const ipAccessListNote = getAccessListNote(ipAccessListResult);
+
         return {
             content: [
                 {
                     type: "text",
                     text: `User "${username}" created successfully${shouldGeneratePassword ? ` with password: \`${password}\`` : ""}.`,
                 },
+                ...(ipAccessListNote ? [{ type: "text" as const, text: ipAccessListNote }] : []),
             ],
             structuredContent: {
                 username,

--- a/src/tools/atlas/create/createFreeCluster.ts
+++ b/src/tools/atlas/create/createFreeCluster.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { type ToolArgs, type OperationType, type ToolExecutionContext, type ToolResult } from "../../tool.js";
 import { AtlasToolBase } from "../atlasTool.js";
 import type { ClusterDescription20240805 } from "../../../common/atlas/openapi.js";
-import { ensureCurrentIpInAccessList } from "../../../common/atlas/accessListUtils.js";
+import { ensureCurrentIpInAccessList, getAccessListNote } from "../../../common/atlas/accessListUtils.js";
 import { AtlasArgs } from "../../args.js";
 
 const CreateFreeClusterOutputSchema = {
@@ -46,7 +46,7 @@ export class CreateFreeClusterTool extends AtlasToolBase {
             terminationProtectionEnabled: false,
         } as unknown as ClusterDescription20240805;
 
-        await ensureCurrentIpInAccessList(this.apiClient, projectId, context);
+        const ipAccessListResult = await ensureCurrentIpInAccessList(this.apiClient, projectId, context);
         await this.apiClient.createCluster(
             {
                 params: {
@@ -59,10 +59,12 @@ export class CreateFreeClusterTool extends AtlasToolBase {
             context
         );
 
+        const ipAccessListNote = getAccessListNote(ipAccessListResult);
+
         return {
             content: [
                 { type: "text", text: `Cluster "${name}" has been created in region "${region}".` },
-                { type: "text", text: `Double check your access lists to enable your current IP.` },
+                ...(ipAccessListNote ? [{ type: "text" as const, text: ipAccessListNote }] : []),
             ],
             structuredContent: {
                 created: true,

--- a/tests/integration/tools/atlas/dbUsers.test.ts
+++ b/tests/integration/tools/atlas/dbUsers.test.ts
@@ -81,7 +81,9 @@ describeWithAtlas("db users", (integration) => {
             it("should create a database user with supplied password", async () => {
                 const response = await createUserWithMCP("testpassword");
 
-                const elements = getResponseElements(response);
+                // The tool may append an IP access list note depending on whether the
+                // runner's IP was already present in the project's access list.
+                const elements = getResponseElements(response).filter((e) => !e.text.includes("IP access list"));
                 expect(elements).toHaveLength(1);
                 expect(elements[0]?.text).toContain("created successfully");
                 expect(elements[0]?.text).toContain(userName);
@@ -100,7 +102,9 @@ describeWithAtlas("db users", (integration) => {
 
             it("should create a database user with generated password", async () => {
                 const response = await createUserWithMCP();
-                const elements = getResponseElements(response);
+                // The tool may append an IP access list note depending on whether the
+                // runner's IP was already present in the project's access list.
+                const elements = getResponseElements(response).filter((e) => !e.text.includes("IP access list"));
                 expect(elements).toHaveLength(1);
                 expect(elements[0]?.text).toContain("created successfully");
                 expect(elements[0]?.text).toContain(userName);

--- a/tests/unit/accessListUtils.test.ts
+++ b/tests/unit/accessListUtils.test.ts
@@ -8,11 +8,12 @@ import type { LoggerBase } from "../../src/common/logging/loggerBase.js";
 describe("accessListUtils", () => {
     it("should add the current IP to the access list", async () => {
         const apiClient = {
+            supportsCurrentIpLookup: true,
             getIpInfo: vi.fn().mockResolvedValue({ currentIpv4Address: "127.0.0.1" } as never),
             createAccessListEntry: vi.fn().mockResolvedValue(undefined as never),
             logger: new NullLogger(),
         } as unknown as ApiClient;
-        await ensureCurrentIpInAccessList(apiClient, "projectId");
+        await expect(ensureCurrentIpInAccessList(apiClient, "projectId")).resolves.toBe("added");
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(apiClient.createAccessListEntry).toHaveBeenCalledWith(
             {
@@ -25,6 +26,7 @@ describe("accessListUtils", () => {
 
     it("should not fail if the current IP is already in the access list", async () => {
         const apiClient = {
+            supportsCurrentIpLookup: true,
             getIpInfo: vi.fn().mockResolvedValue({ currentIpv4Address: "127.0.0.1" } as never),
             createAccessListEntry: vi
                 .fn()
@@ -36,7 +38,7 @@ describe("accessListUtils", () => {
                 ),
             logger: new NullLogger(),
         } as unknown as ApiClient;
-        await ensureCurrentIpInAccessList(apiClient, "projectId");
+        await expect(ensureCurrentIpInAccessList(apiClient, "projectId")).resolves.toBe("already-present");
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(apiClient.createAccessListEntry).toHaveBeenCalledWith(
             {
@@ -45,6 +47,41 @@ describe("accessListUtils", () => {
             },
             undefined
         );
+    });
+
+    it("does not fail when the current IP cannot be determined", async () => {
+        const logger = { debug: vi.fn(), warning: vi.fn() } as unknown as LoggerBase;
+        const apiClient = {
+            supportsCurrentIpLookup: true,
+            getIpInfo: vi
+                .fn()
+                .mockRejectedValue(
+                    ApiClientError.fromError(
+                        { status: 404, statusText: "Not Found" } as Response,
+                        { message: "Not Found" } as never
+                    ) as never
+                ),
+            createAccessListEntry: vi.fn(),
+            logger,
+        } as unknown as ApiClient;
+        await expect(ensureCurrentIpInAccessList(apiClient, "projectId")).resolves.toBe("failed");
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(apiClient.createAccessListEntry).not.toHaveBeenCalled();
+        expect((logger as unknown as { warning: ReturnType<typeof vi.fn> }).warning).toHaveBeenCalled();
+    });
+
+    it("skips the IP lookup entirely when the api client does not support it", async () => {
+        const apiClient = {
+            supportsCurrentIpLookup: false,
+            getIpInfo: vi.fn(),
+            createAccessListEntry: vi.fn(),
+            logger: new NullLogger(),
+        } as unknown as ApiClient;
+        await expect(ensureCurrentIpInAccessList(apiClient, "projectId")).resolves.toBe("skipped");
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(apiClient.getIpInfo).not.toHaveBeenCalled();
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(apiClient.createAccessListEntry).not.toHaveBeenCalled();
     });
 
     const context = { requestInfo: { headers: { "x-request-id": "req-access-1" } } };
@@ -69,6 +106,7 @@ describe("accessListUtils", () => {
             createMock = vi.fn().mockRejectedValue(new Error("network error"));
         }
         return {
+            supportsCurrentIpLookup: true,
             getIpInfo: vi.fn().mockResolvedValue({ currentIpv4Address: "1.2.3.4" }),
             createAccessListEntry: createMock,
             logger,

--- a/tests/unit/common/apiClient.test.ts
+++ b/tests/unit/common/apiClient.test.ts
@@ -59,6 +59,26 @@ describe("ApiClient", () => {
         });
     });
 
+    describe("supportsCurrentIpLookup", () => {
+        it("is enabled by default", () => {
+            expect(apiClient.supportsCurrentIpLookup).toBe(true);
+        });
+
+        it("makes getIpInfo reject without a network call when disabled", async () => {
+            const client = new ApiClient(
+                {
+                    baseUrl: "https://api.test.com",
+                    userAgent: "test-user-agent",
+                    supportsCurrentIpLookup: false,
+                },
+                new NullLogger()
+            );
+
+            expect(client.supportsCurrentIpLookup).toBe(false);
+            await expect(client.getIpInfo()).rejects.toThrow("does not support current IP detection");
+        });
+    });
+
     describe("User-Agent", () => {
         it("should use custom userAgent when provided in options", async () => {
             const mockFetch = vi.spyOn(global, "fetch");

--- a/tests/unit/tools/atlas/create/createAccessList.test.ts
+++ b/tests/unit/tools/atlas/create/createAccessList.test.ts
@@ -23,7 +23,12 @@ describe("CreateAccessListTool", () => {
             createAccessListEntry: vi.fn().mockResolvedValue({}),
             getIpInfo: vi.fn().mockResolvedValue({ currentIpv4Address: currentIpAddress }),
         };
+        Object.assign(mockApiClient, { supportsCurrentIpLookup: true });
 
+        tool = makeTool(mockApiClient);
+    });
+
+    function makeTool(apiClient: unknown): CreateAccessListTool {
         const mockLogger = {
             info: vi.fn(),
             debug: vi.fn(),
@@ -33,7 +38,7 @@ describe("CreateAccessListTool", () => {
 
         const mockSession = {
             logger: mockLogger,
-            apiClient: mockApiClient as unknown as ApiClient,
+            apiClient: apiClient as ApiClient,
         } as unknown as Session;
 
         const params: ToolConstructorParams = {
@@ -54,8 +59,8 @@ describe("CreateAccessListTool", () => {
             uiRegistry: new UIRegistry(),
         };
 
-        tool = new CreateAccessListTool(params);
-    });
+        return new CreateAccessListTool(params);
+    }
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
@@ -103,8 +108,39 @@ describe("CreateAccessListTool", () => {
 
     it("throws when no inputs are provided", async () => {
         await expect(exec({ projectId })).rejects.toThrow(
-            "One of  ipAddresses, cidrBlocks, currentIpAddress must be provided."
+            "One of ipAddresses, cidrBlocks, currentIpAddress must be provided."
         );
+    });
+
+    it("includes the currentIpAddress arg when current IP lookup is supported", () => {
+        expect(Object.keys(tool.argsShape)).toContain("currentIpAddress");
+    });
+
+    describe("when current IP lookup is not supported", () => {
+        beforeEach(() => {
+            tool = makeTool({ ...mockApiClient, supportsCurrentIpLookup: false });
+        });
+
+        it("omits the currentIpAddress arg", () => {
+            expect(Object.keys(tool.argsShape)).not.toContain("currentIpAddress");
+        });
+
+        it("directs the user to provide explicit IPs when no inputs are provided", async () => {
+            await expect(exec({ projectId })).rejects.toThrow("Either ipAddresses or cidrBlocks must be provided.");
+        });
+
+        it("still creates entries for explicitly provided IPs", async () => {
+            await exec({ projectId, ipAddresses: ["192.168.1.1"] });
+
+            expect(mockApiClient.getIpInfo).not.toHaveBeenCalled();
+            expect(mockApiClient.createAccessListEntry).toHaveBeenCalledWith(
+                {
+                    params: { path: { groupId: projectId } },
+                    body: [{ groupId: projectId, ipAddress: "192.168.1.1", comment: DEFAULT_ACCESS_LIST_COMMENT }],
+                },
+                expect.anything()
+            );
+        });
     });
 
     it("uses custom comment when provided", async () => {

--- a/tests/unit/tools/atlas/create/createCluster.test.ts
+++ b/tests/unit/tools/atlas/create/createCluster.test.ts
@@ -333,6 +333,7 @@ describe("CreateClusterTool", () => {
             expect(mockApiClient.createCluster).toHaveBeenCalledOnce();
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
             expect(text).toContain("No IP access list changes were made");
+            expect(text).toContain("did not succeed");
         });
     });
 

--- a/tests/unit/tools/atlas/create/createCluster.test.ts
+++ b/tests/unit/tools/atlas/create/createCluster.test.ts
@@ -11,6 +11,7 @@ import type { ApiClient } from "../../../../../src/common/atlas/apiClient.js";
 import { UIRegistry } from "../../../../../src/ui/registry/index.js";
 import { MockMetrics } from "../../../mocks/metrics.js";
 import type { Keychain } from "../../../../../src/lib.js";
+import { ApiClientError } from "../../../../../src/common/atlas/apiClientError.js";
 
 const BASE_ARGS = {
     projectId: "507f1f77bcf86cd799439011",
@@ -30,7 +31,10 @@ describe("CreateClusterTool", () => {
         mockApiClient = {
             listClusters: vi.fn().mockResolvedValue({ results: [] }),
             createCluster: vi.fn().mockResolvedValue(CREATE_RESULT),
+            getIpInfo: vi.fn().mockResolvedValue({ currentIpv4Address: "127.0.0.1" }),
+            createAccessListEntry: vi.fn().mockResolvedValue({}),
         };
+        Object.assign(mockApiClient, { supportsCurrentIpLookup: true });
 
         const mockLogger = {
             info: vi.fn(),
@@ -38,6 +42,7 @@ describe("CreateClusterTool", () => {
             warning: vi.fn(),
             error: vi.fn(),
         } as unknown as CompositeLogger;
+        Object.assign(mockApiClient, { logger: mockLogger });
 
         mockSession = {
             logger: mockLogger,
@@ -293,6 +298,41 @@ describe("CreateClusterTool", () => {
                 computeAutoScaling: true,
                 terminationProtectionEnabled: false,
             });
+        });
+    });
+
+    describe("IP access list", () => {
+        it("adds the current IP to the access list and discloses it", async () => {
+            const result = await exec(BASE_ARGS);
+
+            expect(mockApiClient.createAccessListEntry).toHaveBeenCalledOnce();
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Your current IP address has been added");
+        });
+
+        it("does not mention the access list when the current IP is already present", async () => {
+            mockApiClient.createAccessListEntry?.mockRejectedValue(
+                ApiClientError.fromError(
+                    { status: 409, statusText: "Conflict" } as Response,
+                    { message: "Conflict" } as never
+                )
+            );
+
+            const result = await exec(BASE_ARGS);
+
+            expect(result.isError).toBeFalsy();
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).not.toContain("access list");
+        });
+
+        it("still creates the cluster and notes that no access list changes were made when the IP lookup fails", async () => {
+            mockApiClient.getIpInfo?.mockRejectedValue(new Error("ipinfo unavailable"));
+
+            const result = await exec(BASE_ARGS);
+
+            expect(mockApiClient.createCluster).toHaveBeenCalledOnce();
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("No IP access list changes were made");
         });
     });
 

--- a/tests/unit/tools/atlas/create/createDBUser.test.ts
+++ b/tests/unit/tools/atlas/create/createDBUser.test.ts
@@ -11,10 +11,11 @@ import type { ApiClient } from "../../../../../src/common/atlas/apiClient.js";
 import { UIRegistry } from "../../../../../src/ui/registry/index.js";
 import { MockMetrics } from "../../../mocks/metrics.js";
 import type { Keychain } from "../../../../../src/lib.js";
+import { ensureCurrentIpInAccessList } from "../../../../../src/common/atlas/accessListUtils.js";
 
-vi.mock("../../../../../src/common/atlas/accessListUtils.js", () => ({
-    ensureCurrentIpInAccessList: vi.fn().mockResolvedValue(false),
-    DEFAULT_ACCESS_LIST_COMMENT: "Added by MongoDB MCP Server to enable tool access",
+vi.mock("../../../../../src/common/atlas/accessListUtils.js", async (importOriginal) => ({
+    ...(await importOriginal<Record<string, unknown>>()),
+    ensureCurrentIpInAccessList: vi.fn(),
 }));
 
 vi.mock("../../../../../src/helpers/generatePassword.js", () => ({
@@ -33,6 +34,7 @@ describe("CreateDBUserTool", () => {
     };
 
     beforeEach(() => {
+        vi.mocked(ensureCurrentIpInAccessList).mockResolvedValue("added");
         register = vi.fn();
         mockApiClient = {
             createDatabaseUser: vi.fn().mockResolvedValue({}),
@@ -97,6 +99,37 @@ describe("CreateDBUserTool", () => {
             username: baseArgs.username,
             password: "generated-password",
         });
+    });
+
+    it.each(["skipped", "failed"] as const)(
+        "notes that no access list changes were made when the current IP setup result is %s",
+        async (ensureResult) => {
+            vi.mocked(ensureCurrentIpInAccessList).mockResolvedValue(ensureResult);
+
+            const result = await exec({ ...baseArgs, password: "user-password" });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain('User "test-user" created successfully');
+            expect(text).toContain("No IP access list changes were made");
+        }
+    );
+
+    it("discloses that the current IP was added to the access list", async () => {
+        vi.mocked(ensureCurrentIpInAccessList).mockResolvedValue("added");
+
+        const result = await exec({ ...baseArgs, password: "user-password" });
+
+        const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+        expect(text).toContain("Your current IP address has been added");
+    });
+
+    it("does not mention the access list when the current IP is already present", async () => {
+        vi.mocked(ensureCurrentIpInAccessList).mockResolvedValue("already-present");
+
+        const result = await exec({ ...baseArgs, password: "user-password" });
+
+        const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+        expect(text).not.toContain("access list");
     });
 
     it("passes cluster scopes to the API when clusters are provided", async () => {

--- a/tests/unit/tools/atlas/create/createDBUser.test.ts
+++ b/tests/unit/tools/atlas/create/createDBUser.test.ts
@@ -101,18 +101,28 @@ describe("CreateDBUserTool", () => {
         });
     });
 
-    it.each(["skipped", "failed"] as const)(
-        "notes that no access list changes were made when the current IP setup result is %s",
-        async (ensureResult) => {
-            vi.mocked(ensureCurrentIpInAccessList).mockResolvedValue(ensureResult);
+    it("explains that the current IP cannot be determined when the IP setup is skipped", async () => {
+        vi.mocked(ensureCurrentIpInAccessList).mockResolvedValue("skipped");
 
-            const result = await exec({ ...baseArgs, password: "user-password" });
+        const result = await exec({ ...baseArgs, password: "user-password" });
 
-            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain('User "test-user" created successfully');
-            expect(text).toContain("No IP access list changes were made");
-        }
-    );
+        const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+        expect(text).toContain('User "test-user" created successfully');
+        expect(text).toContain("No IP access list changes were made");
+        expect(text).toContain("cannot determine your public IP address");
+    });
+
+    it("explains that adding the current IP did not succeed when the IP setup fails", async () => {
+        vi.mocked(ensureCurrentIpInAccessList).mockResolvedValue("failed");
+
+        const result = await exec({ ...baseArgs, password: "user-password" });
+
+        const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+        expect(text).toContain('User "test-user" created successfully');
+        expect(text).toContain("No IP access list changes were made");
+        expect(text).toContain("did not succeed");
+        expect(text).not.toContain("cannot determine your public IP address");
+    });
 
     it("discloses that the current IP was added to the access list", async () => {
         vi.mocked(ensureCurrentIpInAccessList).mockResolvedValue("added");

--- a/tests/unit/tools/atlas/create/createFreeCluster.test.ts
+++ b/tests/unit/tools/atlas/create/createFreeCluster.test.ts
@@ -9,9 +9,11 @@ import type { CompositeLogger } from "../../../../../src/common/logging/index.js
 import type { ApiClient } from "../../../../../src/common/atlas/apiClient.js";
 import { UIRegistry } from "../../../../../src/ui/registry/index.js";
 import { MockMetrics } from "../../../mocks/metrics.js";
+import { ApiClientError } from "../../../../../src/common/atlas/apiClientError.js";
 
 describe("CreateFreeClusterTool", () => {
     let mockApiClient: {
+        supportsCurrentIpLookup: boolean;
         createCluster: ReturnType<typeof vi.fn>;
         getIpInfo: ReturnType<typeof vi.fn>;
         createAccessListEntry: ReturnType<typeof vi.fn>;
@@ -34,6 +36,7 @@ describe("CreateFreeClusterTool", () => {
         } as unknown as CompositeLogger;
 
         mockApiClient = {
+            supportsCurrentIpLookup: true,
             createCluster: vi.fn().mockResolvedValue({}),
             getIpInfo: vi.fn().mockResolvedValue({ currentIpv4Address: "127.0.0.1" }),
             createAccessListEntry: vi.fn().mockResolvedValue({}),
@@ -70,15 +73,53 @@ describe("CreateFreeClusterTool", () => {
     const exec = (args: Record<string, unknown> = baseArgs) =>
         tool["execute"](args as never, { signal: new AbortController().signal } as never);
 
-    it("creates a free cluster and returns success content", async () => {
+    it("creates a free cluster and notes that the current IP was added to the access list", async () => {
         const result = await exec();
 
         const text = result.content.map((c) => (c as { text: string }).text).join("\n");
         expect(text).toContain('Cluster "free-cluster" has been created in region "US_EAST_1"');
-        expect(text).toContain("Double check your access lists");
+        expect(text).toContain("Your current IP address has been added");
         expect(result.structuredContent).toEqual({
             created: true,
         });
+    });
+
+    it("does not mention the access list when the current IP is already present", async () => {
+        mockApiClient.createAccessListEntry.mockRejectedValue(
+            ApiClientError.fromError(
+                { status: 409, statusText: "Conflict" } as Response,
+                { message: "Conflict" } as never
+            )
+        );
+
+        const result = await exec();
+
+        const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+        expect(text).toContain('Cluster "free-cluster" has been created in region "US_EAST_1"');
+        expect(text).not.toContain("access list");
+    });
+
+    it("skips the IP lookup and explains that no access list changes were made when current IP lookup is not supported", async () => {
+        Object.assign(mockApiClient, { supportsCurrentIpLookup: false });
+
+        const result = await exec();
+
+        expect(mockApiClient.getIpInfo).not.toHaveBeenCalled();
+        const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+        expect(text).toContain('Cluster "free-cluster" has been created in region "US_EAST_1"');
+        expect(text).toContain("No IP access list changes were made");
+        expect(text).not.toContain("Your current IP address has been added");
+    });
+
+    it("still creates the cluster and notes that no access list changes were made when the IP lookup fails", async () => {
+        mockApiClient.getIpInfo.mockRejectedValue(new Error("ipinfo unavailable"));
+
+        const result = await exec();
+
+        expect(mockApiClient.createCluster).toHaveBeenCalledOnce();
+        const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+        expect(text).toContain("No IP access list changes were made");
+        expect(text).not.toContain("Your current IP address has been added");
     });
 
     it("calls createCluster with M0 replication specs", async () => {

--- a/tests/unit/tools/atlas/create/createFreeCluster.test.ts
+++ b/tests/unit/tools/atlas/create/createFreeCluster.test.ts
@@ -108,6 +108,7 @@ describe("CreateFreeClusterTool", () => {
         const text = result.content.map((c) => (c as { text: string }).text).join("\n");
         expect(text).toContain('Cluster "free-cluster" has been created in region "US_EAST_1"');
         expect(text).toContain("No IP access list changes were made");
+        expect(text).toContain("cannot determine your public IP address");
         expect(text).not.toContain("Your current IP address has been added");
     });
 
@@ -119,7 +120,8 @@ describe("CreateFreeClusterTool", () => {
         expect(mockApiClient.createCluster).toHaveBeenCalledOnce();
         const text = result.content.map((c) => (c as { text: string }).text).join("\n");
         expect(text).toContain("No IP access list changes were made");
-        expect(text).not.toContain("Your current IP address has been added");
+        expect(text).toContain("did not succeed");
+        expect(text).not.toContain("cannot determine your public IP address");
     });
 
     it("calls createCluster with M0 replication specs", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,9 @@ const vitestDefaultExcludes = [
     "**/dist/**",
     "**/cypress/**",
     "**/.{idea,git,cache,output,temp}/**",
+    // Agent worktrees contain full repo copies whose tests would otherwise be
+    // picked up by the unanchored include globs and race over fixed ports.
+    "**/.claude/**",
     "**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*",
 ];
 


### PR DESCRIPTION
## Proposed changes

When hosting the server remotely, the functionality to add IP Access lists doesn't make sense. This change allows consumers to disable it through the API client and adjusts corresponding tools to handle the change.