### PR TITLE
fix: accept no-recommendations response in performance advisor long-running test - MCP-604

### DIFF
--- a/tests/integration/tools/atlas/performanceAdvisor.test.ts
+++ b/tests/integration/tools/atlas/performanceAdvisor.test.ts
@@ -124,7 +124,15 @@ describeWithAtlas("performanceAdvisor", (integration) => {
                     },
                 });
 
+                // A freshly provisioned cluster has no query workload yet, so Atlas's performance
+                // advisor may legitimately have no suggestions to report. Support both shapes
+                // instead of assuming recommendations are always present.
                 const elements = getResponseElements(response.content);
+                if (elements.length === 1) {
+                    expect(elements[0]?.text).toBe("No performance advisor recommendations found.");
+                    return;
+                }
+
                 expect(elements).toHaveLength(2);
 
                 expect(elements[0]?.text).toContain("Performance advisor data");


### PR DESCRIPTION
The long-running tests workflow has failed on every run since 2026-07-01, on the same assertion in `performanceAdvisor.test.ts`. The real-cluster test provisions a fresh M10 cluster with no query workload and expects the performance advisor tool to always return two content elements.

[PR #1288](https://github.com/mongodb-js/mongodb-mcp-server/pull/1288) fixed a dead-code bug in `getPerformanceAdvisor.ts` that used to mask this: an unreachable check meant the tool always returned formatted advisor data no matter what. Now it correctly returns a single "no recommendations" message when a cluster has no traffic to analyze, which is exactly what a freshly provisioned test cluster looks like. This updates the test to accept both response shapes instead of hardcoding two elements.

Root cause is written up in [MCP-604](https://jira.mongodb.org/browse/MCP-604).

## Test plan

- [x] `npx tsc --noEmit -p .`
- [x] `npx eslint tests/integration/tools/atlas/performanceAdvisor.test.ts`
- [x] `npx vitest run tests/unit/tools/atlas/read/getPerformanceAdvisor.test.ts` (6 passed)
- [x] `npx vitest run tests/integration/tools/atlas/performanceAdvisor.test.ts` (3 passed, 2 skipped without Atlas credentials — real-cluster path can only be verified in CI)