### PR TITLE
fix: allow empty loggers to be passed in userConfig CLOUDP-426852

### DIFF
--- a/src/common/config/userConfig.ts
+++ b/src/common/config/userConfig.ts
@@ -50,7 +50,6 @@ const ServerConfigSchema = z.object({
             z.array(z.enum(["stderr", "disk", "mcp"]))
         )
         .check(
-            z.minLength(1, "Cannot be an empty array"),
             z.refine((val) => new Set(val).size === val.length, {
                 message: "Duplicate loggers found in config",
             })

--- a/tests/unit/common/config.test.ts
+++ b/tests/unit/common/config.test.ts
@@ -826,12 +826,6 @@ describe("config", () => {
         describe("loggers", () => {
             const invalidLoggerTestCases = [
                 {
-                    description: "must not be empty",
-                    args: ["--loggers", ""],
-                    expectedError:
-                        "Invalid configuration for the following fields:\nloggers - Cannot be an empty array",
-                },
-                {
                     description: "must not allow duplicates",
                     args: ["--loggers", "disk,disk,disk"],
                     expectedError:
@@ -845,6 +839,11 @@ describe("config", () => {
                     expect(error).toEqual(expect.stringContaining(expectedError));
                 });
             }
+
+            it("allows an empty list (no built-in sinks; e.g. when logs are forwarded to an additional logger)", () => {
+                const { parsed: actual } = parseUserConfig({ args: ["--loggers", ""] });
+                expect(actual?.loggers).toEqual([]);
+            });
 
             it("allows mcp logger", () => {
                 const { parsed: actual } = parseUserConfig({ args: ["--loggers", "mcp"] });


### PR DESCRIPTION
## Proposed changes

Empty logger config allows downstream consumers to provide their own replacement loggers.