### PR TITLE
fix(mongodb-atlas-mcp-remote): add missing OAuth base URL mapping for staging

### DIFF
--- a/packages/mongodb-atlas-mcp-remote/src/config.test.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/config.test.ts
@@ -67,7 +67,7 @@ describe("loadConfig", () => {
             ["https://mcp.mongodb.com", "https://cloud.mongodb.com"],
             ["https://mcp-dev.mongodb.com", "https://cloud-dev.mongodb.com"],
             ["https://mcp-qa.mongodb.com", "https://cloud-qa.mongodb.com"],
-            ["https://mcp-staging.mongodb.com", "https://authorize-staging.mongodb.com"],
+            ["https://mcp-staging.mongodb.com", "https://cloud-stage.mongodb.com"],
         ])("maps known MCP base URL %s to its OAuth base URL %s", (mcpBaseUrl, oauthBaseUrl) => {
             stubSA();
             vi.stubEnv("MDB_MCP_API_BASE_URL", mcpBaseUrl);
@@ -83,7 +83,7 @@ describe("loadConfig", () => {
             vi.stubEnv("MDB_MCP_API_BASE_URL", "https://mcp-staging.mongodb.com/");
             expect(loadConfig()).toEqual({
                 ...DEFAULT_CONFIG,
-                tokenUrl: "https://authorize-staging.mongodb.com/api/oauth/token",
+                tokenUrl: "https://cloud-stage.mongodb.com/api/oauth/token",
                 remoteUrl: "https://mcp-staging.mongodb.com",
             });
         });

--- a/packages/mongodb-atlas-mcp-remote/src/config.test.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/config.test.ts
@@ -63,6 +63,31 @@ describe("loadConfig", () => {
             });
         });
 
+        it.each([
+            ["https://mcp.mongodb.com", "https://cloud.mongodb.com"],
+            ["https://mcp-dev.mongodb.com", "https://cloud-dev.mongodb.com"],
+            ["https://mcp-qa.mongodb.com", "https://cloud-qa.mongodb.com"],
+            ["https://mcp-staging.mongodb.com", "https://authorize-staging.mongodb.com"],
+        ])("maps known MCP base URL %s to its OAuth base URL %s", (mcpBaseUrl, oauthBaseUrl) => {
+            stubSA();
+            vi.stubEnv("MDB_MCP_API_BASE_URL", mcpBaseUrl);
+            expect(loadConfig()).toEqual({
+                ...DEFAULT_CONFIG,
+                tokenUrl: `${oauthBaseUrl}/api/oauth/token`,
+                remoteUrl: mcpBaseUrl,
+            });
+        });
+
+        it("strips a trailing slash from MDB_MCP_API_BASE_URL before matching known OAuth mappings", () => {
+            stubSA();
+            vi.stubEnv("MDB_MCP_API_BASE_URL", "https://mcp-staging.mongodb.com/");
+            expect(loadConfig()).toEqual({
+                ...DEFAULT_CONFIG,
+                tokenUrl: "https://authorize-staging.mongodb.com/api/oauth/token",
+                remoteUrl: "https://mcp-staging.mongodb.com",
+            });
+        });
+
         it("accepts valid MDB_MCP_TOKEN_TIMEOUT_MS", () => {
             stubSA();
             vi.stubEnv("MDB_MCP_TOKEN_TIMEOUT_MS", "5000");

--- a/packages/mongodb-atlas-mcp-remote/src/config.test.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/config.test.ts
@@ -63,31 +63,6 @@ describe("loadConfig", () => {
             });
         });
 
-        it.each([
-            ["https://mcp.mongodb.com", "https://cloud.mongodb.com"],
-            ["https://mcp-dev.mongodb.com", "https://cloud-dev.mongodb.com"],
-            ["https://mcp-qa.mongodb.com", "https://cloud-qa.mongodb.com"],
-            ["https://mcp-staging.mongodb.com", "https://cloud-stage.mongodb.com"],
-        ])("maps known MCP base URL %s to its OAuth base URL %s", (mcpBaseUrl, oauthBaseUrl) => {
-            stubSA();
-            vi.stubEnv("MDB_MCP_API_BASE_URL", mcpBaseUrl);
-            expect(loadConfig()).toEqual({
-                ...DEFAULT_CONFIG,
-                tokenUrl: `${oauthBaseUrl}/api/oauth/token`,
-                remoteUrl: mcpBaseUrl,
-            });
-        });
-
-        it("strips a trailing slash from MDB_MCP_API_BASE_URL before matching known OAuth mappings", () => {
-            stubSA();
-            vi.stubEnv("MDB_MCP_API_BASE_URL", "https://mcp-staging.mongodb.com/");
-            expect(loadConfig()).toEqual({
-                ...DEFAULT_CONFIG,
-                tokenUrl: "https://cloud-stage.mongodb.com/api/oauth/token",
-                remoteUrl: "https://mcp-staging.mongodb.com",
-            });
-        });
-
         it("accepts valid MDB_MCP_TOKEN_TIMEOUT_MS", () => {
             stubSA();
             vi.stubEnv("MDB_MCP_TOKEN_TIMEOUT_MS", "5000");

--- a/packages/mongodb-atlas-mcp-remote/src/config.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/config.ts
@@ -7,6 +7,7 @@ const MCP_BASE_URL_TO_OAUTH_BASE: Readonly<Record<string, string>> = {
     "https://mcp.mongodb.com": "https://cloud.mongodb.com",
     "https://mcp-dev.mongodb.com": "https://cloud-dev.mongodb.com",
     "https://mcp-qa.mongodb.com": "https://cloud-qa.mongodb.com",
+    "https://mcp-staging.mongodb.com": "https://authorize-staging.mongodb.com",
 };
 
 function loadPosIntEnvVar(name: string, defaultValue: number, errors: string[]): number {

--- a/packages/mongodb-atlas-mcp-remote/src/config.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/config.ts
@@ -7,7 +7,7 @@ const MCP_BASE_URL_TO_OAUTH_BASE: Readonly<Record<string, string>> = {
     "https://mcp.mongodb.com": "https://cloud.mongodb.com",
     "https://mcp-dev.mongodb.com": "https://cloud-dev.mongodb.com",
     "https://mcp-qa.mongodb.com": "https://cloud-qa.mongodb.com",
-    "https://mcp-staging.mongodb.com": "https://cloud-stage.mongodb.com",
+    "https://mcp-stage.mongodb.com": "https://cloud-stage.mongodb.com",
 };
 
 function loadPosIntEnvVar(name: string, defaultValue: number, errors: string[]): number {

--- a/packages/mongodb-atlas-mcp-remote/src/config.ts
+++ b/packages/mongodb-atlas-mcp-remote/src/config.ts
@@ -7,7 +7,7 @@ const MCP_BASE_URL_TO_OAUTH_BASE: Readonly<Record<string, string>> = {
     "https://mcp.mongodb.com": "https://cloud.mongodb.com",
     "https://mcp-dev.mongodb.com": "https://cloud-dev.mongodb.com",
     "https://mcp-qa.mongodb.com": "https://cloud-qa.mongodb.com",
-    "https://mcp-staging.mongodb.com": "https://authorize-staging.mongodb.com",
+    "https://mcp-staging.mongodb.com": "https://cloud-stage.mongodb.com",
 };
 
 function loadPosIntEnvVar(name: string, defaultValue: number, errors: string[]): number {


### PR DESCRIPTION
## Summary
* Updates the MCP staging URL
