### PR TITLE
feat: multi-connection support (named connections + per-call selection)

### DIFF
--- a/src/common/config/configUtils.ts
+++ b/src/common/config/configUtils.ts
@@ -77,6 +77,47 @@ export function commaSeparatedToArray<T extends string[]>(str: string | string[]
 }
 
 /**
+ * Preprocessor for the `connections` config field (env var
+ * `MDB_MCP_CONNECTIONS`). The value arrives as a JSON string mapping connection
+ * names to targets, e.g. `{"analytics":"mongodb://...","reporting":{"connectionString":"mongodb://..."}}`.
+ *
+ * Normalises each target into the `{ connectionString }` object shape and,
+ * mirroring {@link commaSeparatedToArray}, never throws: a malformed JSON blob
+ * is returned unchanged so the downstream Zod `record` schema rejects it and the
+ * error surfaces through the normal config-parsing channel.
+ */
+export function parseNamedConnections(val: unknown): unknown {
+    if (val === undefined || val === null) {
+        return undefined;
+    }
+
+    let raw: unknown = val;
+    if (typeof val === "string") {
+        const trimmed = val.trim();
+        if (trimmed.length === 0) {
+            return undefined;
+        }
+        try {
+            raw = JSON.parse(trimmed);
+        } catch {
+            // Leave the raw string in place; the record schema will reject it
+            // with a validation error surfaced by parseUserConfig.
+            return val;
+        }
+    }
+
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+        return raw;
+    }
+
+    const normalized: Record<string, unknown> = {};
+    for (const [name, target] of Object.entries(raw as Record<string, unknown>)) {
+        normalized[name] = typeof target === "string" ? { connectionString: target } : target;
+    }
+    return normalized;
+}
+
+/**
  * Preprocessor for boolean values that handles string "false"/"0" correctly.
  * Zod's coerce.boolean() treats any non-empty string as true, which is not what we want.
  */

--- a/src/common/config/parseUserConfig.ts
+++ b/src/common/config/parseUserConfig.ts
@@ -87,12 +87,76 @@ export function parseUserConfig({
     // TODO: Separate correctly parsed user config from all other valid
     // arguments relevant to mongosh's args-parser.
     const userConfig: UserConfig = { ...parsed, ...configParseResult.data };
+
+    // Fold the legacy connection string into the named-connection registry as
+    // the reserved "default" entry before validating and registering secrets.
+    const foldWarning = foldLegacyConnectionIntoRegistry(userConfig);
+    if (foldWarning) {
+        warnings.push(foldWarning);
+    }
+
+    const namedConnectionError = validateNamedConnections(userConfig);
+    if (namedConnectionError) {
+        return { error: namedConnectionError, warnings, parsed: undefined };
+    }
+
     registerKnownSecretsInRootKeychain(userConfig);
     return {
         parsed: userConfig,
         warnings,
         error: undefined,
     };
+}
+
+/**
+ * Folds the legacy `connectionString` into `connections` under the reserved
+ * `"default"` name so the registry and the session-default share one source of
+ * truth. The legacy connection string always wins the `"default"` slot; a
+ * warning is returned when it displaces an explicit `"default"` entry.
+ */
+function foldLegacyConnectionIntoRegistry(userConfig: UserConfig): string | undefined {
+    if (!userConfig.connectionString) {
+        return undefined;
+    }
+
+    const existing = userConfig.connections ?? {};
+    const hadDefault = Object.prototype.hasOwnProperty.call(existing, "default");
+    userConfig.connections = {
+        ...existing,
+        default: { connectionString: userConfig.connectionString },
+    };
+
+    if (hadDefault) {
+        return 'Warning: Both MDB_MCP_CONNECTION_STRING and a "default" entry in MDB_MCP_CONNECTIONS were provided. The legacy connection string takes precedence for the "default" connection.';
+    }
+
+    return undefined;
+}
+
+/**
+ * Validates the named-connection configuration: connection names must be
+ * non-empty and `defaultConnection`, when set, must reference an existing entry.
+ */
+function validateNamedConnections(userConfig: UserConfig): string | undefined {
+    const connections = userConfig.connections ?? {};
+
+    for (const name of Object.keys(connections)) {
+        if (name.trim().length === 0) {
+            return "Invalid configuration: connection names in MDB_MCP_CONNECTIONS must not be empty.";
+        }
+    }
+
+    if (
+        userConfig.defaultConnection &&
+        !Object.prototype.hasOwnProperty.call(connections, userConfig.defaultConnection)
+    ) {
+        const available = Object.keys(connections)
+            .map((name) => `"${name}"`)
+            .join(", ");
+        return `Invalid configuration: defaultConnection "${userConfig.defaultConnection}" does not reference a configured connection. Available connections: ${available || "none"}.`;
+    }
+
+    return undefined;
 }
 
 function parseUserConfigSources<T extends typeof UserConfigSchema>({
@@ -177,6 +241,14 @@ function registerKnownSecretsInRootKeychain(userConfig: Partial<UserConfig>): vo
     maybeRegister(userConfig.username, "user");
     maybeRegister(userConfig.voyageApiKey, "password");
     maybeRegister(userConfig.connectionString, "mongodb uri");
+
+    // The named-connection map arrives as a single secret env blob, so each
+    // parsed connection string must be registered individually to stay redacted.
+    if (userConfig.connections) {
+        for (const target of Object.values(userConfig.connections)) {
+            maybeRegister(target?.connectionString, "mongodb uri");
+        }
+    }
 }
 
 function matchingConfigKey(key: string): string | undefined {

--- a/src/common/config/userConfig.ts
+++ b/src/common/config/userConfig.ts
@@ -9,6 +9,7 @@ import {
     onlyStricterLogLevelOverride,
     onlySubsetOfBaseValueOverride,
     parseBoolean,
+    parseNamedConnections,
 } from "./configUtils.js";
 import { MCP_LOG_LEVELS } from "../logging/loggingTypes.js";
 import { monitoringServerFeatureValues, previewFeatureValues } from "../schemas.js";
@@ -44,6 +45,34 @@ const ServerConfigSchema = z.object({
             "MongoDB connection string for direct database connections. Optional, if not set, you'll need to call the connect tool before interacting with MongoDB data."
         )
         .register(configRegistry, { isSecret: true, overrideBehavior: "not-allowed" }),
+    connections: z
+        .preprocess(
+            (val: unknown) => parseNamedConnections(val),
+            // A catchall object (rather than z.record) so the mongosh arg-parser,
+            // which introspects this schema to build CLI/env options, recognises
+            // it as a JSON-object field (handled like httpHeaders via coerceObject)
+            // instead of throwing "Unknown field type: ZodRecord". The per-entry
+            // preprocess keeps the "name":"mongodb://..." string shorthand working
+            // on the arg-parser's coerce path, where parseNamedConnections is bypassed.
+            z.object({}).catchall(
+                z.preprocess(
+                    (target: unknown) => (typeof target === "string" ? { connectionString: target } : target),
+                    z.object({ connectionString: z.string().min(1, "connectionString must not be empty") })
+                )
+            )
+        )
+        .default({})
+        .describe(
+            'A JSON object mapping connection names to targets, e.g. \'{"analytics":"mongodb://...","reporting":{"connectionString":"mongodb://..."}}\'. Supplied via the MDB_MCP_CONNECTIONS environment variable. Enables per-tool-call connection selection through the optional "connection" argument on data tools. The legacy MDB_MCP_CONNECTION_STRING, when set, is folded in as the reserved "default" entry.'
+        )
+        .register(configRegistry, { isSecret: true, overrideBehavior: "not-allowed" }),
+    defaultConnection: z
+        .string()
+        .optional()
+        .describe(
+            'Name of the connection (from "connections") to use as the session default when no MDB_MCP_CONNECTION_STRING is set. Ignored when MDB_MCP_CONNECTION_STRING is provided (that always becomes the "default").'
+        )
+        .register(configRegistry, { overrideBehavior: "override" }),
     loggers: z
         .preprocess(
             (val: string | string[] | undefined) => commaSeparatedToArray(val),

--- a/src/common/connectionManager.ts
+++ b/src/common/connectionManager.ts
@@ -48,6 +48,103 @@ export const defaultDriverOptions: ConnectionInfo["driverOptions"] = {
     applyProxyToOIDC: true,
 };
 
+/**
+ * Dependencies required to assemble a {@link NodeDriverServiceProvider} from a
+ * set of {@link ConnectionSettings}.
+ */
+export interface BuildServiceProviderDeps {
+    /** Active user configuration; drives the mongosh CLI-derived driver options. */
+    userConfig: UserConfig;
+    /** Provider of the stable device identifier embedded in the connection's `appName`. */
+    deviceId: DeviceId;
+    /** MCP client name embedded in the connection's `appName`. */
+    clientName: string;
+    /** Optional event emitter shared with the OIDC plugin. */
+    bus?: EventEmitter;
+    /** Optional callback invoked when the OIDC device flow surfaces a verification URL and user code. */
+    onNotifyDeviceFlow?: (flowInfo: { verificationUrl: string; userCode: string }) => void;
+}
+
+export interface BuiltServiceProvider {
+    /**
+     * The (possibly still pending) service provider. For non-OIDC connections
+     * awaiting this resolves once the driver is connected; for OIDC flows it
+     * resolves once the plugin reports auth success.
+     */
+    serviceProvider: Promise<NodeDriverServiceProvider>;
+    connectionStringInfo: ConnectionStringInfo;
+}
+
+/**
+ * Assembles a {@link NodeDriverServiceProvider} from the supplied
+ * {@link ConnectionSettings}, applying the MCP-specific `appName` and driver
+ * options (read/write concerns, proxy and OIDC defaults).
+ *
+ * This is the shared, side-effect-free connection-assembly primitive used by
+ * both the single-slot {@link MCPConnectionManager} (which drives the
+ * session-default connection and its OIDC state machine) and the keyed
+ * `ConnectionRegistry` (which lazily pools named connections). It intentionally
+ * does NOT touch any connection state, emit events, or perform teardown.
+ */
+export async function buildServiceProvider(
+    settings: ConnectionSettings,
+    { userConfig, deviceId, clientName, bus, onNotifyDeviceFlow }: BuildServiceProviderDeps
+): Promise<BuiltServiceProvider> {
+    const resolvedSettings: ConnectionSettings = { ...settings };
+
+    const appNameComponents: AppNameComponents = {
+        appName: `${packageInfo.mcpServerName} ${packageInfo.version}`,
+        deviceId: deviceId.get(),
+        clientName,
+    };
+
+    resolvedSettings.connectionString = await setAppNameParamIfMissing({
+        connectionString: resolvedSettings.connectionString,
+        components: appNameComponents,
+    });
+
+    const connectionInfo: ConnectionInfo = resolvedSettings.driverOptions
+        ? {
+              connectionString: resolvedSettings.connectionString,
+              driverOptions: resolvedSettings.driverOptions,
+          }
+        : generateConnectionInfoFromCliArgs({
+              ...defaultDriverOptions,
+              /** TODO: Currently we're passing the entire user config to make it apply the mongosh CLI commands that were passed in. We should consider seperating the fields in the future. */
+              ...userConfig,
+              connectionSpecifier: resolvedSettings.connectionString,
+          });
+
+    if (connectionInfo.driverOptions.oidc) {
+        connectionInfo.driverOptions.oidc.allowedFlows ??= ["auth-code"];
+        if (onNotifyDeviceFlow) {
+            connectionInfo.driverOptions.oidc.notifyDeviceFlow ??= onNotifyDeviceFlow;
+        }
+    }
+
+    connectionInfo.driverOptions.proxy ??= { useEnvironmentVariableProxies: true };
+    connectionInfo.driverOptions.applyProxyToOIDC ??= true;
+
+    const connectionStringInfo = getConnectionStringInfo(
+        connectionInfo.connectionString,
+        userConfig,
+        resolvedSettings.atlas
+    );
+
+    const serviceProvider = NodeDriverServiceProvider.connect(
+        connectionInfo.connectionString,
+        {
+            productDocsLink: "https://github.com/mongodb-js/mongodb-mcp-server/",
+            productName: "MongoDB MCP",
+            ...connectionInfo.driverOptions,
+        },
+        undefined,
+        bus
+    );
+
+    return { serviceProvider, connectionStringInfo };
+}
+
 export class ConnectionStateConnected implements ConnectionState {
     public tag = "connected" as const;
 
@@ -294,54 +391,15 @@ export class MCPConnectionManager extends ConnectionManager {
         let connectionStringInfo: ConnectionStringInfo = { authType: "scram", hostType: "unknown" };
 
         try {
-            settings = { ...settings };
-            const appNameComponents: AppNameComponents = {
-                appName: `${packageInfo.mcpServerName} ${packageInfo.version}`,
-                deviceId: this.deviceId.get(),
+            const built = await buildServiceProvider(settings, {
+                userConfig: this.userConfig,
+                deviceId: this.deviceId,
                 clientName: this.clientName,
-            };
-
-            settings.connectionString = await setAppNameParamIfMissing({
-                connectionString: settings.connectionString,
-                components: appNameComponents,
+                bus: this.bus,
+                onNotifyDeviceFlow: this.onOidcNotifyDeviceFlow.bind(this),
             });
-
-            const connectionInfo: ConnectionInfo = settings.driverOptions
-                ? {
-                      connectionString: settings.connectionString,
-                      driverOptions: settings.driverOptions,
-                  }
-                : generateConnectionInfoFromCliArgs({
-                      ...defaultDriverOptions,
-                      /** TODO: Currently we're passing the entire user config to make it apply the mongosh CLI commands that were passed in. We should consider seperating the fields in the future. */
-                      ...this.userConfig,
-                      connectionSpecifier: settings.connectionString,
-                  });
-
-            if (connectionInfo.driverOptions.oidc) {
-                connectionInfo.driverOptions.oidc.allowedFlows ??= ["auth-code"];
-                connectionInfo.driverOptions.oidc.notifyDeviceFlow ??= this.onOidcNotifyDeviceFlow.bind(this);
-            }
-
-            connectionInfo.driverOptions.proxy ??= { useEnvironmentVariableProxies: true };
-            connectionInfo.driverOptions.applyProxyToOIDC ??= true;
-
-            connectionStringInfo = getConnectionStringInfo(
-                connectionInfo.connectionString,
-                this.userConfig,
-                settings.atlas
-            );
-
-            serviceProvider = NodeDriverServiceProvider.connect(
-                connectionInfo.connectionString,
-                {
-                    productDocsLink: "https://github.com/mongodb-js/mongodb-mcp-server/",
-                    productName: "MongoDB MCP",
-                    ...connectionInfo.driverOptions,
-                },
-                undefined,
-                this.bus
-            );
+            serviceProvider = built.serviceProvider;
+            connectionStringInfo = built.connectionStringInfo;
         } catch (error: unknown) {
             const errorReason = error instanceof Error ? error.message : `${error as string}`;
             this.changeState("connection-error", {

--- a/src/common/connectionRegistry.ts
+++ b/src/common/connectionRegistry.ts
@@ -1,0 +1,220 @@
+import { EventEmitter } from "events";
+import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import type { DeviceId } from "../helpers/deviceId.js";
+import type { UserConfig } from "./config/userConfig.js";
+import { ErrorCodes, MongoDBError } from "./errors.js";
+import { type LoggerBase, LogId } from "./logging/index.js";
+import { buildServiceProvider, type ConnectionSettings } from "./connectionManager.js";
+import type { ConnectionStringInfo } from "./connectionInfo.js";
+
+/** Lifecycle status of a single named connection in the registry. */
+export type ConnectionRegistryEntryStatus = "idle" | "connecting" | "connected" | "errored";
+
+interface ConnectionRegistryEntry {
+    name: string;
+    settings: ConnectionSettings;
+    /**
+     * The in-flight or settled connect promise. Stored before it settles so
+     * concurrent first-callers share a single physical connect. Cleared on
+     * failure so a later call can retry.
+     */
+    provider?: Promise<NodeDriverServiceProvider>;
+    status: ConnectionRegistryEntryStatus;
+    connectionStringInfo?: ConnectionStringInfo;
+}
+
+export interface ConnectionRegistryOptions {
+    userConfig: UserConfig;
+    deviceId: DeviceId;
+    logger: LoggerBase;
+    /**
+     * Lazily resolves the current MCP client name for the connection's
+     * `appName`. Read at resolve time because the client name is only known
+     * after the MCP client initialises the session.
+     */
+    getClientName: () => string;
+    /** Parsed named-connection targets, keyed by connection name. */
+    connections?: Record<string, { connectionString: string }>;
+    /** Name of the entry that acts as the session default, when any. */
+    defaultConnectionName?: string;
+}
+
+/**
+ * Resolves the name of the registry entry that should act as the session
+ * default, following the precedence: legacy `connectionString` (folded into the
+ * reserved `"default"` entry) → explicit `defaultConnection` → a literal
+ * `"default"` key in the connections map → none.
+ */
+export function resolveDefaultConnectionName(config: UserConfig): string | undefined {
+    if (config.connectionString) {
+        return "default";
+    }
+    if (config.defaultConnection) {
+        return config.defaultConnection;
+    }
+    if (config.connections && Object.prototype.hasOwnProperty.call(config.connections, "default")) {
+        return "default";
+    }
+    return undefined;
+}
+
+/**
+ * A lazy, keyed pool of named {@link NodeDriverServiceProvider}s that coexists
+ * with — and never mutates — the single-slot session-default connection managed
+ * by {@link import("./connectionManager.js").MCPConnectionManager}.
+ *
+ * This implements the MCP "explicit-handle" pattern: the handle is the
+ * connection **name**, supplied per tool call. When a name is supplied nothing
+ * shared is mutated, which is what makes a single session safe to share behind
+ * a gateway. Each name owns one long-lived provider (the driver is itself a
+ * concurrency-safe pool); first-use races collapse to a single connect via the
+ * stored in-flight promise.
+ */
+export class ConnectionRegistry {
+    private readonly entries = new Map<string, ConnectionRegistryEntry>();
+    private readonly userConfig: UserConfig;
+    private readonly deviceId: DeviceId;
+    private readonly logger: LoggerBase;
+    private readonly getClientName: () => string;
+    /** Name of the entry backing the session default, when any. */
+    public readonly defaultName?: string;
+
+    constructor({
+        userConfig,
+        deviceId,
+        logger,
+        getClientName,
+        connections,
+        defaultConnectionName,
+    }: ConnectionRegistryOptions) {
+        this.userConfig = userConfig;
+        this.deviceId = deviceId;
+        this.logger = logger;
+        this.getClientName = getClientName;
+        this.defaultName = defaultConnectionName;
+
+        for (const [name, target] of Object.entries(connections ?? {})) {
+            this.entries.set(name, {
+                name,
+                settings: { connectionString: target.connectionString },
+                status: "idle",
+            });
+        }
+    }
+
+    /** Whether a connection with the given name is configured. */
+    public has(name: string): boolean {
+        return this.entries.has(name);
+    }
+
+    /** Names of all configured connections. */
+    public names(): string[] {
+        return [...this.entries.keys()];
+    }
+
+    /** Current lifecycle status of a named connection, or undefined when unknown. */
+    public statusOf(name: string): ConnectionRegistryEntryStatus | undefined {
+        return this.entries.get(name)?.status;
+    }
+
+    /** The {@link ConnectionSettings} for a named connection, or undefined when unknown. */
+    public getSettings(name: string): ConnectionSettings | undefined {
+        return this.entries.get(name)?.settings;
+    }
+
+    /**
+     * Lazily establishes (or returns the already-established) provider for the
+     * named connection. Concurrent first-callers share a single physical
+     * connect. Never touches the session-default connection.
+     *
+     * @throws {@link MongoDBError} with {@link ErrorCodes.NamedConnectionNotFound}
+     * when the name is unknown, or {@link ErrorCodes.NamedConnectionFailed} when
+     * establishing the connection fails. Both codes bypass the session-default
+     * connection recovery handler.
+     */
+    public async resolve(name: string): Promise<NodeDriverServiceProvider> {
+        const entry = this.entries.get(name);
+        if (!entry) {
+            throw new MongoDBError(
+                ErrorCodes.NamedConnectionNotFound,
+                `Connection "${name}" is not configured. Available connections: ${this.formatNames()}.`
+            );
+        }
+
+        if (entry.provider) {
+            return entry.provider;
+        }
+
+        entry.status = "connecting";
+        const providerPromise = this.establish(entry).then(
+            (provider) => {
+                entry.status = "connected";
+                return provider;
+            },
+            (error: unknown) => {
+                entry.status = "errored";
+                // Allow a later call to retry a failed connection.
+                entry.provider = undefined;
+                throw error instanceof MongoDBError
+                    ? error
+                    : new MongoDBError(
+                          ErrorCodes.NamedConnectionFailed,
+                          `Failed to establish connection "${name}": ${error instanceof Error ? error.message : String(error)}`
+                      );
+            }
+        );
+        // Store the promise BEFORE awaiting so N concurrent first-callers share it.
+        entry.provider = providerPromise;
+        return providerPromise;
+    }
+
+    private async establish(entry: ConnectionRegistryEntry): Promise<NodeDriverServiceProvider> {
+        this.logger.debug({
+            id: LogId.mongodbConnectTry,
+            context: "connectionRegistry",
+            message: `Establishing named connection "${entry.name}"`,
+        });
+
+        const { serviceProvider, connectionStringInfo } = await buildServiceProvider(entry.settings, {
+            userConfig: this.userConfig,
+            deviceId: this.deviceId,
+            clientName: this.getClientName(),
+            bus: new EventEmitter(),
+        });
+
+        entry.connectionStringInfo = connectionStringInfo;
+        return serviceProvider;
+    }
+
+    /** Closes every established provider (best-effort) and resets all entries to idle. */
+    public async close(): Promise<void> {
+        const pending = [...this.entries.values()]
+            .map((entry) => entry.provider)
+            .filter((provider): provider is Promise<NodeDriverServiceProvider> => provider !== undefined);
+
+        for (const entry of this.entries.values()) {
+            entry.provider = undefined;
+            entry.status = "idle";
+        }
+
+        await Promise.allSettled(
+            pending.map(async (providerPromise) => {
+                try {
+                    const provider = await providerPromise;
+                    await provider.close();
+                } catch (error: unknown) {
+                    this.logger.warning({
+                        id: LogId.mongodbDisconnectFailure,
+                        context: "connectionRegistry",
+                        message: `Error closing a named connection: ${error instanceof Error ? error.message : String(error)}`,
+                    });
+                }
+            })
+        );
+    }
+
+    private formatNames(): string {
+        const names = this.names();
+        return names.length > 0 ? names.map((name) => `"${name}"`).join(", ") : "none";
+    }
+}

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -8,6 +8,20 @@ export enum ErrorCodes {
     AtlasVectorSearchInvalidQuery = 1_000_007,
     InvalidPipeline = 1_000_008,
     ForbiddenServerSideJS = 1_000_009,
+    /**
+     * A per-call `connection` argument referenced a name that is not present in
+     * the configured connection registry. Distinct from
+     * {@link ErrorCodes.NotConnectedToMongoDB} / {@link ErrorCodes.MisconfiguredConnectionString}
+     * so that failures for a named connection do not trigger the session-default
+     * connection recovery handler.
+     */
+    NamedConnectionNotFound = 1_000_010,
+    /**
+     * Establishing a named connection from the registry failed (e.g. the target
+     * cluster was unreachable). Kept separate from the session-default error
+     * codes for the same reason as {@link ErrorCodes.NamedConnectionNotFound}.
+     */
+    NamedConnectionFailed = 1_000_011,
 }
 
 export class MongoDBError<ErrorCode extends ErrorCodes = ErrorCodes> extends Error {

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -17,6 +17,7 @@ import { ErrorCodes, MongoDBError } from "./errors.js";
 import type { ExportsManager } from "./exportsManager.js";
 import type { Client } from "@mongodb-js/atlas-local";
 import type { Keychain } from "./keychain.js";
+import type { ConnectionRegistry } from "./connectionRegistry.js";
 import { generateConnectionInfoFromCliArgs } from "@mongosh/arg-parser";
 import { type UserConfig } from "../common/config/userConfig.js";
 import { type ConnectionErrorHandler } from "./connectionErrorHandler.js";
@@ -26,6 +27,7 @@ export interface SessionOptions<TUserConfig extends UserConfig = UserConfig> {
     logger: CompositeLogger;
     exportsManager: ExportsManager;
     connectionManager: ConnectionManager;
+    connectionRegistry: ConnectionRegistry;
     keychain: Keychain;
     atlasLocalClient?: Client;
     connectionErrorHandler: ConnectionErrorHandler;
@@ -44,6 +46,7 @@ export class Session extends EventEmitter<SessionEvents> {
     readonly sessionId: string = new ObjectId().toString();
     readonly exportsManager: ExportsManager;
     readonly connectionManager: ConnectionManager;
+    readonly connectionRegistry: ConnectionRegistry;
     readonly apiClient: ApiClient;
     readonly atlasLocalClient?: Client;
     readonly keychain: Keychain;
@@ -61,6 +64,7 @@ export class Session extends EventEmitter<SessionEvents> {
         userConfig,
         logger,
         connectionManager,
+        connectionRegistry,
         exportsManager,
         keychain,
         atlasLocalClient,
@@ -76,6 +80,7 @@ export class Session extends EventEmitter<SessionEvents> {
         this.atlasLocalClient = atlasLocalClient;
         this.exportsManager = exportsManager;
         this.connectionManager = connectionManager;
+        this.connectionRegistry = connectionRegistry;
         this.connectionErrorHandler = connectionErrorHandler;
         this.connectionManager.events.on("connection-success", () => this.emit("connect"));
         this.connectionManager.events.on("connection-time-out", (error) => this.emit("connection-error", error));
@@ -132,12 +137,35 @@ export class Session extends EventEmitter<SessionEvents> {
 
     async close(): Promise<void> {
         await this.disconnect();
+        await this.connectionRegistry.close();
         await this.apiClient?.close();
         await this.exportsManager.close();
         this.emit("close");
     }
 
     async connectToConfiguredConnection(): Promise<void> {
+        // Prefer the legacy connection string for byte-for-byte backward
+        // compatibility when it is set.
+        if (this.userConfig.connectionString) {
+            const connectionInfo = generateConnectionInfoFromCliArgs({
+                ...this.userConfig,
+                connectionSpecifier: this.userConfig.connectionString,
+            });
+            await this.connectToMongoDB(connectionInfo);
+            return;
+        }
+
+        // Otherwise source the session-default from the registry's default entry.
+        const defaultName = this.connectionRegistry.defaultName;
+        if (defaultName) {
+            const settings = this.connectionRegistry.getSettings(defaultName);
+            if (settings) {
+                await this.connectToMongoDB(settings);
+                return;
+            }
+        }
+
+        // Nothing configured: preserve the legacy behavior (and its error).
         const connectionInfo = generateConnectionInfoFromCliArgs({
             ...this.userConfig,
             connectionSpecifier: this.userConfig.connectionString,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -63,6 +63,7 @@ export {
     ConnectionManager,
     MCPConnectionManager,
     ConnectionStateConnected,
+    buildServiceProvider,
     type AnyConnectionState,
     type ConnectionState,
     type ConnectionStateConnecting,
@@ -73,7 +74,15 @@ export {
     type ConnectionManagerEvents,
     type ConnectionTag,
     type OIDCConnectionAuthType,
+    type BuildServiceProviderDeps,
+    type BuiltServiceProvider,
 } from "./common/connectionManager.js";
+export {
+    ConnectionRegistry,
+    resolveDefaultConnectionName,
+    type ConnectionRegistryOptions,
+    type ConnectionRegistryEntryStatus,
+} from "./common/connectionRegistry.js";
 export {
     connectionErrorHandler,
     type ConnectionErrorHandler,

--- a/src/tools/mongodb/connect/listConnections.ts
+++ b/src/tools/mongodb/connect/listConnections.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { MongoDBToolBase } from "../mongodbTool.js";
+import type { OperationType, ToolResult } from "../../tool.js";
+import { formatUntrustedData } from "../../tool.js";
+
+export const ListConnectionsOutputSchema = {
+    connections: z.array(
+        z.object({
+            name: z.string(),
+            isDefault: z.boolean(),
+            status: z.enum(["idle", "connecting", "connected", "errored"]),
+        })
+    ),
+    totalCount: z.number(),
+};
+
+export type ListConnectionsOutput = z.infer<z.ZodObject<typeof ListConnectionsOutputSchema>>;
+
+export class ListConnectionsTool extends MongoDBToolBase {
+    static toolName = "list-connections";
+    public description =
+        "List the pre-configured named MongoDB connections available for the optional 'connection' argument on data tools, including which one is the session default and each connection's current status.";
+    public argsShape = {};
+    public override outputSchema = ListConnectionsOutputSchema;
+    static operationType: OperationType = "metadata";
+
+    protected execute(): Promise<ToolResult<typeof this.outputSchema>> {
+        const registry = this.session.connectionRegistry;
+        const defaultName = registry.defaultName;
+        const connections = registry.names().map((name) => ({
+            name,
+            isDefault: name === defaultName,
+            status: registry.statusOf(name) ?? ("idle" as const),
+        }));
+
+        return Promise.resolve({
+            content: formatUntrustedData(
+                `Found ${connections.length} configured connection(s).`,
+                JSON.stringify(connections)
+            ),
+            structuredContent: {
+                connections,
+                totalCount: connections.length,
+            },
+        });
+    }
+}

--- a/src/tools/mongodb/connect/switchConnection.ts
+++ b/src/tools/mongodb/connect/switchConnection.ts
@@ -4,6 +4,7 @@ import { type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { MongoDBToolBase } from "../mongodbTool.js";
 import { type ToolArgs, type OperationType, type ToolConstructorParams } from "../../tool.js";
 import type { Server } from "../../../server.js";
+import { ErrorCodes, MongoDBError } from "../../../common/errors.js";
 
 export class SwitchConnectionTool extends MongoDBToolBase {
     static toolName = "switch-connection";
@@ -16,6 +17,12 @@ export class SwitchConnectionTool extends MongoDBToolBase {
             .optional()
             .describe(
                 "MongoDB connection string to switch to (in the mongodb:// or mongodb+srv:// format). If a connection string is not provided, the connection string from the config will be used."
+            ),
+        connection: z
+            .string()
+            .optional()
+            .describe(
+                "Name of a pre-configured connection (see the list-connections tool) to switch the session default to. Takes precedence over connectionString when both are provided."
             ),
     };
 
@@ -44,11 +51,28 @@ export class SwitchConnectionTool extends MongoDBToolBase {
         return registrationSuccessful;
     }
 
-    protected override async execute({ connectionString }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
-        if (typeof connectionString !== "string") {
-            await this.session.connectToConfiguredConnection();
-        } else {
+    protected override async execute({
+        connectionString,
+        connection,
+    }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
+        if (typeof connection === "string") {
+            // Point the session-default slot at a named connection's settings.
+            const settings = this.session.connectionRegistry.getSettings(connection);
+            if (!settings) {
+                const available = this.session.connectionRegistry
+                    .names()
+                    .map((name) => `"${name}"`)
+                    .join(", ");
+                throw new MongoDBError(
+                    ErrorCodes.NamedConnectionNotFound,
+                    `Connection "${connection}" is not configured. Available connections: ${available || "none"}.`
+                );
+            }
+            await this.session.connectToMongoDB(settings);
+        } else if (typeof connectionString === "string") {
             await this.session.connectToMongoDB({ connectionString });
+        } else {
+            await this.session.connectToConfiguredConnection();
         }
 
         return {

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -1,5 +1,6 @@
+import { AsyncLocalStorage } from "async_hooks";
 import { z } from "zod";
-import type { OperationType, ToolArgs, ToolCategory } from "../tool.js";
+import type { OperationType, ToolArgs, ToolCategory, ToolExecutionContext } from "../tool.js";
 import { ToolBase } from "../tool.js";
 import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -11,6 +12,12 @@ import { assertNoServerSideJS, isWriteStage } from "../../helpers/mqlGuards.js";
 
 export const DBOperationArgs = {
     database: z.string().describe("Database name"),
+    connection: z
+        .string()
+        .optional()
+        .describe(
+            "Name of a pre-configured connection (see the list-connections tool) to run this operation against. When omitted, the active/default connection is used."
+        ),
 };
 
 export const CollOperationArgs = {
@@ -18,11 +25,56 @@ export const CollOperationArgs = {
     collection: z.string().describe("Collection name"),
 };
 
+/**
+ * Per-call storage for the requested named `connection`. Threaded through
+ * {@link AsyncLocalStorage} rather than instance state because tool instances
+ * are per-session singletons reused across concurrent, pipelined calls — so the
+ * requested name must not be stashed on `this`. ALS propagates across every
+ * `await` within a single call chain while staying isolated per async call.
+ */
+interface ConnectionArgStore {
+    connectionName?: string;
+}
+
+const connectionArgStore = new AsyncLocalStorage<ConnectionArgStore>();
+
+function extractConnectionName(args: unknown): string | undefined {
+    if (args && typeof args === "object" && "connection" in args) {
+        const value = (args as { connection?: unknown }).connection;
+        if (typeof value === "string" && value.length > 0) {
+            return value;
+        }
+    }
+    return undefined;
+}
+
 export abstract class MongoDBToolBase extends ToolBase {
     protected server?: Server;
     static category: ToolCategory = "mongodb";
 
+    /**
+     * Wraps the base tool invocation so the per-call `connection` argument is
+     * available (via {@link AsyncLocalStorage}) to {@link ensureConnected}
+     * throughout the entire async call chain, without stashing it on `this`.
+     */
+    public override invoke(
+        args: ToolArgs<typeof this.argsShape>,
+        context: ToolExecutionContext
+    ): Promise<CallToolResult> {
+        const connectionName = extractConnectionName(args);
+        return connectionArgStore.run({ connectionName }, () => super.invoke(args, context));
+    }
+
     protected async ensureConnected(): Promise<NodeDriverServiceProvider> {
+        // When a named connection is supplied, resolve it from the registry on
+        // its own dedicated provider without ever touching the session-default
+        // slot. Failures here throw NamedConnection* errors, which deliberately
+        // bypass the session-default connection recovery handler.
+        const connectionName = connectionArgStore.getStore()?.connectionName;
+        if (connectionName) {
+            return this.session.connectionRegistry.resolve(connectionName);
+        }
+
         if (!this.session.isConnectedToMongoDB) {
             if (this.session.connectedAtlasCluster) {
                 throw new MongoDBError(

--- a/src/tools/mongodb/tools.ts
+++ b/src/tools/mongodb/tools.ts
@@ -22,3 +22,4 @@ export { LogsTool, type LogsOutput } from "./metadata/logs.js";
 export { ExportTool } from "./read/export.js";
 export { DropIndexTool, type DropIndexOutput } from "./delete/dropIndex.js";
 export { SwitchConnectionTool } from "./connect/switchConnection.js";
+export { ListConnectionsTool, type ListConnectionsOutput } from "./connect/listConnections.js";

--- a/src/transports/base.ts
+++ b/src/transports/base.ts
@@ -10,6 +10,7 @@ import { ExportsManager } from "../common/exportsManager.js";
 import { DeviceId } from "../helpers/deviceId.js";
 import { Keychain } from "../common/keychain.js";
 import { defaultCreateConnectionManager, type ConnectionManagerFactoryFn } from "../common/connectionManager.js";
+import { ConnectionRegistry, resolveDefaultConnectionName } from "../common/connectionRegistry.js";
 import {
     type ConnectionErrorHandler,
     connectionErrorHandler as defaultConnectionErrorHandler,
@@ -302,6 +303,19 @@ export abstract class TransportRunnerBase<
             sessionOptions?.connectionManager ??
             (await this.createConnectionManager({ logger: logger, deviceId: this.deviceId, userConfig }));
 
+        // One registry per Session, so named-connection pools are isolated per
+        // `mcp-session-id` just like the single-slot connection manager. The
+        // client name is read lazily from the connection manager (set once the
+        // MCP client initialises the session).
+        const connectionRegistry = new ConnectionRegistry({
+            userConfig,
+            deviceId: this.deviceId,
+            logger,
+            getClientName: () => connectionManager.clientName,
+            connections: userConfig.connections,
+            defaultConnectionName: resolveDefaultConnectionName(userConfig),
+        });
+
         const { apiClientId, apiClientSecret } = userConfig;
         const apiClientOptions: ApiClientOptions = {
             baseUrl: userConfig.apiBaseUrl,
@@ -323,6 +337,7 @@ export abstract class TransportRunnerBase<
             connectionErrorHandler: sessionOptions?.connectionErrorHandler ?? this.connectionErrorHandler,
             exportsManager,
             connectionManager,
+            connectionRegistry,
             keychain: Keychain.root,
             apiClient: sessionOptions?.apiClient ?? apiClient,
         });

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -11,6 +11,7 @@ import { ResourceUpdatedNotificationSchema } from "@modelcontextprotocol/sdk/typ
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { ConnectionManager, ConnectionState } from "../../src/common/connectionManager.js";
 import { MCPConnectionManager } from "../../src/common/connectionManager.js";
+import { ConnectionRegistry, resolveDefaultConnectionName } from "../../src/common/connectionRegistry.js";
 import { DeviceId } from "../../src/helpers/deviceId.js";
 import { connectionErrorHandler } from "../../src/common/connectionErrorHandler.js";
 import { Keychain } from "../../src/common/keychain.js";
@@ -99,12 +100,21 @@ export function setupIntegrationTest(
 
         deviceId = DeviceId.create(logger);
         const connectionManager = new MCPConnectionManager(userConfig, logger, deviceId);
+        const connectionRegistry = new ConnectionRegistry({
+            userConfig,
+            deviceId,
+            logger,
+            getClientName: () => connectionManager.clientName,
+            connections: userConfig.connections,
+            defaultConnectionName: resolveDefaultConnectionName(userConfig),
+        });
 
         const session = new Session({
             userConfig,
             logger,
             exportsManager,
             connectionManager,
+            connectionRegistry,
             keychain: new Keychain(),
             connectionErrorHandler,
             atlasLocalClient: await defaultCreateAtlasLocalClient({ logger }),

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -1,4 +1,5 @@
 import { MCPConnectionManager } from "../../src/common/connectionManager.js";
+import { ConnectionRegistry, resolveDefaultConnectionName } from "../../src/common/connectionRegistry.js";
 import { ExportsManager } from "../../src/common/exportsManager.js";
 import { CompositeLogger } from "../../src/common/logging/index.js";
 import { DeviceId } from "../../src/helpers/deviceId.js";
@@ -179,12 +180,21 @@ describe("Server integration test", () => {
         const logger = new CompositeLogger(...loggers);
         const deviceId = DeviceId.create(logger);
         const connectionManager = new MCPConnectionManager(config, logger, deviceId);
+        const connectionRegistry = new ConnectionRegistry({
+            userConfig: config,
+            deviceId,
+            logger,
+            getClientName: () => connectionManager.clientName,
+            connections: config.connections,
+            defaultConnectionName: resolveDefaultConnectionName(config),
+        });
         const exportsManager = ExportsManager.init(config, logger);
         const session = new Session({
             userConfig: config,
             logger,
             exportsManager,
             connectionManager,
+            connectionRegistry,
             keychain: Keychain.root,
             connectionErrorHandler,
             atlasLocalClient: await defaultCreateAtlasLocalClient({ logger }),

--- a/tests/integration/tools/mongodb/mongodbTool.test.ts
+++ b/tests/integration/tools/mongodb/mongodbTool.test.ts
@@ -6,6 +6,7 @@ import { MongoDBToolBase } from "../../../../src/tools/mongodb/mongodbTool.js";
 import { type OperationType, type ToolClass } from "../../../../src/tools/tool.js";
 import { type UserConfig } from "../../../../src/common/config/userConfig.js";
 import { MCPConnectionManager } from "../../../../src/common/connectionManager.js";
+import { ConnectionRegistry, resolveDefaultConnectionName } from "../../../../src/common/connectionRegistry.js";
 import { Session } from "../../../../src/common/session.js";
 import { CompositeLogger } from "../../../../src/common/logging/index.js";
 import { DeviceId } from "../../../../src/helpers/deviceId.js";
@@ -98,11 +99,20 @@ describe("MongoDBTool implementations", () => {
         const exportsManager = ExportsManager.init(userConfig, logger);
         deviceId = DeviceId.create(logger);
         const connectionManager = new MCPConnectionManager(userConfig, logger, deviceId);
+        const connectionRegistry = new ConnectionRegistry({
+            userConfig,
+            deviceId,
+            logger,
+            getClientName: () => connectionManager.clientName,
+            connections: userConfig.connections,
+            defaultConnectionName: resolveDefaultConnectionName(userConfig),
+        });
         const session = new Session({
             userConfig,
             logger,
             exportsManager,
             connectionManager,
+            connectionRegistry,
             keychain: new Keychain(),
             connectionErrorHandler: errorHandler,
             apiClient: defaultCreateApiClient(

--- a/tests/integration/ui/mcpUIFeature.test.ts
+++ b/tests/integration/ui/mcpUIFeature.test.ts
@@ -7,6 +7,7 @@ import { Session } from "../../../src/common/session.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Server } from "../../../src/server.js";
 import { MCPConnectionManager } from "../../../src/common/connectionManager.js";
+import { ConnectionRegistry, resolveDefaultConnectionName } from "../../../src/common/connectionRegistry.js";
 import { DeviceId } from "../../../src/helpers/deviceId.js";
 import { connectionErrorHandler } from "../../../src/common/connectionErrorHandler.js";
 import { Keychain } from "../../../src/common/keychain.js";
@@ -173,6 +174,14 @@ describe("mcpUI feature with custom UIs", () => {
         const logger = new CompositeLogger();
         const deviceId = DeviceId.create(logger);
         const connectionManager = new MCPConnectionManager(userConfig, logger, deviceId);
+        const connectionRegistry = new ConnectionRegistry({
+            userConfig,
+            deviceId,
+            logger,
+            getClientName: () => connectionManager.clientName,
+            connections: userConfig.connections,
+            defaultConnectionName: resolveDefaultConnectionName(userConfig),
+        });
         const exportsManager = ExportsManager.init(userConfig, logger);
 
         const session = new Session({
@@ -180,6 +189,7 @@ describe("mcpUI feature with custom UIs", () => {
             logger,
             exportsManager,
             connectionManager,
+            connectionRegistry,
             keychain: Keychain.root,
             connectionErrorHandler,
             atlasLocalClient: await defaultCreateAtlasLocalClient({ logger }),

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -51,6 +51,7 @@ const expectedDefaults = {
     maxBytesPerQuery: 16 * 1024 * 1024, // ~16 mb
     atlasTemporaryDatabaseUserLifetimeMs: 4 * 60 * 60 * 1000, // 4 hours
     voyageApiKey: "",
+    connections: {},
     previewFeatures: [],
     dryRun: false,
     allowRequestOverrides: false,
@@ -220,7 +221,12 @@ describe("config", () => {
                 },
                 {
                     cli: ["--connectionString", "mongodb://localhost"],
-                    expected: { connectionString: "mongodb://localhost" },
+                    // A legacy connectionString is folded into the named-connection
+                    // map as the reserved "default" entry (see parseUserConfig).
+                    expected: {
+                        connectionString: "mongodb://localhost",
+                        connections: { default: { connectionString: "mongodb://localhost" } },
+                    },
                 },
                 {
                     cli: ["--httpHost", "mongodb://localhost"],
@@ -907,7 +913,12 @@ describe("keychain management", () => {
 
     const secretsFromSchema = Object.keys(UserConfigSchema.shape).filter((key) => {
         const meta = getConfigMeta(key as keyof UserConfig);
-        return meta?.isSecret === true;
+        // `connections` is a JSON-object secret: its secret values are the nested
+        // connection strings (registered individually), not the field's raw
+        // scalar value, and its input must be valid JSON. It therefore can't be
+        // exercised by the "pass the field name as the value" loop below and has
+        // a dedicated test instead.
+        return meta?.isSecret === true && key !== "connections";
     });
 
     for (const secretKey of secretsFromSchema) {
@@ -918,6 +929,14 @@ describe("keychain management", () => {
             expect(registeredSecret).toBeDefined();
         });
     }
+
+    it("should register each connection string in MDB_MCP_CONNECTIONS as a secret in the root keychain", () => {
+        parseUserConfig({ args: ["--connections", '{"analytics":"mongodb://sekret-host/db"}'] });
+
+        const registeredSecret = keychain.allSecrets.find((s) => s.value === "mongodb://sekret-host/db");
+        expect(registeredSecret).toBeDefined();
+        expect(registeredSecret?.kind).toBe("mongodb uri");
+    });
 });
 
 describe("custom override logic functions", () => {

--- a/tests/unit/common/session.test.ts
+++ b/tests/unit/common/session.test.ts
@@ -5,6 +5,7 @@ import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver
 import { Session } from "../../../src/common/session.js";
 import { CompositeLogger } from "../../../src/common/logging/index.js";
 import { MCPConnectionManager } from "../../../src/common/connectionManager.js";
+import { ConnectionRegistry, resolveDefaultConnectionName } from "../../../src/common/connectionRegistry.js";
 import { ExportsManager } from "../../../src/common/exportsManager.js";
 import { DeviceId } from "../../../src/helpers/deviceId.js";
 import { Keychain } from "../../../src/common/keychain.js";
@@ -27,6 +28,14 @@ describe("Session", () => {
 
         mockDeviceId = MockDeviceId;
         const connectionManager = new MCPConnectionManager(defaultTestConfig, logger, mockDeviceId);
+        const connectionRegistry = new ConnectionRegistry({
+            userConfig: defaultTestConfig,
+            deviceId: mockDeviceId,
+            logger,
+            getClientName: () => connectionManager.clientName,
+            connections: defaultTestConfig.connections,
+            defaultConnectionName: resolveDefaultConnectionName(defaultTestConfig),
+        });
 
         session = new Session({
             userConfig: {
@@ -37,6 +46,7 @@ describe("Session", () => {
             logger,
             exportsManager: ExportsManager.init(defaultTestConfig, logger),
             connectionManager: connectionManager,
+            connectionRegistry,
             keychain: new Keychain(),
             apiClient: defaultCreateApiClient(
                 {

--- a/tests/unit/resources/common/debug.test.ts
+++ b/tests/unit/resources/common/debug.test.ts
@@ -3,6 +3,7 @@ import { DebugResource } from "../../../../src/resources/common/debug.js";
 import { Session } from "../../../../src/common/session.js";
 import { CompositeLogger } from "../../../../src/common/logging/index.js";
 import { MCPConnectionManager } from "../../../../src/common/connectionManager.js";
+import { ConnectionRegistry, resolveDefaultConnectionName } from "../../../../src/common/connectionRegistry.js";
 import { ExportsManager } from "../../../../src/common/exportsManager.js";
 import { DeviceId } from "../../../../src/helpers/deviceId.js";
 import { Keychain } from "../../../../src/common/keychain.js";
@@ -14,6 +15,14 @@ describe("debug resource", () => {
     const logger = new CompositeLogger();
     const deviceId = DeviceId.create(logger);
     const connectionManager = new MCPConnectionManager(defaultTestConfig, logger, deviceId);
+    const connectionRegistry = new ConnectionRegistry({
+        userConfig: defaultTestConfig,
+        deviceId,
+        logger,
+        getClientName: () => connectionManager.clientName,
+        connections: defaultTestConfig.connections,
+        defaultConnectionName: resolveDefaultConnectionName(defaultTestConfig),
+    });
 
     const session = vi.mocked(
         new Session({
@@ -21,6 +30,7 @@ describe("debug resource", () => {
             logger,
             exportsManager: ExportsManager.init(defaultTestConfig, logger),
             connectionManager,
+            connectionRegistry,
             keychain: new Keychain(),
             connectionErrorHandler,
             apiClient: defaultCreateApiClient(

--- a/tests/unit/tools/mongodb/multiConnectionBehavior.test.ts
+++ b/tests/unit/tools/mongodb/multiConnectionBehavior.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Focused unit tests for the per-call `connection` argument added by the
+ * multi-connection feature (src/common/connectionRegistry.ts +
+ * src/tools/mongodb/mongodbTool.ts).
+ *
+ * These tests exercise the real production wiring (MongoDBToolBase.invoke,
+ * Session, MCPConnectionManager, ConnectionRegistry) end to end. The only
+ * seam that is mocked is the deepest driver call,
+ * `NodeDriverServiceProvider.connect`, exactly like
+ * `tests/unit/common/session.test.ts` already does — so no real MongoDB
+ * process or network access is required.
+ *
+ * Proves:
+ *  (a) Backward compat — a single MDB_MCP_CONNECTION_STRING (config.connectionString)
+ *      still works when a tool call carries no `connection` argument.
+ *  (b) A per-call `connection` argument selects the named connection from the
+ *      registry, without ever touching the session-default connection.
+ *  (c) Two different `connection` values in interleaved (overlapping)
+ *      concurrent calls do not cross state — each call observes only its own
+ *      requested connection's provider, regardless of resolution order.
+ */
+import type { Mocked } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { MongoDBToolBase } from "../../../../src/tools/mongodb/mongodbTool.js";
+import type { OperationType, ToolArgs, ToolCategory, ToolExecutionContext } from "../../../../src/tools/tool.js";
+import type { TelemetryToolMetadata } from "../../../../src/telemetry/types.js";
+import type { UserConfig } from "../../../../src/common/config/userConfig.js";
+import { MCPConnectionManager } from "../../../../src/common/connectionManager.js";
+import { ConnectionRegistry, resolveDefaultConnectionName } from "../../../../src/common/connectionRegistry.js";
+import { Session } from "../../../../src/common/session.js";
+import { CompositeLogger } from "../../../../src/common/logging/index.js";
+import { DeviceId } from "../../../../src/helpers/deviceId.js";
+import { ExportsManager } from "../../../../src/common/exportsManager.js";
+import { Keychain } from "../../../../src/common/keychain.js";
+import { connectionErrorHandler } from "../../../../src/common/connectionErrorHandler.js";
+import { defaultCreateApiClient } from "../../../../src/lib.js";
+import { defaultTestConfig } from "../../../integration/helpers.js";
+import { MockMetrics } from "../../mocks/metrics.js";
+
+vi.mock("@mongosh/service-provider-node-driver");
+
+const MockNodeDriverServiceProvider = vi.mocked(NodeDriverServiceProvider);
+
+/** A fake connected provider, tagged with the connection string it was "opened" against. */
+interface FakeProvider {
+    _tag: string;
+    close: () => Promise<void>;
+}
+
+function makeFakeProvider(tag: string): FakeProvider {
+    return { _tag: tag, close: vi.fn().mockResolvedValue(undefined) };
+}
+
+/** Resolves a deferred promise from outside its executor. */
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+/**
+ * Minimal MongoDBToolBase implementation used purely to drive `ensureConnected()`
+ * (and, through it, the `connection` argument resolution) via the real
+ * `invoke()` override in MongoDBToolBase. The tool reports back which
+ * provider it ended up talking to via the fake provider's `_tag`.
+ */
+class ProbeTool extends MongoDBToolBase {
+    static toolName = "probe-tool";
+    static category: ToolCategory = "mongodb";
+    static operationType: OperationType = "read";
+    public description = "Reports which connection it resolved to.";
+    public argsShape = {
+        connection: z.string().optional().describe("Name of a pre-configured connection to use for this call."),
+    };
+
+    protected async execute(): Promise<CallToolResult> {
+        const provider = await this.ensureConnected();
+        const tag = (provider as unknown as FakeProvider)._tag;
+        return { content: [{ type: "text", text: tag }] };
+    }
+
+    protected resolveTelemetryMetadata(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _args: ToolArgs<typeof this.argsShape>,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _extra: { result: CallToolResult }
+    ): TelemetryToolMetadata {
+        return {};
+    }
+}
+
+function resultText(result: CallToolResult): string {
+    const first = result.content[0];
+    if (!first || first.type !== "text") {
+        throw new Error(`Expected a text content block, got: ${JSON.stringify(result)}`);
+    }
+    return first.text;
+}
+
+function newContext(): ToolExecutionContext {
+    return { signal: new AbortController().signal };
+}
+
+describe("MongoDBToolBase multi-connection behavior (connection argument)", () => {
+    let mockDeviceId: Mocked<DeviceId>;
+    let logger: CompositeLogger;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        logger = new CompositeLogger();
+        mockDeviceId = vi.mocked(DeviceId.create(logger));
+        mockDeviceId.get = vi.fn().mockResolvedValue("test-device-id");
+    });
+
+    /** Builds a real Session (real ConnectionManager + real ConnectionRegistry) for the given config. */
+    function buildSession(config: UserConfig): Session {
+        const connectionManager = new MCPConnectionManager(config, logger, mockDeviceId);
+        const connectionRegistry = new ConnectionRegistry({
+            userConfig: config,
+            deviceId: mockDeviceId,
+            logger,
+            getClientName: () => connectionManager.clientName,
+            connections: config.connections,
+            defaultConnectionName: resolveDefaultConnectionName(config),
+        });
+
+        return new Session({
+            userConfig: config,
+            logger,
+            exportsManager: ExportsManager.init(config, logger),
+            connectionManager,
+            connectionRegistry,
+            keychain: new Keychain(),
+            apiClient: defaultCreateApiClient(
+                { baseUrl: config.apiBaseUrl, credentials: undefined },
+                logger
+            ),
+            connectionErrorHandler,
+        });
+    }
+
+    function buildProbeTool(session: Session, config: UserConfig): ProbeTool {
+        return new ProbeTool({
+            name: ProbeTool.toolName,
+            category: ProbeTool.category,
+            operationType: ProbeTool.operationType,
+            session,
+            config,
+            telemetry: { isTelemetryEnabled: () => false, emitEvents: vi.fn() } as never,
+            elicitation: { requestConfirmation: vi.fn() } as never,
+            metrics: new MockMetrics(),
+        });
+    }
+
+    it("(a) backward compat: a single connectionString still works with no 'connection' arg", async () => {
+        MockNodeDriverServiceProvider.connect = vi
+            .fn()
+            .mockImplementation((connectionString: string) => Promise.resolve(makeFakeProvider("legacy")));
+
+        const config: UserConfig = {
+            ...defaultTestConfig,
+            connectionString: "mongodb://legacy-host/db",
+        };
+        const session = buildSession(config);
+        const tool = buildProbeTool(session, config);
+
+        const result = await tool.invoke({} as ToolArgs<typeof tool.argsShape>, newContext());
+
+        expect(result.isError).toBeFalsy();
+        expect(resultText(result)).toBe("legacy");
+
+        // The legacy connection string was used to establish the session-default connection.
+        expect(MockNodeDriverServiceProvider.connect).toHaveBeenCalledTimes(1);
+        const usedConnectionString = MockNodeDriverServiceProvider.connect.mock.calls[0]?.[0];
+        expect(usedConnectionString).toContain("legacy-host");
+
+        // The registry never had (and never gained) any named entries — this really is
+        // the legacy single-connection path, not the registry.
+        expect(session.connectionRegistry.names()).toEqual([]);
+        expect(session.isConnectedToMongoDB).toBe(true);
+    });
+
+    it("(b) a per-call 'connection' arg selects the named connection without touching the session default", async () => {
+        MockNodeDriverServiceProvider.connect = vi.fn().mockImplementation((connectionString: string) => {
+            if (connectionString.includes("analytics-host")) {
+                return Promise.resolve(makeFakeProvider("analytics"));
+            }
+            if (connectionString.includes("legacy-host")) {
+                return Promise.resolve(makeFakeProvider("legacy"));
+            }
+            return Promise.reject(new Error(`unexpected connection string: ${connectionString}`));
+        });
+
+        const config: UserConfig = {
+            ...defaultTestConfig,
+            // A legacy default IS configured, to prove it is not the one used.
+            connectionString: "mongodb://legacy-host/db",
+            connections: {
+                analytics: { connectionString: "mongodb://analytics-host/db" },
+            },
+        };
+        const session = buildSession(config);
+        const tool = buildProbeTool(session, config);
+
+        const result = await tool.invoke(
+            { connection: "analytics" } as ToolArgs<typeof tool.argsShape>,
+            newContext()
+        );
+
+        expect(result.isError).toBeFalsy();
+        expect(resultText(result)).toBe("analytics");
+
+        // Only the named connection was dialed — the legacy default was never connected.
+        expect(MockNodeDriverServiceProvider.connect).toHaveBeenCalledTimes(1);
+        const usedConnectionString = MockNodeDriverServiceProvider.connect.mock.calls[0]?.[0];
+        expect(usedConnectionString).toContain("analytics-host");
+
+        expect(session.connectionRegistry.statusOf("analytics")).toBe("connected");
+        // The session-default connection manager was never engaged.
+        expect(session.isConnectedToMongoDB).toBe(false);
+    });
+
+    it("(c) two different 'connection' values in interleaved calls do not cross state", async () => {
+        const alphaGate = createDeferred<void>();
+        const betaGate = createDeferred<void>();
+        const connectOrder: string[] = [];
+
+        MockNodeDriverServiceProvider.connect = vi.fn().mockImplementation(async (connectionString: string) => {
+            if (connectionString.includes("alpha-host")) {
+                connectOrder.push("alpha-start");
+                await alphaGate.promise;
+                connectOrder.push("alpha-end");
+                return makeFakeProvider("alpha");
+            }
+            if (connectionString.includes("beta-host")) {
+                connectOrder.push("beta-start");
+                await betaGate.promise;
+                connectOrder.push("beta-end");
+                return makeFakeProvider("beta");
+            }
+            throw new Error(`unexpected connection string: ${connectionString}`);
+        });
+
+        const config: UserConfig = {
+            ...defaultTestConfig,
+            // No legacy connectionString at all: both calls must go through named connections.
+            connections: {
+                alpha: { connectionString: "mongodb://alpha-host/db" },
+                beta: { connectionString: "mongodb://beta-host/db" },
+            },
+        };
+        const session = buildSession(config);
+        const tool = buildProbeTool(session, config);
+
+        // Kick off BOTH calls without awaiting - they both pause inside the
+        // mocked `connect()`, holding two independent AsyncLocalStorage
+        // contexts (one per `invoke()` call) simultaneously in flight.
+        const callAlpha = tool.invoke({ connection: "alpha" } as ToolArgs<typeof tool.argsShape>, newContext());
+        const callBeta = tool.invoke({ connection: "beta" } as ToolArgs<typeof tool.argsShape>, newContext());
+
+        // Let both reach their gate before releasing either.
+        await vi.waitFor(() => {
+            expect(connectOrder).toContain("alpha-start");
+            expect(connectOrder).toContain("beta-start");
+        });
+
+        // Resolve BETA first even though ALPHA was requested first - if the
+        // per-call connection name ever leaked through shared/instance state
+        // instead of staying scoped to its own call via AsyncLocalStorage,
+        // finishing beta before alpha would surface the wrong tag on one of them.
+        betaGate.resolve();
+        const betaResult = await callBeta;
+        alphaGate.resolve();
+        const alphaResult = await callAlpha;
+
+        expect(resultText(betaResult)).toBe("beta");
+        expect(resultText(alphaResult)).toBe("alpha");
+
+        // Confirms genuine interleaving happened (beta finished while alpha was still pending).
+        expect(connectOrder).toEqual(["alpha-start", "beta-start", "beta-end", "alpha-end"]);
+
+        expect(MockNodeDriverServiceProvider.connect).toHaveBeenCalledTimes(2);
+        expect(session.connectionRegistry.statusOf("alpha")).toBe("connected");
+        expect(session.connectionRegistry.statusOf("beta")).toBe("connected");
+        // Neither call touched the session-default slot.
+        expect(session.isConnectedToMongoDB).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Adds **multi-connection support** to the MongoDB MCP server so a single server/session can address more than one MongoDB target:

- **Named connections** configured via a new `MDB_MCP_CONNECTIONS` config value — a JSON object mapping a connection name to a target, e.g. `{"analytics":"mongodb://…","reporting":{"connectionString":"mongodb://…"}}` (both the string shorthand and the `{ connectionString }` object form are accepted).
- **Optional per-call `connection` argument** on data tools (via `DBOperationArgs`) that selects which named connection an individual tool call runs against. When omitted, the active/session-default connection is used exactly as before. The per-call name is threaded through `AsyncLocalStorage`, so concurrent/pipelined calls on the shared per-session tool instances never cross state.
- A **`list-connections`** tool to enumerate configured connections.
- **Backward compatible:** the existing single `MDB_MCP_CONNECTION_STRING` continues to work with no `connection` argument, and is folded in as the reserved `"default"` entry.

Each named connection is a lazy, per-session keyed pool of service providers (`connectionRegistry.ts`) that coexists with — and never mutates — the single-slot session-default connection, which keeps a single session safe to share behind a gateway.

### Note: config arg-parser fix included

The `connections` field is expressed as a **catchall object** rather than a `z.record`. The mongosh arg-parser introspects the config schema to build CLI/env options and throws `Unknown field type: ZodRecord`, which (silently) breaks **all** CLI/env config parsing when a `record` field is present. A catchall object is handled the same way as the existing `httpHeaders` field (`coerceObject`), so the whole config-parsing path stays healthy.

This is **Phase 1**: named connections for direct (`connectionString`) targets, with per-call selection on the data tools.

## Deferred (Phase 2 / follow-ups)

- [ ] Metadata tools (`list-databases`, `mongodb-logs`) do not yet accept the per-call `connection` argument.
- [ ] Telemetry still reports the session-default connection (per-call named-connection attribution is not wired).
- [ ] Atlas-typed named connections are deferred to Phase 2 (`connectCluster.ts` is untouched — named connections are direct connection strings only).
- [ ] OIDC device-flow UX for named connections is unwired.
- [ ] `pnpm run update:api` (the api-extractor report) has not been regenerated.

## Testing

- `pnpm run check:types` — clean.
- `pnpm build` — clean.
- Full unit suite green (`vitest run --project unit-and-integration tests/unit`): **960 passed**.
- Adds a permanent unit test (`tests/unit/tools/mongodb/multiConnectionBehavior.test.ts`) proving: (a) backward compat with a single `connectionString`, (b) per-call `connection` selects the correct named connection without touching the session default, and (c) two interleaved `connection` values do not cross state.
- Integration tests were not run here (they require a live Atlas/mongod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
