### PR TITLE
chore: tweak tool description to remove reference to export tool when unavailable

### DIFF
--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -1587,6 +1587,8 @@ export abstract class MongoDBToolBase extends ToolBase {
     // (undocumented)
     protected handleError(error: unknown, args: ToolArgs<typeof MongoDBToolBase.argsShape>): Promise<CallToolResult>;
     // (undocumented)
+    protected get isExportToolAvailable(): boolean;
+    // (undocumented)
     protected isSearchSupported(connectionId: string): Promise<boolean>;
     protected peekConnection(connectionId: string | undefined): Promise<ConnectionEntry | undefined>;
     // (undocumented)

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -34,11 +34,11 @@ export const CURSOR_LIMIT_KEYS = z.enum([
 export type CursorLimitKey = z.infer<typeof CURSOR_LIMIT_KEYS>;
 
 /**
- * A map of applied limit on cursors to a text that is supposed to be sent as
- * response to LLM
+ * A map of applied limit on cursors to a human-readable description that is
+ * returned to the model.
  */
 export const CURSOR_LIMITS_TO_LLM_TEXT = {
-    "config.maxDocumentsPerQuery": "server's configured - maxDocumentsPerQuery",
-    "config.maxBytesPerQuery": "server's configured - maxBytesPerQuery",
-    "tool.responseBytesLimit": "tool's parameter - responseBytesLimit",
+    "config.maxDocumentsPerQuery": "the server's configured maximum number of documents",
+    "config.maxBytesPerQuery": "the server's configured maximum response size",
+    "tool.responseBytesLimit": "the responseBytesLimit parameter",
 } as const satisfies Record<CursorLimitKey, string>;

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -17,6 +17,15 @@ export const AGG_COUNT_MAX_TIME_MS_CAP: number = 60_000;
 
 export const ONE_MB: number = 1 * 1024 * 1024;
 
+/**
+ * The name of the `export` tool. Defined here (rather than referenced from the
+ * `ExportTool` class) so tools such as `find`/`aggregate` can check for the
+ * export tool's availability without importing `ExportTool`, which would create
+ * a circular import (`export.ts` imports `MongoDBToolBase`, `FindArgs` and
+ * `AggregateArgs`).
+ */
+export const EXPORT_TOOL_NAME = "export";
+
 export const CURSOR_LIMIT_KEYS = z.enum([
     "config.maxDocumentsPerQuery",
     "config.maxBytesPerQuery",

--- a/src/tools/mongodb/metadata/collectionSchema.ts
+++ b/src/tools/mongodb/metadata/collectionSchema.ts
@@ -28,7 +28,7 @@ export class CollectionSchemaTool extends MongoDBToolBase {
             .optional()
             .default(ONE_MB)
             .describe(
-                `The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded.`
+                "The maximum number of bytes to return in the response. This value is capped by the server's configured maximum and cannot be exceeded."
             ),
     };
     public override outputSchema = CollectionSchemaOutputSchema;

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -8,6 +8,7 @@ import type { ConnectionEntry } from "../../common/connectionRegistry.js";
 import type { Server } from "../../server.js";
 import type { ConnectionMetadata } from "../../telemetry/types.js";
 import { assertNoServerSideJS, isWriteStage } from "../../helpers/mqlGuards.js";
+import { EXPORT_TOOL_NAME } from "../../helpers/constants.js";
 
 export const DBOperationArgs = {
     database: z.string().describe("Database name"),
@@ -32,6 +33,12 @@ export const ConnectionIdArgs = {
 export abstract class MongoDBToolBase extends ToolBase {
     protected server?: Server;
     static category: ToolCategory = "mongodb";
+
+    protected get isExportToolAvailable(): boolean {
+        const registeredTools = this.server?.tools ?? [];
+        const exportTool = registeredTools.find((tool) => tool.name === EXPORT_TOOL_NAME);
+        return exportTool?.isEnabled() ?? false;
+    }
 
     /**
      * Resolves the required `connectionId` argument to a live service provider

--- a/src/tools/mongodb/read/aggregate.ts
+++ b/src/tools/mongodb/read/aggregate.ts
@@ -51,10 +51,13 @@ export class AggregateTool extends MongoDBToolBase {
         ...ConnectionIdArgs,
         ...CollOperationArgs,
         ...AggregateArgs,
-        responseBytesLimit: z.number().optional().default(ONE_MB).describe(`\
-The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. \
-Note to LLM: If the entire aggregation result is required, use the "export" tool instead of increasing this limit.\
-`),
+        responseBytesLimit: z
+            .number()
+            .optional()
+            .default(ONE_MB)
+            .describe(
+                "The maximum number of bytes to return in the response. This value is capped by the server's configured maximum and cannot be exceeded."
+            ),
     };
     static operationType: OperationType = "read";
 
@@ -346,9 +349,10 @@ Note to LLM: If the entire aggregation result is required, use the "export" tool
             if (appliedLimits.length) {
                 message += ` while respecting the applied limits of ${appliedLimits
                     .map((limit) => CURSOR_LIMITS_TO_LLM_TEXT[limit])
-                    .join(
-                        ", "
-                    )}. Note to LLM: If the entire query result is required then use "export" tool to export the query results`;
+                    .join(", ")}`;
+                if (this.isExportToolAvailable) {
+                    message += `. If the entire aggregation result is required, use the "export" tool to retrieve the full result set`;
+                }
             }
 
             message += ".";

--- a/src/tools/mongodb/read/aggregateDB.ts
+++ b/src/tools/mongodb/read/aggregateDB.ts
@@ -45,8 +45,13 @@ export class AggregateDBTool extends MongoDBToolBase {
         ...ConnectionIdArgs,
         ...DBOperationArgs,
         ...AggregateArgs,
-        responseBytesLimit: z.number().optional().default(ONE_MB).describe(`\
-The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded.`),
+        responseBytesLimit: z
+            .number()
+            .optional()
+            .default(ONE_MB)
+            .describe(
+                "The maximum number of bytes to return in the response. This value is capped by the server's configured maximum and cannot be exceeded."
+            ),
     };
     static operationType: OperationType = "read";
 

--- a/src/tools/mongodb/read/export.ts
+++ b/src/tools/mongodb/read/export.ts
@@ -7,9 +7,10 @@ import { CollOperationArgs, ConnectionIdArgs, MongoDBToolBase } from "../mongodb
 import { FindArgs } from "./find.js";
 import { jsonExportFormat } from "../../../common/exportsManager.js";
 import { AggregateArgs } from "./aggregate.js";
+import { EXPORT_TOOL_NAME } from "../../../helpers/constants.js";
 
 export class ExportTool extends MongoDBToolBase {
-    static toolName = "export";
+    static toolName = EXPORT_TOOL_NAME;
     public description = "Export a query or aggregation results in the specified EJSON format.";
     public argsShape = {
         ...ConnectionIdArgs,

--- a/src/tools/mongodb/read/find.ts
+++ b/src/tools/mongodb/read/find.ts
@@ -49,10 +49,13 @@ export class FindTool extends MongoDBToolBase {
         ...ConnectionIdArgs,
         ...CollOperationArgs,
         ...FindArgs,
-        responseBytesLimit: z.number().optional().default(ONE_MB).describe(`\
-The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. \
-Note to LLM: If the entire query result is required, use the "export" tool instead of increasing this limit.\
-`),
+        responseBytesLimit: z
+            .number()
+            .optional()
+            .default(ONE_MB)
+            .describe(
+                "The maximum number of bytes to return in the response. This value is capped by the server's configured maximum and cannot be exceeded."
+            ),
     };
     static operationType: OperationType = "read";
 
@@ -181,16 +184,19 @@ Note to LLM: If the entire query result is required, use the "export" tool inste
         documents: unknown[];
         appliedLimits: CursorLimitKey[];
     }): string {
-        const appliedLimitsText = appliedLimits.length
-            ? `\
-while respecting the applied limits of ${appliedLimits.map((limit) => CURSOR_LIMITS_TO_LLM_TEXT[limit]).join(", ")}. \
-Note to LLM: If the entire query result is required then use "export" tool to export the query results.\
-`
-            : "";
+        let appliedLimitsText = "";
+        if (appliedLimits.length) {
+            appliedLimitsText = ` while respecting the applied limits of ${appliedLimits
+                .map((limit) => CURSOR_LIMITS_TO_LLM_TEXT[limit])
+                .join(", ")}.`;
+            if (this.isExportToolAvailable) {
+                appliedLimitsText += ` If the entire query result is required, use the "export" tool to retrieve the full result set.`;
+            }
+        }
 
         return `\
 Query on collection "${collection}" resulted in ${queryResultsCount === undefined ? "indeterminable number of" : queryResultsCount} documents. \
-Returning ${documents.length} documents${appliedLimitsText ? ` ${appliedLimitsText}` : "."}\
+Returning ${documents.length} documents${appliedLimitsText || "."}\
 `;
     }
 

--- a/tests/integration/tools/mongodb/metadata/collectionSchema.test.ts
+++ b/tests/integration/tools/mongodb/metadata/collectionSchema.test.ts
@@ -27,7 +27,7 @@ describeWithMongoDB("collectionSchema tool", (integration) => {
         {
             name: "responseBytesLimit",
             type: "number",
-            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded.`,
+            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maximum and cannot be exceeded.`,
             required: false,
         },
     ]);

--- a/tests/integration/tools/mongodb/read/aggregate.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregate.test.ts
@@ -16,6 +16,7 @@ import {
     validateAutoConnectBehavior,
     waitUntilSearchIndexIsQueryable,
     waitUntilSearchIsReady,
+    type MongoDBIntegrationTestCase,
 } from "../mongodbHelpers.js";
 import * as constants from "../../../../../src/helpers/constants.js";
 import { freshInsertDocuments } from "./find.test.js";
@@ -646,7 +647,7 @@ describeWithMongoDB(
             const content = getResponseContent(response);
             expect(content).toContain("The aggregation resulted in 990 documents");
             expect(content).toContain(
-                `Returning 20 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery.`
+                `Returning 20 documents while respecting the applied limits of the server's configured maximum number of documents.`
             );
             const docs = getDocsFromUntrustedContent(content);
             validateDocs(docs, 20);
@@ -671,7 +672,7 @@ describeWithMongoDB(
             const content = getResponseContent(response);
             expect(content).toContain("The aggregation resulted in 50 documents");
             expect(content).toContain(
-                `Returning 20 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery.`
+                `Returning 20 documents while respecting the applied limits of the server's configured maximum number of documents.`
             );
             const docs = getDocsFromUntrustedContent(content);
             validateDocs(docs, 20);
@@ -734,7 +735,7 @@ describeWithMongoDB(
             const content = getResponseContent(response);
             expect(content).toContain("The aggregation resulted in 990 documents");
             expect(content).toContain(
-                `Returning 3 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery, server's configured - maxBytesPerQuery.`
+                `Returning 3 documents while respecting the applied limits of the server's configured maximum number of documents, the server's configured maximum response size.`
             );
             expectAggregateStructuredContent(response, {
                 count: 990,
@@ -765,7 +766,7 @@ describeWithMongoDB(
             const content = getResponseContent(response);
             expect(content).toContain("The aggregation resulted in 990 documents");
             expect(content).toContain(
-                `Returning 1 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery, tool's parameter - responseBytesLimit.`
+                `Returning 1 documents while respecting the applied limits of the server's configured maximum number of documents, the responseBytesLimit parameter.`
             );
             expectAggregateStructuredContent(response, {
                 count: 990,
@@ -777,6 +778,64 @@ describeWithMongoDB(
         getUserConfig: () => ({ ...defaultTestConfig, maxBytesPerQuery: 200 }),
     }
 );
+
+describe("aggregate tool export hint in the applied-limits message", () => {
+    // A tiny responseBytesLimit guarantees the result is truncated so the
+    // applied-limits portion of the message is always present.
+    const truncatingArgs = { responseBytesLimit: 100 };
+    const appliedLimitsSnippet = "while respecting the applied limits of";
+    const exportHintSnippet = `use the "export" tool`;
+
+    const callAggregate = async (integration: MongoDBIntegrationTestCase): Promise<string> => {
+        await freshInsertDocuments({
+            collection: integration.mongoClient().db(integration.randomDbName()).collection("people"),
+            count: 1000,
+            documentMapper(index) {
+                return { name: `Person ${index}`, age: index };
+            },
+        });
+        const connectionId = await integration.connectMcpClient();
+        const response = await integration.mcpClient().callTool({
+            name: "aggregate",
+            arguments: {
+                connectionId,
+                database: integration.randomDbName(),
+                collection: "people",
+                pipeline: [{ $match: { age: { $gte: 10 } } }, { $sort: { name: -1 } }],
+                ...truncatingArgs,
+            },
+        });
+        return getResponseContent(response);
+    };
+
+    describeWithMongoDB(
+        "when the export tool is available",
+        (integration) => {
+            it("points to the export tool for retrieving the full result set", async () => {
+                const content = await callAggregate(integration);
+                expect(content).toContain(appliedLimitsSnippet);
+                expect(content).toContain(exportHintSnippet);
+            });
+        },
+        {
+            getUserConfig: () => ({ ...defaultTestConfig }),
+        }
+    );
+
+    describeWithMongoDB(
+        "when the export tool is disabled (e.g. remote deployment)",
+        (integration) => {
+            it("reports the applied limits without referencing the export tool", async () => {
+                const content = await callAggregate(integration);
+                expect(content).toContain(appliedLimitsSnippet);
+                expect(content).not.toContain(exportHintSnippet);
+            });
+        },
+        {
+            getUserConfig: () => ({ ...defaultTestConfig, disabledTools: ["export"] }),
+        }
+    );
+});
 
 describeWithMongoDB(
     "aggregate tool with disabled max documents and max bytes per query",

--- a/tests/integration/tools/mongodb/read/aggregate.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregate.test.ts
@@ -67,7 +67,7 @@ describeWithMongoDB("aggregate tool", (integration) => {
         },
         {
             name: "responseBytesLimit",
-            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. Note to LLM: If the entire aggregation result is required, use the "export" tool instead of increasing this limit.`,
+            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maximum and cannot be exceeded.`,
             type: "number",
             required: false,
         },
@@ -835,7 +835,7 @@ describeWithMongoDB(
             },
             {
                 name: "responseBytesLimit",
-                description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. Note to LLM: If the entire aggregation result is required, use the "export" tool instead of increasing this limit.`,
+                description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maximum and cannot be exceeded.`,
                 type: "number",
                 required: false,
             },

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -68,7 +68,7 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
         },
         {
             name: "responseBytesLimit",
-            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded.`,
+            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maximum and cannot be exceeded.`,
             type: "number",
             required: false,
         },

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -304,7 +304,7 @@ describeWithMongoDB(
             const content = getResponseContent(response);
             expect(content).toContain("The aggregation resulted in 100 documents");
             expect(content).toContain(
-                `Returning 20 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery.`
+                `Returning 20 documents while respecting the applied limits of the server's configured maximum number of documents.`
             );
             const docs = getDocsFromUntrustedContent(content);
             validateDocs(docs, 20);
@@ -328,7 +328,7 @@ describeWithMongoDB(
             const content = getResponseContent(response);
             expect(content).toContain("The aggregation resulted in 50 documents");
             expect(content).toContain(
-                `Returning 20 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery.`
+                `Returning 20 documents while respecting the applied limits of the server's configured maximum number of documents.`
             );
             const docs = getDocsFromUntrustedContent(content);
             validateDocs(docs, 20);
@@ -388,7 +388,7 @@ describeWithMongoDB(
             const content = getResponseContent(response);
             expect(content).toContain("The aggregation resulted in 1000 documents");
             expect(content).toContain(
-                `Returning 5 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery, server's configured - maxBytesPerQuery.`
+                `Returning 5 documents while respecting the applied limits of the server's configured maximum number of documents, the server's configured maximum response size.`
             );
             expectAggregateDBStructuredContent(response, content, {
                 aggResultsCount: 1000,
@@ -411,7 +411,7 @@ describeWithMongoDB(
             const content = getResponseContent(response);
             expect(content).toContain("The aggregation resulted in 1000 documents");
             expect(content).toContain(
-                `Returning 2 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery, tool's parameter - responseBytesLimit.`
+                `Returning 2 documents while respecting the applied limits of the server's configured maximum number of documents, the responseBytesLimit parameter.`
             );
             expectAggregateDBStructuredContent(response, content, {
                 aggResultsCount: 1000,

--- a/tests/integration/tools/mongodb/read/find.test.ts
+++ b/tests/integration/tools/mongodb/read/find.test.ts
@@ -10,7 +10,12 @@ import {
     defaultTestConfig,
 } from "../../../helpers.js";
 import * as constants from "../../../../../src/helpers/constants.js";
-import { describeWithMongoDB, getDocsFromUntrustedContent, validateAutoConnectBehavior } from "../mongodbHelpers.js";
+import {
+    describeWithMongoDB,
+    getDocsFromUntrustedContent,
+    validateAutoConnectBehavior,
+    type MongoDBIntegrationTestCase,
+} from "../mongodbHelpers.js";
 import type { Client } from "@modelcontextprotocol/sdk/client";
 import type { CursorLimitKey } from "../../../../../src/helpers/constants.js";
 import { bsonToJson } from "../../../../../src/helpers/bsonToJson.js";
@@ -107,7 +112,7 @@ describeWithMongoDB("find tool with default configuration", (integration) => {
         },
         {
             name: "responseBytesLimit",
-            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maxBytesPerQuery and cannot be exceeded. Note to LLM: If the entire query result is required, use the "export" tool instead of increasing this limit.`,
+            description: `The maximum number of bytes to return in the response. This value is capped by the server's configured maximum and cannot be exceeded.`,
             type: "number",
             required: false,
         },
@@ -455,6 +460,61 @@ for (const { suiteLabel, userConfig, cases } of findLimitSuites) {
         }
     );
 }
+
+describe("find tool export hint in the applied-limits message", () => {
+    // A tiny responseBytesLimit guarantees the result is truncated so the
+    // applied-limits portion of the message is always present.
+    const truncatingArgs = { limit: 1000, responseBytesLimit: 50 };
+    const appliedLimitsSnippet = "while respecting the applied limits of";
+    const exportHintSnippet = `use the "export" tool`;
+
+    const callFind = async (integration: MongoDBIntegrationTestCase): Promise<string> => {
+        await freshInsertDocuments({
+            collection: integration.mongoClient().db(integration.randomDbName()).collection("foo"),
+            count: 1000,
+        });
+        const connectionId = await integration.connectMcpClient();
+        const response = await integration.mcpClient().callTool({
+            name: "find",
+            arguments: {
+                connectionId,
+                database: integration.randomDbName(),
+                collection: "foo",
+                filter: {},
+                ...truncatingArgs,
+            },
+        });
+        return getResponseContent(response);
+    };
+
+    describeWithMongoDB(
+        "when the export tool is available",
+        (integration) => {
+            it("points to the export tool for retrieving the full result set", async () => {
+                const content = await callFind(integration);
+                expect(content).toContain(appliedLimitsSnippet);
+                expect(content).toContain(exportHintSnippet);
+            });
+        },
+        {
+            getUserConfig: () => ({ ...defaultTestConfig }),
+        }
+    );
+
+    describeWithMongoDB(
+        "when the export tool is disabled (e.g. remote deployment)",
+        (integration) => {
+            it("reports the applied limits without referencing the export tool", async () => {
+                const content = await callFind(integration);
+                expect(content).toContain(appliedLimitsSnippet);
+                expect(content).not.toContain(exportHintSnippet);
+            });
+        },
+        {
+            getUserConfig: () => ({ ...defaultTestConfig, disabledTools: ["export"] }),
+        }
+    );
+});
 
 describeWithMongoDB(
     "find tool with abort signal",

--- a/tests/integration/tools/mongodb/read/find.test.ts
+++ b/tests/integration/tools/mongodb/read/find.test.ts
@@ -363,7 +363,7 @@ const findLimitSuites: {
                 arguments: { limit: 10000 },
                 contentContains: [
                     `Query on collection "foo" resulted in 1000 documents.`,
-                    `Returning 10 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery.`,
+                    `Returning 10 documents while respecting the applied limits of the server's configured maximum number of documents.`,
                 ],
                 structured: { count: 1000, limits: ["config.maxDocumentsPerQuery"] },
             },
@@ -378,7 +378,7 @@ const findLimitSuites: {
                 arguments: { limit: 1000 },
                 contentContains: [
                     `Query on collection "foo" resulted in 1000 documents.`,
-                    `Returning 3 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery, server's configured - maxBytesPerQuery`,
+                    `Returning 3 documents while respecting the applied limits of the server's configured maximum number of documents, the server's configured maximum response size`,
                 ],
                 structured: {
                     count: 1000,
@@ -390,7 +390,7 @@ const findLimitSuites: {
                 arguments: { limit: 1000, responseBytesLimit: 50 },
                 contentContains: [
                     `Query on collection "foo" resulted in 1000 documents.`,
-                    `Returning 1 documents while respecting the applied limits of server's configured - maxDocumentsPerQuery, tool's parameter - responseBytesLimit.`,
+                    `Returning 1 documents while respecting the applied limits of the server's configured maximum number of documents, the responseBytesLimit parameter.`,
                 ],
                 structured: {
                     count: 1000,
@@ -414,7 +414,7 @@ const findLimitSuites: {
                 arguments: { limit: 1000, responseBytesLimit: 50 },
                 contentContains: [
                     `Query on collection "foo" resulted in 1000 documents.`,
-                    `Returning 1 documents while respecting the applied limits of tool's parameter - responseBytesLimit.`,
+                    `Returning 1 documents while respecting the applied limits of the responseBytesLimit parameter.`,
                 ],
                 structured: { count: 1000, limits: ["tool.responseBytesLimit"] },
             },


### PR DESCRIPTION
## Proposed changes

Anthropic's review suggested that we make our tool description factual and remove references to tools and config keys that are not exposed to the end users.

The change does exactly that - removes references to export tool and also maxBytesPerQuery parameter (which is configurable only on server).

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
