### PR TITLE
fix: reject unrecognized tool arguments via strict input validation - MCP-602

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -42,7 +42,7 @@ import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { TransportRequestContext } from '@mongodb-js/mcp-types';
 import { z } from 'zod';
-import type { ZodRawShape } from 'zod';
+import { ZodRawShape } from 'zod';
 
 // @public (undocumented)
 export type AnyConnectionState = ConnectionStateConnected | ConnectionStateConnecting | ConnectionStateDisconnected | ConnectionStateErrored;

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -27,7 +27,7 @@ import type { TelemetryEvents } from '@mongodb-js/mcp-types';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { z } from 'zod';
-import type { ZodRawShape } from 'zod';
+import { ZodRawShape } from 'zod';
 
 // @public (undocumented)
 export class AggregateDBTool extends MongoDBToolBase {

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -30,7 +30,7 @@ import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { TransportRequestContext } from '@mongodb-js/mcp-types';
 import { z } from 'zod';
-import type { ZodRawShape } from 'zod';
+import { ZodRawShape } from 'zod';
 
 // @public (undocumented)
 export type AnyConnectionState = ConnectionStateConnected | ConnectionStateConnecting | ConnectionStateDisconnected | ConnectionStateErrored;

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1,4 +1,4 @@
-import type { z, ZodRawShape } from "zod";
+import { z, type ZodRawShape } from "zod";
 import type { RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult, ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { Session } from "../common/session.js";
@@ -708,7 +708,7 @@ export abstract class ToolBase<
                     name: string,
                     config: {
                         description?: string;
-                        inputSchema?: ZodRawShape;
+                        inputSchema?: z.ZodType;
                         outputSchema?: ZodRawShape;
                         annotations?: ToolAnnotations;
                         _meta?: Record<string, unknown>;
@@ -719,7 +719,10 @@ export abstract class ToolBase<
                 this.name,
                 {
                     description: this.description,
-                    inputSchema: this.argsShape,
+                    // Wrap the raw shape in a strict object so the SDK rejects unrecognized
+                    // argument keys instead of silently stripping them (see MCP-602). Only the
+                    // top-level object is strict; nested schemas keep their own behavior.
+                    inputSchema: z.object(this.argsShape).strict(),
                     outputSchema: this.outputSchema,
                     annotations: this.annotations,
                     _meta: this.toolMeta,

--- a/tests/integration/tools/mongodb/metadata/dbStats.test.ts
+++ b/tests/integration/tools/mongodb/metadata/dbStats.test.ts
@@ -115,7 +115,6 @@ describeWithMongoDB("dbStats tool", (integration) => {
         return {
             args: {
                 database: integration.randomDbName(),
-                collection: "foo",
             },
             expectedResponse: `Statistics for database:`,
         };

--- a/tests/integration/tools/mongodb/metadata/logs.test.ts
+++ b/tests/integration/tools/mongodb/metadata/logs.test.ts
@@ -111,10 +111,7 @@ describeWithMongoDB("logs tool", (integration) => {
 
     validateAutoConnectBehavior(integration, "mongodb-logs", () => {
         return {
-            args: {
-                database: integration.randomDbName(),
-                collection: "foo",
-            },
+            args: {},
             validate: (content): void => {
                 const elements = getResponseElements(content);
                 expect(elements.length).toBeLessThanOrEqual(51);

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -198,7 +198,6 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
             name: "aggregate-db",
             arguments: {
                 database: integration.randomDbName(),
-                collection: "people",
                 pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $merge: "mergedpeople" }],
             },
         });

--- a/tests/unit/toolBase.test.ts
+++ b/tests/unit/toolBase.test.ts
@@ -1,7 +1,7 @@
 import type { Mock } from "vitest";
 import { describe, it, expect, vi, beforeEach, type MockedFunction } from "vitest";
 import type { ZodRawShape } from "zod";
-import type { ToolConstructorParams, ToolExecutionContext } from "../../src/tools/tool.js";
+import type { ToolBase, ToolConstructorParams, ToolExecutionContext } from "../../src/tools/tool.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { Session } from "../../src/common/session.js";
 import type { UserConfig } from "../../src/common/config/userConfig.js";
@@ -604,6 +604,52 @@ describe("ToolBase", () => {
                     "x-request-id"
                 );
             }
+        });
+    });
+
+    describe("strict argument validation", () => {
+        function registeredInputSchema(tool: ToolBase): { safeParse: (value: unknown) => { success: boolean } } {
+            let inputSchema: unknown;
+            const mockServer = {
+                mcpServer: {
+                    registerTool: (
+                        _name: string,
+                        config: { inputSchema: unknown }
+                    ): { enabled: boolean; disable: () => void; enable: () => void } => {
+                        inputSchema = config.inputSchema;
+                        return { enabled: true, disable: vi.fn(), enable: vi.fn() };
+                    },
+                },
+            };
+            tool.register(mockServer as unknown as Server);
+            return inputSchema as { safeParse: (value: unknown) => { success: boolean } };
+        }
+
+        it("rejects an unrecognized argument name instead of silently dropping it", () => {
+            const schema = registeredInputSchema(testTool);
+
+            // register() must hand the SDK a built schema (not a raw shape) so unknown keys are rejected
+            expect(typeof schema.safeParse).toBe("function");
+            expect(schema.safeParse({ param1: "ok" }).success).toBe(true);
+            expect(schema.safeParse({ param1: "ok", param3: "typo" }).success).toBe(false);
+        });
+
+        it("rejects unknown arguments for tools with no declared parameters", () => {
+            const noArgTool = new ErrorTool({
+                name: ErrorTool.toolName,
+                category: ErrorTool.category,
+                operationType: ErrorTool.operationType,
+                session: mockSession,
+                config: mockConfig,
+                telemetry: mockTelemetry,
+                elicitation: mockElicitation,
+                metrics: mockMetrics,
+            });
+            const schema = registeredInputSchema(noArgTool);
+
+            expect(typeof schema.safeParse).toBe("function");
+            expect(schema.safeParse({}).success).toBe(true);
+            expect(schema.safeParse({ bogus: 1 }).success).toBe(false);
         });
     });
 });


### PR DESCRIPTION
## What

`ToolBase.register()` now wraps every tool's argument shape in a strict Zod object, so the MCP server rejects unrecognized argument names instead of silently stripping them. Defaults and required-ness are unchanged; only unknown top-level keys now cause an error.

## Why

MCP-602: the shared registration path passed the raw Zod shape to the SDK, which wraps it in a plain (non-strict) `z.object(...)`. Zod's default mode is "strip", so any misspelled or extra argument key was silently discarded before the tool ran. Concretely:

* `projId` instead of `projectId` (a required field): the key is dropped, then the tool fails only incidentally with "projectId: expected string, received undefined", never naming `projId`.
* `backupType` instead of `backup` (a defaulted field): the key is dropped, the default is applied, and the call succeeds with the wrong value and no error at all.

With strict validation both cases now fail with `Unrecognized key(s) in object: "projId"` / `"backupType"`, so a wrong argument name is always surfaced.

## Change

* `src/tools/tool.ts`: `ToolBase.register()` passes `z.object(this.argsShape).strict()` as `inputSchema` instead of the raw shape. The SDK returns a pre-built schema untouched (`getZodSchemaObject`) and validates against it, so unknown keys are rejected with an `InvalidParams` error and `tools/list` advertises `additionalProperties: false` (which also nudges clients away from inventing keys).

Scope and safety:

* One place, covers all tools. No tool relies on top-level extra keys.
* Only the top-level object becomes strict. Nested `.passthrough()` schemas (the `find` projection, streams connection configs) keep their behavior, and their unit tests still pass.
* Genuinely-omitted optional or defaulted fields still take their defaults. This only rejects keys that are not part of the schema.

