### PR TITLE
fix: require projectName and orgId for atlas-create-project - MCP-602

### DIFF
--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -656,8 +656,8 @@ export class CreateIndexTool extends MongoDBToolBase {
 export class CreateProjectTool extends AtlasToolBase {
     // (undocumented)
     argsShape: {
-        projectName: z.ZodOptional<z.ZodString>;
-        orgId: z.ZodOptional<z.ZodString>;
+        projectName: z.ZodString;
+        orgId: z.ZodString;
     };
     // (undocumented)
     description: string;
@@ -668,7 +668,7 @@ export class CreateProjectTool extends AtlasToolBase {
     // (undocumented)
     outputSchema: {
         projectName: z.ZodString;
-        orgId: z.ZodOptional<z.ZodString>;
+        orgId: z.ZodString;
     };
     // (undocumented)
     static toolName: string;

--- a/src/tools/atlas/create/createProject.ts
+++ b/src/tools/atlas/create/createProject.ts
@@ -6,7 +6,7 @@ import { AtlasArgs } from "../../args.js";
 
 const CreateProjectOutputSchema = {
     projectName: z.string(),
-    orgId: z.string().optional(),
+    orgId: z.string(),
 };
 
 export class CreateProjectTool extends AtlasToolBase {
@@ -14,8 +14,8 @@ export class CreateProjectTool extends AtlasToolBase {
     public description = "Create a MongoDB Atlas project";
     static operationType: OperationType = "create";
     public argsShape = {
-        projectName: AtlasArgs.projectName().optional().describe("Name for the new project"),
-        orgId: AtlasArgs.organizationId().optional().describe("Organization ID for the new project"),
+        projectName: AtlasArgs.projectName().describe("Name for the new project"),
+        orgId: AtlasArgs.organizationId().describe("Organization ID that will own the new project"),
     };
     public override outputSchema = CreateProjectOutputSchema;
 
@@ -23,46 +23,12 @@ export class CreateProjectTool extends AtlasToolBase {
         { projectName, orgId }: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
-        let assumedOrg = false;
-
-        if (!projectName) {
-            projectName = "Atlas Project";
-        }
-
-        if (!orgId) {
-            try {
-                const organizations = await this.apiClient.listOrgs(undefined, context);
-                if (!organizations?.results?.length) {
-                    throw new Error(
-                        "No organizations were found in your MongoDB Atlas account. Please create an organization first."
-                    );
-                }
-                const firstOrg = organizations.results[0];
-                if (!firstOrg?.id) {
-                    throw new Error(
-                        "The first organization found does not have an ID. Please check your Atlas account."
-                    );
-                }
-                orgId = firstOrg.id;
-                assumedOrg = true;
-            } catch {
-                throw new Error(
-                    "Could not search for organizations in your MongoDB Atlas account, please provide an organization ID or create one first."
-                );
-            }
-        }
-
         const input = {
             name: projectName,
-            orgId: orgId,
+            orgId,
         } as Group;
 
-        const group = await this.apiClient.createGroup(
-            {
-                body: input,
-            },
-            context
-        );
+        const group = await this.apiClient.createGroup({ body: input }, context);
 
         if (!group?.id) {
             throw new Error("Failed to create project");
@@ -72,12 +38,12 @@ export class CreateProjectTool extends AtlasToolBase {
             content: [
                 {
                     type: "text",
-                    text: `Project "${projectName}" created successfully${assumedOrg ? ` (using orgId ${orgId}).` : ""}.`,
+                    text: `Project "${projectName}" created successfully.`,
                 },
             ],
             structuredContent: {
                 projectName,
-                ...(assumedOrg && { orgId }),
+                orgId,
             },
         };
     }

--- a/tests/integration/tools/atlas/projects.test.ts
+++ b/tests/integration/tools/atlas/projects.test.ts
@@ -42,8 +42,8 @@ describeWithAtlas("projects", (integration) => {
             const session = integration.mcpServer().session;
             assertApiClientIsAvailable(session);
             const orgs = await session.apiClient.listOrgs();
-            const orgId = (orgs.results && orgs.results[0]?.id) ?? "";
-
+            const orgId = orgs.results?.[0]?.id;
+            expectDefined(orgId);
             const response = await integration.mcpClient().callTool({
                 name: "atlas-create-project",
                 arguments: { projectName: projName, orgId },

--- a/tests/integration/tools/atlas/projects.test.ts
+++ b/tests/integration/tools/atlas/projects.test.ts
@@ -39,10 +39,14 @@ describeWithAtlas("projects", (integration) => {
             const projName = `testProj-${new ObjectId().toString()}`;
             projectsToCleanup.push(projName);
 
-            const session = integration.mcpServer().session;
-            assertApiClientIsAvailable(session);
-            const orgs = await session.apiClient.listOrgs();
-            const orgId = orgs.results?.[0]?.id;
+            // Prefer a pinned org from the environment; only hit the API when it is not provided.
+            let orgId = process.env.DEV_ATLAS_MCP_ORG_ID;
+            if (!orgId) {
+                const session = integration.mcpServer().session;
+                assertApiClientIsAvailable(session);
+                const orgs = await session.apiClient.listOrgs();
+                orgId = orgs.results?.[0]?.id;
+            }
             expectDefined(orgId);
             const response = await integration.mcpClient().callTool({
                 name: "atlas-create-project",

--- a/tests/integration/tools/atlas/projects.test.ts
+++ b/tests/integration/tools/atlas/projects.test.ts
@@ -39,9 +39,14 @@ describeWithAtlas("projects", (integration) => {
             const projName = `testProj-${new ObjectId().toString()}`;
             projectsToCleanup.push(projName);
 
+            const session = integration.mcpServer().session;
+            assertApiClientIsAvailable(session);
+            const orgs = await session.apiClient.listOrgs();
+            const orgId = (orgs.results && orgs.results[0]?.id) ?? "";
+
             const response = await integration.mcpClient().callTool({
                 name: "atlas-create-project",
-                arguments: { projectName: projName },
+                arguments: { projectName: projName, orgId },
             });
 
             const elements = getResponseElements(response);

--- a/tests/unit/tools/atlas/create/createProject.test.ts
+++ b/tests/unit/tools/atlas/create/createProject.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod";
 import type { ToolConstructorParams } from "../../../../../src/tools/tool.js";
 import { CreateProjectTool } from "../../../../../src/tools/atlas/create/createProject.js";
 import type { Session } from "../../../../../src/common/session.js";
@@ -57,39 +58,31 @@ describe("CreateProjectTool", () => {
     const exec = (args: Record<string, unknown> = {}) =>
         tool["execute"](args as never, { signal: new AbortController().signal } as never);
 
-    it("creates a project with explicit organizationId", async () => {
+    it("requires projectName and orgId, rejecting missing values", () => {
+        const schema = z.object(tool.argsShape);
+        const validOrgId = "66c5c66592100e05467ebfad";
+
+        expect(schema.safeParse({}).success).toBe(false);
+        expect(schema.safeParse({ projectName: "My Project" }).success).toBe(false);
+        expect(schema.safeParse({ orgId: validOrgId }).success).toBe(false);
+        expect(schema.safeParse({ projectName: "My Project", orgId: validOrgId }).success).toBe(true);
+    });
+
+    it("creates a project with the provided name and organizationId", async () => {
         mockApiClient.createGroup!.mockResolvedValue({ id: "proj-123", name: "My Project", orgId: "org-1" });
 
         const result = await exec({ projectName: "My Project", orgId: "org-1" });
 
         expect((result.content[0] as { text: string }).text).toContain('Project "My Project" created successfully');
         expect(mockApiClient.listOrgs).not.toHaveBeenCalled();
+        expect(mockApiClient.createGroup).toHaveBeenCalledWith(
+            { body: { name: "My Project", orgId: "org-1" } },
+            expect.anything()
+        );
         expect(result.structuredContent).toEqual({
             projectName: "My Project",
+            orgId: "org-1",
         });
-    });
-
-    it("assumes first organization when organizationId is omitted", async () => {
-        mockApiClient.listOrgs!.mockResolvedValue({ results: [{ id: "org-first", name: "First Org" }] });
-        mockApiClient.createGroup!.mockResolvedValue({ id: "proj-456", name: "Atlas Project", orgId: "org-first" });
-
-        const result = await exec();
-
-        expect(mockApiClient.listOrgs).toHaveBeenCalled();
-        expect((result.content[0] as { text: string }).text).toContain("using orgId org-first");
-        expect(result.structuredContent).toEqual({
-            projectName: "Atlas Project",
-            orgId: "org-first",
-        });
-    });
-
-    it("uses default project name when projectName is omitted", async () => {
-        mockApiClient.listOrgs!.mockResolvedValue({ results: [{ id: "org-1", name: "Org" }] });
-        mockApiClient.createGroup!.mockResolvedValue({ id: "proj-789", name: "Atlas Project", orgId: "org-1" });
-
-        const result = await exec({ orgId: "org-1" });
-
-        expect(result.structuredContent?.projectName).toBe("Atlas Project");
     });
 
     it("throws when createGroup returns no id", async () => {


### PR DESCRIPTION
## What

`atlas-create-project` now requires `projectName` and `orgId` instead of treating them as optional and silently backfilling. Removed the `"Atlas Project"` default name and the `listOrgs()` first-organization inference for `orgId`. The tool waits for the caller to provide real values and rejects the call when they are missing.

## Follow-ups (separate)

* Systemic `.strict()` validation for all tools so unrecognized keys are rejected everywhere (MCP-602).
* Apply the same hardening to the sibling Atlas create tools (`atlas-create-cluster`, `atlas-create-free-cluster`, `atlas-create-access-list`, `atlas-create-db-user`).
