### PR TITLE
fix: fix regressed search index creation eval cases CLOUDP-424118

### DIFF
--- a/src/tools/mongodb/create/createIndex.ts
+++ b/src/tools/mongodb/create/createIndex.ts
@@ -164,6 +164,7 @@ Use 'filter' for additional fields to filter on. At least one 'vector' or 'autoE
                         .object({
                             name: z
                                 .string()
+                                .min(1)
                                 .regex(
                                     /^(?!lucene\.|mongodb\.|builtin\.)/,
                                     "Custom analyzer names may not start with 'lucene.', 'mongodb.' or 'builtin.'"
@@ -247,7 +248,7 @@ Use 'filter' for additional fields to filter on. At least one 'vector' or 'autoE
             synonyms: z
                 .array(
                     z.object({
-                        name: z.string().describe("Unique name for this synonym mapping."),
+                        name: z.string().min(1).describe("Unique name for this synonym mapping."),
                         source: z
                             .object({
                                 collection: z
@@ -271,6 +272,7 @@ Use 'filter' for additional fields to filter on. At least one 'vector' or 'autoE
                     z.object({
                         name: z
                             .string()
+                            .min(1)
                             .describe("Unique name for this type set, referenced from `mappings.dynamic.typeSet`."),
                         types: z
                             .array(
@@ -288,6 +290,7 @@ Use 'filter' for additional fields to filter on. At least one 'vector' or 'autoE
                                     ]),
                                 })
                             )
+                            .min(1)
                             .describe("The field types that this type set allows dynamic mapping to index."),
                     })
                 )
@@ -351,10 +354,13 @@ Use 'filter' for additional fields to filter on. At least one 'vector' or 'autoE
                     z.boolean(),
                     z
                         .object({
-                            include: z.array(z.string()).optional(),
-                            exclude: z.array(z.string()).optional(),
+                            include: z.array(z.string()).min(1).optional(),
+                            exclude: z.array(z.string()).min(1).optional(),
                         })
-                        .strict(),
+                        .strict()
+                        .refine((data) => !!data.include || !!data.exclude, {
+                            message: "`storedSource` must specify a non-empty `include` or `exclude` array",
+                        }),
                 ])
                 .optional()
                 .describe(

--- a/src/tools/mongodb/create/createIndex.ts
+++ b/src/tools/mongodb/create/createIndex.ts
@@ -122,6 +122,32 @@ Use 'filter' for additional fields to filter on. At least one 'vector' or 'autoE
         })
         .describe("Definition for a Vector Search index.");
 
+    private searchFieldDefinitionSchema = z
+        .object({
+            type: z
+                .enum([
+                    "autocomplete",
+                    "boolean",
+                    "date",
+                    "dateFacet",
+                    "document",
+                    "embeddedDocuments",
+                    "geo",
+                    "number",
+                    "numberFacet",
+                    "objectId",
+                    "string",
+                    "stringFacet",
+                    "token",
+                    "uuid",
+                ])
+                .describe("The field type"),
+        })
+        .passthrough()
+        .describe(
+            "The field index definition. It must contain the field type, as well as any additional options for that field type."
+        );
+
     private atlasSearchIndexDefinition = z
         .object({
             type: z.literal("search"),
@@ -130,39 +156,176 @@ Use 'filter' for additional fields to filter on. At least one 'vector' or 'autoE
                 .optional()
                 .default("lucene.standard")
                 .describe(
-                    "The analyzer to use for the index. Can be one of the built-in lucene analyzers (`lucene.standard`, `lucene.simple`, `lucene.whitespace`, `lucene.keyword`), a language-specific analyzer, such as `lucene.cjk` or `lucene.czech`, or a custom analyzer defined in the Atlas UI."
+                    "The analyzer to use for the index. Can be one of the built-in lucene analyzers (`lucene.standard`, `lucene.simple`, `lucene.whitespace`, `lucene.keyword`), a language-specific analyzer, such as `lucene.cjk` or `lucene.czech`, or a custom analyzer defined by name in `analyzers`."
+                ),
+            analyzers: z
+                .array(
+                    z
+                        .object({
+                            name: z
+                                .string()
+                                .regex(
+                                    /^(?!lucene\.|mongodb\.|builtin\.)/,
+                                    "Custom analyzer names may not start with 'lucene.', 'mongodb.' or 'builtin.'"
+                                )
+                                .describe(
+                                    "Unique name for this custom analyzer. Reference it by name from a field's `analyzer` or `searchAnalyzer` option."
+                                ),
+                            charFilters: z
+                                .array(
+                                    z
+                                        .object({
+                                            type: z.enum(["htmlStrip", "icuNormalize", "mapping", "persian"]),
+                                        })
+                                        .passthrough()
+                                )
+                                .optional()
+                                .describe(
+                                    "Character filters applied to the text before tokenization, e.g. `{ type: 'htmlStrip' }` or `{ type: 'mapping', mappings: {...} }`."
+                                ),
+                            tokenizer: z
+                                .object({
+                                    type: z.enum([
+                                        "edgeGram",
+                                        "keyword",
+                                        "nGram",
+                                        "regexCaptureGroup",
+                                        "regexSplit",
+                                        "standard",
+                                        "uaxUrlEmail",
+                                        "whitespace",
+                                    ]),
+                                })
+                                .passthrough()
+                                .describe(
+                                    "Splits text into tokens, e.g. `{ type: 'standard' }`, `{ type: 'whitespace' }`, `{ type: 'keyword' }`, or `{ type: 'nGram', minGram: 2, maxGram: 3 }`."
+                                ),
+                            tokenFilters: z
+                                .array(
+                                    z
+                                        .object({
+                                            type: z.enum([
+                                                "asciiFolding",
+                                                "daitchMokotoffSoundex",
+                                                "edgeGram",
+                                                "englishMinimalStemming",
+                                                "englishPossessive",
+                                                "flattenGraph",
+                                                "icuFolding",
+                                                "icuNormalizer",
+                                                "keywordRepeat",
+                                                "kStemming",
+                                                "length",
+                                                "lowercase",
+                                                "nGram",
+                                                "porterStemming",
+                                                "regex",
+                                                "removeDuplicates",
+                                                "reverse",
+                                                "shingle",
+                                                "snowballStemming",
+                                                "spanishPluralStemming",
+                                                "stempel",
+                                                "stopword",
+                                                "trim",
+                                                "wordDelimiterGraph",
+                                            ]),
+                                        })
+                                        .passthrough()
+                                )
+                                .optional()
+                                .describe(
+                                    "Filters applied to tokens after tokenization, e.g. `{ type: 'lowercase' }`, `{ type: 'stopword' }`, or `{ type: 'snowballStemming', stemmerName: 'english' }`."
+                                ),
+                        })
+                        .describe("A custom analyzer definition.")
+                )
+                .optional()
+                .describe(
+                    "Custom analyzer definitions for this index. Define one here and reference it by `name` from a field's `analyzer`/`searchAnalyzer` option, instead of a built-in `lucene.*` analyzer."
+                ),
+            synonyms: z
+                .array(
+                    z.object({
+                        name: z.string().describe("Unique name for this synonym mapping."),
+                        source: z
+                            .object({
+                                collection: z
+                                    .string()
+                                    .describe(
+                                        "Name of the collection (in the same database) containing the synonym documents."
+                                    ),
+                            })
+                            .describe("Source of the synonym documents."),
+                        analyzer: z
+                            .string()
+                            .describe(
+                                "Analyzer applied to synonym entries. Should match the analyzer used on the field(s) being searched."
+                            ),
+                    })
+                )
+                .optional()
+                .describe("Synonym mappings for this index, each sourced from a collection of synonym documents."),
+            typeSets: z
+                .array(
+                    z.object({
+                        name: z
+                            .string()
+                            .describe("Unique name for this type set, referenced from `mappings.dynamic.typeSet`."),
+                        types: z
+                            .array(
+                                z.object({
+                                    type: z.enum([
+                                        "autocomplete",
+                                        "boolean",
+                                        "date",
+                                        "geo",
+                                        "number",
+                                        "objectId",
+                                        "string",
+                                        "token",
+                                        "uuid",
+                                    ]),
+                                })
+                            )
+                            .describe("The field types that this type set allows dynamic mapping to index."),
+                    })
+                )
+                .optional()
+                .describe(
+                    "Named sets of field types for use with `mappings.dynamic.typeSet`, to restrict dynamic mapping to only the listed types instead of every dynamically indexable type."
                 ),
             mappings: z
                 .object({
                     dynamic: z
-                        .boolean()
+                        .union([
+                            z.boolean(),
+                            z
+                                .object({
+                                    typeSet: z
+                                        .string()
+                                        .describe("Name of a type set defined in this index's `typeSets`."),
+                                })
+                                .strict(),
+                        ])
                         .optional()
                         .default(false)
                         .describe(
-                            "Enables or disables dynamic mapping of fields for this index. If set to true, Atlas Search recursively indexes all dynamically indexable fields. If set to false, you must specify individual fields to index using mappings.fields."
+                            "Enables or disables dynamic mapping of fields for this index. If set to true, Atlas Search recursively indexes all dynamically indexable fields. If set to false, you must specify individual fields to index using mappings.fields. If set to `{ typeSet: '<name>' }`, dynamic mapping is restricted to only the field types listed in that named entry of `typeSets`."
                         ),
                     fields: z
                         .record(
                             z.string().describe("The field name"),
                             z
-                                .object({
-                                    type: z
-                                        .enum([
-                                            "autocomplete",
-                                            "boolean",
-                                            "date",
-                                            "document",
-                                            "embeddedDocuments",
-                                            "geo",
-                                            "number",
-                                            "objectId",
-                                            "string",
-                                            "token",
-                                            "uuid",
-                                        ])
-                                        .describe("The field type"),
-                                })
-                                .passthrough()
+                                .union([
+                                    this.searchFieldDefinitionSchema,
+                                    z
+                                        .array(this.searchFieldDefinitionSchema)
+                                        .min(1)
+                                        .describe(
+                                            "Multiple field definitions to index the same field as multiple types, e.g. both `string` and `autocomplete`."
+                                        ),
+                                ])
                                 .describe(
                                     "The field index definition. It must contain the field type, as well as any additional options for that field type."
                                 )
@@ -170,12 +333,32 @@ Use 'filter' for additional fields to filter on. At least one 'vector' or 'autoE
                         .optional()
                         .describe("The field mapping definitions. If `dynamic` is set to `false`, this is required."),
                 })
-                .refine((data) => data.dynamic !== !!(data.fields && Object.keys(data.fields).length > 0), {
-                    message:
-                        "Either `dynamic` must be `true` and `fields` empty or `dynamic` must be `false` and at least one field must be defined in `fields`",
-                })
+                .refine(
+                    (data) => {
+                        const dynamicEnabled = typeof data.dynamic === "boolean" ? data.dynamic : true;
+                        return dynamicEnabled !== !!(data.fields && Object.keys(data.fields).length > 0);
+                    },
+                    {
+                        message:
+                            "Either `dynamic` must be `true` (or a typeSet object) and `fields` empty, or `dynamic` must be `false` and at least one field must be defined in `fields`",
+                    }
+                )
                 .describe(
-                    "Document describing the index to create. Either `dynamic` must be `true` and `fields` empty or `dynamic` must be `false` and at least one field must be defined in the `fields` document."
+                    "Document describing the index to create. Either `dynamic` must be `true` (or a typeSet object) and `fields` empty, or `dynamic` must be `false` and at least one field must be defined in the `fields` document."
+                ),
+            storedSource: z
+                .union([
+                    z.boolean(),
+                    z
+                        .object({
+                            include: z.array(z.string()).optional(),
+                            exclude: z.array(z.string()).optional(),
+                        })
+                        .strict(),
+                ])
+                .optional()
+                .describe(
+                    "Controls which fields are stored on search nodes for fast retrieval without a round trip to the database. `true` stores all fields, `false` (default) stores none, `{ include: [...] }` stores only the listed fields, `{ exclude: [...] }` stores all except the listed fields."
                 ),
             numPartitions: z
                 .union([z.literal("1"), z.literal("2"), z.literal("4")])
@@ -274,6 +457,10 @@ Use 'filter' for additional fields to filter on. At least one 'vector' or 'autoE
                             definition: {
                                 mappings: definition.mappings,
                                 analyzer: definition.analyzer,
+                                analyzers: definition.analyzers,
+                                synonyms: definition.synonyms,
+                                storedSource: definition.storedSource,
+                                typeSets: definition.typeSets,
                                 numPartitions: definition.numPartitions,
                             },
                             type: "search",

--- a/tests/accuracy/createIndex.test.ts
+++ b/tests/accuracy/createIndex.test.ts
@@ -250,6 +250,198 @@ describeAccuracyTests(
             ],
             mockedTools,
         },
+        {
+            prompt: "Create an Atlas search index on 'mflix.movies' namespace with a custom analyzer named 'plotCustom' that uses the standard tokenizer and a lowercase token filter, and apply it to the 'plot' field.",
+            expectedToolCalls: [
+                {
+                    toolName: "create-index",
+                    parameters: {
+                        database: "mflix",
+                        collection: "movies",
+                        name: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                        definition: [
+                            {
+                                type: "search",
+                                analyzer: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                                analyzers: [
+                                    {
+                                        name: "plotCustom",
+                                        charFilters: Matcher.anyOf(Matcher.undefined, Matcher.anyValue),
+                                        tokenizer: { type: "standard" },
+                                        tokenFilters: [{ type: "lowercase" }],
+                                    },
+                                ],
+                                mappings: {
+                                    dynamic: Matcher.anyOf(Matcher.undefined, Matcher.value(false)),
+                                    fields: {
+                                        plot: {
+                                            type: "string",
+                                            analyzer: "plotCustom",
+                                        },
+                                    },
+                                },
+                                numPartitions: Matcher.anyOf(Matcher.undefined, Matcher.number()),
+                            },
+                        ],
+                    },
+                },
+            ],
+            mockedTools,
+        },
+        {
+            prompt: "Create a dynamic Atlas search index on 'mflix.movies' namespace with a synonyms mapping named 'plotSynonyms' sourced from the 'synonyms' collection, analyzed with lucene.english.",
+            expectedToolCalls: [
+                {
+                    toolName: "create-index",
+                    parameters: {
+                        database: "mflix",
+                        collection: "movies",
+                        name: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                        definition: [
+                            {
+                                type: "search",
+                                analyzer: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                                synonyms: [
+                                    {
+                                        name: "plotSynonyms",
+                                        source: { collection: "synonyms" },
+                                        analyzer: "lucene.english",
+                                    },
+                                ],
+                                mappings: {
+                                    dynamic: true,
+                                },
+                                numPartitions: Matcher.anyOf(Matcher.undefined, Matcher.number()),
+                            },
+                        ],
+                    },
+                },
+            ],
+            mockedTools,
+        },
+        {
+            prompt: "Create an Atlas search index on 'mflix.movies' namespace that supports faceting: index 'genres' as a string facet and 'year' as a number facet.",
+            expectedToolCalls: [
+                {
+                    toolName: "create-index",
+                    parameters: {
+                        database: "mflix",
+                        collection: "movies",
+                        name: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                        definition: [
+                            {
+                                type: "search",
+                                analyzer: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                                mappings: {
+                                    dynamic: Matcher.anyOf(Matcher.undefined, Matcher.value(false)),
+                                    fields: {
+                                        genres: {
+                                            type: "stringFacet",
+                                        },
+                                        year: {
+                                            type: "numberFacet",
+                                        },
+                                    },
+                                },
+                                numPartitions: Matcher.anyOf(Matcher.undefined, Matcher.number()),
+                            },
+                        ],
+                    },
+                },
+            ],
+            mockedTools,
+        },
+        {
+            prompt: "Create an Atlas search index on 'mflix.movies' namespace that indexes the 'title' field both as a searchable string and as an autocomplete field, using multiple field type definitions.",
+            expectedToolCalls: [
+                {
+                    toolName: "create-index",
+                    parameters: {
+                        database: "mflix",
+                        collection: "movies",
+                        name: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                        definition: [
+                            {
+                                type: "search",
+                                analyzer: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                                mappings: {
+                                    dynamic: Matcher.anyOf(Matcher.undefined, Matcher.value(false)),
+                                    fields: {
+                                        title: Matcher.anyOf(
+                                            Matcher.value([{ type: "string" }, { type: "autocomplete" }]),
+                                            Matcher.value([{ type: "autocomplete" }, { type: "string" }])
+                                        ),
+                                    },
+                                },
+                                numPartitions: Matcher.anyOf(Matcher.undefined, Matcher.number()),
+                            },
+                        ],
+                    },
+                },
+            ],
+            mockedTools,
+        },
+        {
+            prompt: "Create a dynamic Atlas search index on 'mflix.movies' namespace that stores only the 'title' and 'genres' fields on the search nodes via stored source.",
+            expectedToolCalls: [
+                {
+                    toolName: "create-index",
+                    parameters: {
+                        database: "mflix",
+                        collection: "movies",
+                        name: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                        definition: [
+                            {
+                                type: "search",
+                                analyzer: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                                mappings: {
+                                    dynamic: true,
+                                },
+                                storedSource: Matcher.anyOf(
+                                    Matcher.value({ include: ["title", "genres"] }),
+                                    Matcher.value({ include: ["genres", "title"] })
+                                ),
+                                numPartitions: Matcher.anyOf(Matcher.undefined, Matcher.number()),
+                            },
+                        ],
+                    },
+                },
+            ],
+            mockedTools,
+        },
+        {
+            prompt: "Create a text search index on 'mflix.movies' namespace that uses configurable dynamic mapping such that only string and number fields are automatically indexed via a named type set.",
+            expectedToolCalls: [
+                {
+                    toolName: "create-index",
+                    parameters: {
+                        database: "mflix",
+                        collection: "movies",
+                        name: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                        definition: [
+                            {
+                                type: "search",
+                                analyzer: Matcher.anyOf(Matcher.undefined, Matcher.string()),
+                                typeSets: [
+                                    {
+                                        name: Matcher.string(),
+                                        types: Matcher.anyOf(
+                                            Matcher.value([{ type: "string" }, { type: "number" }]),
+                                            Matcher.value([{ type: "number" }, { type: "string" }])
+                                        ),
+                                    },
+                                ],
+                                mappings: {
+                                    dynamic: { typeSet: Matcher.string() },
+                                },
+                                numPartitions: Matcher.anyOf(Matcher.undefined, Matcher.number()),
+                            },
+                        ],
+                    },
+                },
+            ],
+            mockedTools,
+        },
     ],
     {
         clusterConfig: {


### PR DESCRIPTION
## Proposed changes

Expand search index creation schema to include fields that were not accounted for such as analyzers, storedSource etc

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
