### PR TITLE
feat: use collection validators for schema inference MCP-603

### DIFF
--- a/src/helpers/mongoDBJsonSchemaToSimplifiedSchema.ts
+++ b/src/helpers/mongoDBJsonSchemaToSimplifiedSchema.ts
@@ -1,0 +1,129 @@
+import type { MongoDBJSONSchema, SimplifiedSchema, SimplifiedSchemaType } from "mongodb-schema";
+
+/**
+ * A $jsonSchema subschema as it can appear in a collection validator. This is a
+ * superset of mongodb-schema's `MongoDBJSONSchema` since validators may also use
+ * the standard JSON Schema `type`/`oneOf` keywords instead of the BSON-specific ones.
+ */
+type JsonSchemaNode = MongoDBJSONSchema & {
+    type?: string | string[];
+    oneOf?: JsonSchemaNode[];
+    anyOf?: JsonSchemaNode[];
+    properties?: Record<string, JsonSchemaNode>;
+    items?: JsonSchemaNode | JsonSchemaNode[];
+};
+
+/**
+ * Maps MongoDB `$jsonSchema` `bsonType` aliases and standard JSON Schema `type`
+ * names to the capitalised BSON type names used by mongodb-schema's SimplifiedSchema.
+ */
+const TYPE_NAME_MAP: Record<string, string> = {
+    // $jsonSchema bsonType aliases
+    double: "Double",
+    string: "String",
+    object: "Document",
+    array: "Array",
+    binData: "Binary",
+    undefined: "Undefined",
+    objectId: "ObjectId",
+    bool: "Boolean",
+    date: "Date",
+    null: "Null",
+    regex: "BSONRegExp",
+    javascript: "Code",
+    javascriptWithScope: "CodeWScope",
+    symbol: "BSONSymbol",
+    int: "Int32",
+    timestamp: "Timestamp",
+    long: "Int64",
+    decimal: "Decimal128",
+    minKey: "MinKey",
+    maxKey: "MaxKey",
+    number: "Number",
+    // standard JSON Schema type names not already covered above
+    boolean: "Boolean",
+    integer: "Int32",
+};
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+    if (value === undefined) {
+        return [];
+    }
+    return Array.isArray(value) ? value : [value];
+}
+
+function mapTypeName(name: string): string {
+    return TYPE_NAME_MAP[name] ?? name;
+}
+
+function itemTypes(items: JsonSchemaNode | JsonSchemaNode[] | undefined): SimplifiedSchemaType[] {
+    return dedupeTypes(toArray(items).flatMap((item) => resolveTypes(item)));
+}
+
+/**
+ * De-duplicates scalar types by their bsonType while preserving Document/Array
+ * types (which carry nested structure) as-is.
+ */
+function dedupeTypes(types: SimplifiedSchemaType[]): SimplifiedSchemaType[] {
+    const seenScalars = new Set<string>();
+    const result: SimplifiedSchemaType[] = [];
+    for (const type of types) {
+        const isScalar = !("fields" in type) && !("types" in type);
+        if (isScalar) {
+            if (seenScalars.has(type.bsonType)) {
+                continue;
+            }
+            seenScalars.add(type.bsonType);
+        }
+        result.push(type);
+    }
+    return result;
+}
+
+function resolveTypes(node: JsonSchemaNode): SimplifiedSchemaType[] {
+    const result: SimplifiedSchemaType[] = [];
+
+    for (const alternative of [...toArray(node.anyOf), ...toArray(node.oneOf)]) {
+        result.push(...resolveTypes(alternative));
+    }
+
+    const typeNames = node.bsonType !== undefined ? toArray(node.bsonType) : toArray(node.type);
+    if (typeNames.length === 0) {
+        // No explicit type - infer a container type from the structural keywords.
+        if (node.properties) {
+            typeNames.push("object");
+        } else if (node.items) {
+            typeNames.push("array");
+        }
+    }
+
+    for (const name of typeNames) {
+        const bsonType = mapTypeName(name);
+        if (bsonType === "Document") {
+            result.push({ bsonType: "Document", fields: convertProperties(node.properties) });
+        } else if (bsonType === "Array") {
+            result.push({ bsonType: "Array", types: itemTypes(node.items) });
+        } else {
+            result.push({ bsonType } as SimplifiedSchemaType);
+        }
+    }
+
+    return dedupeTypes(result);
+}
+
+function convertProperties(properties: Record<string, JsonSchemaNode> | undefined): SimplifiedSchema {
+    const schema: SimplifiedSchema = {};
+    for (const [field, node] of Object.entries(properties ?? {})) {
+        schema[field] = { types: resolveTypes(node) };
+    }
+    return schema;
+}
+
+/**
+ * Converts a collection validator's `$jsonSchema` into the SimplifiedSchema shape
+ * produced by mongodb-schema's sampling, so both schema sources look identical to
+ * consumers of the collection-schema tool.
+ */
+export function mongoDBJsonSchemaToSimplifiedSchema(jsonSchema: JsonSchemaNode): SimplifiedSchema {
+    return convertProperties(jsonSchema.properties);
+}

--- a/src/tools/mongodb/metadata/collectionSchema.ts
+++ b/src/tools/mongodb/metadata/collectionSchema.ts
@@ -1,11 +1,15 @@
 import { CollOperationArgs, ConnectionIdArgs, MongoDBToolBase } from "../mongodbTool.js";
 import type { ToolArgs, OperationType, ToolExecutionContext, ToolResult } from "../../tool.js";
 import { formatUntrustedData } from "../../tool.js";
+import type { SimplifiedSchema } from "mongodb-schema";
 import { getSimplifiedSchema } from "mongodb-schema";
 import z from "zod";
 import { ONE_MB } from "../../../helpers/constants.js";
 import { collectCursorUntilMaxBytesLimit } from "../../../helpers/collectCursorUntilMaxBytes.js";
 import { isObjectEmpty } from "../../../helpers/isObjectEmpty.js";
+import { mongoDBJsonSchemaToSimplifiedSchema } from "../../../helpers/mongoDBJsonSchemaToSimplifiedSchema.js";
+import { operationWithFallback } from "../../../helpers/operationWithFallback.js";
+import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 
 const MAXIMUM_SAMPLE_SIZE_HARD_LIMIT = 50_000;
 
@@ -40,6 +44,20 @@ export class CollectionSchemaTool extends MongoDBToolBase {
         { signal }: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
         const provider = await this.resolveConnection(connectionId);
+
+        const validatorSchema = await this.getSchemaFromValidator(provider, database, collection, signal);
+        if (validatorSchema) {
+            const fieldsCount = Object.keys(validatorSchema).length;
+            const header = `Found ${fieldsCount} fields derived from the collection's schema validator.`;
+            return {
+                content: formatUntrustedData(header, JSON.stringify({ database, collection, schema: validatorSchema })),
+                structuredContent: {
+                    schema: validatorSchema,
+                    fieldsCount,
+                },
+            };
+        }
+
         const cursor = provider.aggregate(
             database,
             collection,
@@ -81,5 +99,36 @@ export class CollectionSchemaTool extends MongoDBToolBase {
                 fieldsCount,
             },
         };
+    }
+
+    /**
+     * Returns the collection's schema derived from its `$jsonSchema` validator, or
+     * `undefined` when the collection has no validator, the validator does not use a
+     * top-level `$jsonSchema`, the `$jsonSchema` declares no fields, or the validator
+     * metadata could not be read. Callers fall back to sampling in those cases.
+     */
+    private async getSchemaFromValidator(
+        provider: NodeDriverServiceProvider,
+        database: string,
+        collection: string,
+        signal: AbortSignal
+    ): Promise<SimplifiedSchema | undefined> {
+        const jsonSchema = await operationWithFallback(async () => {
+            const collections = await provider.listCollections(database, { name: collection }, { signal });
+            const collectionInfo = collections[0] as
+                | {
+                      options?: {
+                          validator?: { $jsonSchema?: Parameters<typeof mongoDBJsonSchemaToSimplifiedSchema>[0] };
+                      };
+                  }
+                | undefined;
+            return collectionInfo?.options?.validator?.$jsonSchema;
+        }, undefined);
+        if (!jsonSchema) {
+            return undefined;
+        }
+
+        const schema = mongoDBJsonSchemaToSimplifiedSchema(jsonSchema);
+        return isObjectEmpty(schema) ? undefined : schema;
     }
 }

--- a/tests/integration/tools/mongodb/metadata/collectionSchema.test.ts
+++ b/tests/integration/tools/mongodb/metadata/collectionSchema.test.ts
@@ -186,6 +186,89 @@ describeWithMongoDB("collectionSchema tool", (integration) => {
         });
     });
 
+    describe("with a $jsonSchema validator", () => {
+        it("derives the schema from the validator instead of sampling", async () => {
+            const mongoClient = integration.mongoClient();
+            await mongoClient.db(integration.randomDbName()).createCollection("validated", {
+                validator: {
+                    $jsonSchema: {
+                        bsonType: "object",
+                        required: ["name"],
+                        properties: {
+                            name: { bsonType: "string" },
+                            age: { bsonType: "int" },
+                            address: {
+                                bsonType: "object",
+                                properties: {
+                                    city: { bsonType: "string" },
+                                    zip: { bsonType: ["string", "null"] },
+                                },
+                            },
+                            tags: { bsonType: "array", items: { bsonType: "string" } },
+                        },
+                    },
+                },
+            });
+
+            const expectedSchema: SimplifiedSchema = {
+                name: { types: [{ bsonType: "String" }] },
+                age: { types: [{ bsonType: "Int32" }] },
+                address: {
+                    types: [
+                        {
+                            bsonType: "Document",
+                            fields: {
+                                city: { types: [{ bsonType: "String" }] },
+                                zip: { types: [{ bsonType: "String" }, { bsonType: "Null" }] },
+                            },
+                        },
+                    ],
+                },
+                tags: { types: [{ bsonType: "Array", types: [{ bsonType: "String" }] }] },
+            };
+
+            const connectionId = await integration.connectMcpClient();
+            const response = await integration.mcpClient().callTool({
+                name: "collection-schema",
+                arguments: { connectionId, database: integration.randomDbName(), collection: "validated" },
+            });
+            const items = getResponseElements(response.content);
+            expect(items).toHaveLength(2);
+
+            expect(items[0]?.text).toEqual(
+                `Found ${Object.entries(expectedSchema).length} fields derived from the collection's schema validator.`
+            );
+
+            const { schema } = JSON.parse(getDataFromUntrustedContent(items[1]?.text ?? "{}")) as {
+                schema: SimplifiedSchema;
+            };
+            expect(schema).toEqual(expectedSchema);
+
+            const structuredContent = response.structuredContent as CollectionSchemaOutput;
+            expect(structuredContent.schema).toEqual(expectedSchema);
+            expect(structuredContent.fieldsCount).toBe(Object.entries(expectedSchema).length);
+        });
+
+        it("falls back to sampling when the validator has no $jsonSchema", async () => {
+            const mongoClient = integration.mongoClient();
+            await mongoClient.db(integration.randomDbName()).createCollection("queryValidated", {
+                validator: { age: { $gte: 18 } },
+            });
+            await mongoClient
+                .db(integration.randomDbName())
+                .collection("queryValidated")
+                .insertOne({ name: "Alice", age: 30 });
+
+            const connectionId = await integration.connectMcpClient();
+            const response = await integration.mcpClient().callTool({
+                name: "collection-schema",
+                arguments: { connectionId, database: integration.randomDbName(), collection: "queryValidated" },
+            });
+            const items = getResponseElements(response.content);
+            expect(items[0]?.text).toContain("inferred from a sample");
+        });
+    });
+
     validateAutoConnectBehavior(integration, "collection-schema", () => {
         return {
             args: {

--- a/tests/unit/helpers/mongoDBJsonSchemaToSimplifiedSchema.test.ts
+++ b/tests/unit/helpers/mongoDBJsonSchemaToSimplifiedSchema.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import type { SimplifiedSchema } from "mongodb-schema";
+import { mongoDBJsonSchemaToSimplifiedSchema } from "../../../src/helpers/mongoDBJsonSchemaToSimplifiedSchema.js";
+
+describe("mongoDBJsonSchemaToSimplifiedSchema", () => {
+    it("returns an empty schema when there are no properties", () => {
+        expect(mongoDBJsonSchemaToSimplifiedSchema({ bsonType: "object" })).toEqual({});
+    });
+
+    it("maps scalar bsonType aliases to simplified BSON type names", () => {
+        const result = mongoDBJsonSchemaToSimplifiedSchema({
+            bsonType: "object",
+            properties: {
+                _id: { bsonType: "objectId" },
+                name: { bsonType: "string" },
+                age: { bsonType: "int" },
+                score: { bsonType: "double" },
+                balance: { bsonType: "decimal" },
+                active: { bsonType: "bool" },
+                createdAt: { bsonType: "date" },
+            },
+        });
+
+        expect(result).toEqual<SimplifiedSchema>({
+            _id: { types: [{ bsonType: "ObjectId" }] },
+            name: { types: [{ bsonType: "String" }] },
+            age: { types: [{ bsonType: "Int32" }] },
+            score: { types: [{ bsonType: "Double" }] },
+            balance: { types: [{ bsonType: "Decimal128" }] },
+            active: { types: [{ bsonType: "Boolean" }] },
+            createdAt: { types: [{ bsonType: "Date" }] },
+        });
+    });
+
+    it("maps standard JSON Schema `type` when bsonType is absent", () => {
+        const result = mongoDBJsonSchemaToSimplifiedSchema({
+            type: "object",
+            properties: {
+                name: { type: "string" },
+                active: { type: "boolean" },
+                nickname: { type: "null" },
+            },
+        });
+
+        expect(result).toEqual<SimplifiedSchema>({
+            name: { types: [{ bsonType: "String" }] },
+            active: { types: [{ bsonType: "Boolean" }] },
+            nickname: { types: [{ bsonType: "Null" }] },
+        });
+    });
+
+    it("expands an array of bsonTypes into multiple simplified types", () => {
+        const result = mongoDBJsonSchemaToSimplifiedSchema({
+            bsonType: "object",
+            properties: {
+                zip: { bsonType: ["string", "null"] },
+            },
+        });
+
+        expect(result).toEqual<SimplifiedSchema>({
+            zip: { types: [{ bsonType: "String" }, { bsonType: "Null" }] },
+        });
+    });
+
+    it("recurses into nested object properties as Document fields", () => {
+        const result = mongoDBJsonSchemaToSimplifiedSchema({
+            bsonType: "object",
+            properties: {
+                address: {
+                    bsonType: "object",
+                    properties: {
+                        city: { bsonType: "string" },
+                        zip: { bsonType: "string" },
+                    },
+                },
+            },
+        });
+
+        expect(result).toEqual<SimplifiedSchema>({
+            address: {
+                types: [
+                    {
+                        bsonType: "Document",
+                        fields: {
+                            city: { types: [{ bsonType: "String" }] },
+                            zip: { types: [{ bsonType: "String" }] },
+                        },
+                    },
+                ],
+            },
+        });
+    });
+
+    it("recurses into array items", () => {
+        const result = mongoDBJsonSchemaToSimplifiedSchema({
+            bsonType: "object",
+            properties: {
+                tags: {
+                    bsonType: "array",
+                    items: { bsonType: "string" },
+                },
+            },
+        });
+
+        expect(result).toEqual<SimplifiedSchema>({
+            tags: {
+                types: [{ bsonType: "Array", types: [{ bsonType: "String" }] }],
+            },
+        });
+    });
+
+    it("flattens anyOf into the field's list of types", () => {
+        const result = mongoDBJsonSchemaToSimplifiedSchema({
+            bsonType: "object",
+            properties: {
+                value: {
+                    anyOf: [{ bsonType: "string" }, { bsonType: "int" }],
+                },
+            },
+        });
+
+        expect(result).toEqual<SimplifiedSchema>({
+            value: { types: [{ bsonType: "String" }, { bsonType: "Int32" }] },
+        });
+    });
+
+    it("infers Document from properties and Array from items when the type is omitted", () => {
+        const result = mongoDBJsonSchemaToSimplifiedSchema({
+            properties: {
+                meta: {
+                    properties: {
+                        note: { bsonType: "string" },
+                    },
+                },
+                items: {
+                    items: { bsonType: "int" },
+                },
+            },
+        });
+
+        expect(result).toEqual<SimplifiedSchema>({
+            meta: {
+                types: [
+                    {
+                        bsonType: "Document",
+                        fields: { note: { types: [{ bsonType: "String" }] } },
+                    },
+                ],
+            },
+            items: {
+                types: [{ bsonType: "Array", types: [{ bsonType: "Int32" }] }],
+            },
+        });
+    });
+});


### PR DESCRIPTION
## Proposed changes

Updates the collection-schema to use the collection validator's $jsonSchema definition instead of schema inference.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
