### PR TITLE
chore: attempt to evict lru session before rejecting at maxSessions cap CLOUDP-427202

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -1083,6 +1083,7 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
             idleTimeoutMS: number;
             notificationTimeoutMS: number;
             maxSessions: number;
+            evictionIdleGraceMS?: number;
         };
         logger: LoggerBase;
         metrics: Metrics<DefaultMetrics>;

--- a/packages/types/src/sessionStore.ts
+++ b/packages/types/src/sessionStore.ts
@@ -6,7 +6,7 @@ export type CloseableTransport = {
     close(): Promise<void>;
 };
 
-export type SessionCloseReason = "idle_timeout" | "transport_closed" | "server_stop" | "unknown";
+export type SessionCloseReason = "idle_timeout" | "transport_closed" | "server_stop" | "unknown" | "evicted";
 
 export interface ISessionStore<T extends CloseableTransport = CloseableTransport> {
     /**
@@ -44,7 +44,21 @@ export interface ISessionStore<T extends CloseableTransport = CloseableTransport
 }
 
 export type SessionStoreConstructorArgs<TMetrics extends MetricDefinitions = MetricDefinitions> = {
-    options: { idleTimeoutMS: number; notificationTimeoutMS: number; maxSessions: number };
+    options: {
+        idleTimeoutMS: number;
+        notificationTimeoutMS: number;
+        maxSessions: number;
+        /**
+         * When the store is at `maxSessions` and a new session arrives, evict the
+         * least-recently-used session instead of rejecting — but only if it has been
+         * idle for at least this long (ms). Must be < `idleTimeoutMS` (the background
+         * reaper already removes anything past that), or the valve never fires. If a
+         * session idle >= this exists, it is closed locally to make room; otherwise
+         * the new session is rejected. Defaults to 120_000 (2 min), clamped to
+         * `idleTimeoutMS`.
+         */
+        evictionIdleGraceMS?: number;
+    };
     logger: ILoggerBase;
     metrics: IMetrics<TMetrics>;
 };

--- a/src/common/sessionStore.ts
+++ b/src/common/sessionStore.ts
@@ -124,17 +124,26 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
             transport: T;
             abortTimeout: ManagedTimeout;
             notificationTimeout: ManagedTimeout;
+            /** Epoch ms of the last activity on this session; drives LRU eviction order. */
+            lastUsedAt: number;
         };
     } = {};
 
     private readonly idleTimeoutMS: number;
     private readonly notificationTimeoutMS: number;
     private readonly maxSessions: number;
+    /** Min idle time (ms) before the LRU session may be evicted to admit a new one. */
+    private readonly evictionIdleGraceMS: number;
     private readonly logger: LoggerBase;
     private readonly metrics: Metrics<DefaultMetrics>;
 
     constructor(params: {
-        options: { idleTimeoutMS: number; notificationTimeoutMS: number; maxSessions: number };
+        options: {
+            idleTimeoutMS: number;
+            notificationTimeoutMS: number;
+            maxSessions: number;
+            evictionIdleGraceMS?: number;
+        };
         logger: LoggerBase;
         metrics: Metrics<DefaultMetrics>;
     }) {
@@ -142,6 +151,9 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
         this.idleTimeoutMS = options.idleTimeoutMS;
         this.notificationTimeoutMS = options.notificationTimeoutMS;
         this.maxSessions = options.maxSessions;
+        // Default 2 min, but never >= idleTimeoutMS: the reaper already removes sessions
+        // idle past idleTimeoutMS, so a larger grace would make eviction a no-op.
+        this.evictionIdleGraceMS = Math.min(options.evictionIdleGraceMS ?? 120_000, this.idleTimeoutMS);
         this.logger = logger;
         this.metrics = metrics;
 
@@ -186,6 +198,23 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
         session.abortTimeout.restart();
 
         session.notificationTimeout.restart();
+        session.lastUsedAt = Date.now();
+    }
+
+    private findEvictableSession(): string | undefined {
+        const now = Date.now();
+        let oldestId: string | undefined;
+        let oldestLastUsedAt = Infinity;
+        for (const [id, session] of Object.entries(this.sessions)) {
+            if (session.lastUsedAt < oldestLastUsedAt) {
+                oldestLastUsedAt = session.lastUsedAt;
+                oldestId = id;
+            }
+        }
+        if (oldestId === undefined || now - oldestLastUsedAt < this.evictionIdleGraceMS) {
+            return undefined;
+        }
+        return oldestId;
     }
 
     private sendNotification(sessionId: string): void {
@@ -218,12 +247,28 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
             throw new Error(`Session ${sessionId} already exists`);
         }
         if (Object.keys(this.sessions).length >= this.maxSessions) {
-            this.logger.warning({
-                id: LogId.streamableHttpTransportSessionLimitExceeded,
-                context: "sessionStore",
-                message: `Refusing to create session ${sessionId}: maxSessions limit of ${this.maxSessions} reached`,
+            // At capacity: rather than hard-rejecting, evict the least-recently-used
+            // session if it has been idle at least evictionIdleGraceMS — a local-only
+            // close that frees a slot while the evicted client can transparently
+            // re-hydrate on its next request. If nothing is idle enough, reject. This
+            // stays fully synchronous (no await before the insert below), so concurrent
+            // addSession calls run to completion one at a time and can't race past the cap.
+            const victimId = this.findEvictableSession();
+            if (victimId === undefined) {
+                this.logger.warning({
+                    id: LogId.streamableHttpTransportSessionLimitExceeded,
+                    context: "sessionStore",
+                    message: `Refusing to create session ${sessionId}: maxSessions limit of ${this.maxSessions} reached and no session is idle past the eviction grace`,
+                });
+                throw new SessionLimitExceededError(`Session limit of ${this.maxSessions} concurrent sessions reached`);
+            }
+            void this.closeSession({ sessionId: victimId, reason: "evicted" }).catch((error) => {
+                this.logger.error({
+                    id: LogId.streamableHttpTransportSessionCloseFailure,
+                    context: "sessionStore",
+                    message: `Error evicting session ${victimId}: ${error instanceof Error ? error.message : String(error)}`,
+                });
             });
-            throw new SessionLimitExceededError(`Session limit of ${this.maxSessions} concurrent sessions reached`);
         }
         const abortTimeout = setManagedTimeout(async () => {
             if (this.sessions[sessionId]) {
@@ -245,6 +290,7 @@ export class SessionStore<T extends CloseableTransport = CloseableTransport> imp
             abortTimeout,
             notificationTimeout,
             logger,
+            lastUsedAt: Date.now(),
         };
         this.metrics.get("sessionCreated").inc();
         this.metrics.get("sessionsActive").set(Object.keys(this.sessions).length);

--- a/tests/unit/sessionStore.test.ts
+++ b/tests/unit/sessionStore.test.ts
@@ -331,3 +331,247 @@ describe("SessionStore maxSessions", () => {
         expect(store.hasSession("s2")).toBe(true);
     });
 });
+
+describe("SessionStore LRU idle-eviction", () => {
+    // idleTimeoutMS is set well above the 2-min grace so an idle session is evictable
+    // by the LRU valve before the background reaper would remove it.
+    function makeStore(maxSessions: number, metrics: MockMetrics = new MockMetrics()): SessionStore {
+        return new SessionStore({
+            options: {
+                idleTimeoutMS: 600_000,
+                notificationTimeoutMS: 30_000,
+                maxSessions,
+                evictionIdleGraceMS: 120_000,
+            },
+            logger: createMockLogger(),
+            metrics,
+        });
+    }
+
+    it("evicts the least-recently-used idle session to admit a new one at capacity", async () => {
+        vi.useFakeTimers();
+        try {
+            const metrics = new MockMetrics();
+            const store = makeStore(2, metrics);
+            const s1Close = vi.fn().mockResolvedValue(undefined);
+
+            await store.addSession({
+                sessionId: "s1",
+                transport: { close: s1Close },
+                logger: createMockLogger(),
+                session: createMockSession(),
+            });
+            await store.addSession({
+                sessionId: "s2",
+                transport: createMockTransport(),
+                logger: createMockLogger(),
+                session: createMockSession(),
+            });
+
+            // Both idle 2.5 min (> 2-min grace, < 10-min reaper); touch s2 so s1 is the LRU.
+            await vi.advanceTimersByTimeAsync(150_000);
+            await store.getSession("s2");
+
+            await store.addSession({
+                sessionId: "s3",
+                transport: createMockTransport(),
+                logger: createMockLogger(),
+                session: createMockSession(),
+            });
+
+            expect(store.hasSession("s1")).toBe(false); // evicted: LRU, idle past grace
+            expect(store.hasSession("s2")).toBe(true); // recently used, preserved
+            expect(store.hasSession("s3")).toBe(true); // admitted
+            expect(s1Close).toHaveBeenCalledOnce(); // local transport torn down
+
+            const evicted = (await metrics.get("sessionClosed").get()).values.find(
+                (v) => v.labels.reason === "evicted"
+            );
+            expect(evicted?.value).toBe(1);
+            // Exactly at capacity again: one evicted, one admitted.
+            expect((await metrics.get("sessionsActive").get()).values[0]?.value).toBe(2);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("rejects a new session when no session is idle past the grace", async () => {
+        vi.useFakeTimers();
+        try {
+            const store = makeStore(1);
+            await store.addSession({
+                sessionId: "s1",
+                transport: createMockTransport(),
+                logger: createMockLogger(),
+                session: createMockSession(),
+            });
+
+            // s1 idle only 1 min — under the 2-min grace, so it must not be evicted.
+            await vi.advanceTimersByTimeAsync(60_000);
+
+            await expect(
+                store.addSession({
+                    sessionId: "s2",
+                    transport: createMockTransport(),
+                    logger: createMockLogger(),
+                    session: createMockSession(),
+                })
+            ).rejects.toThrow(SessionLimitExceededError);
+
+            expect(store.hasSession("s1")).toBe(true); // incumbent preserved
+            expect(store.hasSession("s2")).toBe(false); // newcomer rejected
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("evicts once a previously-too-fresh session crosses the grace", async () => {
+        vi.useFakeTimers();
+        try {
+            const store = makeStore(1);
+            await store.addSession({
+                sessionId: "s1",
+                transport: createMockTransport(),
+                logger: createMockLogger(),
+                session: createMockSession(),
+            });
+
+            // Just under the grace -> reject.
+            await vi.advanceTimersByTimeAsync(119_000);
+            await expect(
+                store.addSession({
+                    sessionId: "s2",
+                    transport: createMockTransport(),
+                    logger: createMockLogger(),
+                    session: createMockSession(),
+                })
+            ).rejects.toThrow(SessionLimitExceededError);
+
+            // Cross the grace -> s1 now evictable.
+            await vi.advanceTimersByTimeAsync(2_000);
+            await store.addSession({
+                sessionId: "s3",
+                transport: createMockTransport(),
+                logger: createMockLogger(),
+                session: createMockSession(),
+            });
+
+            expect(store.hasSession("s1")).toBe(false);
+            expect(store.hasSession("s3")).toBe(true);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
+describe("SessionStore eviction under concurrent admissions", () => {
+    function makeStore(maxSessions: number, metrics: MockMetrics): SessionStore {
+        return new SessionStore({
+            options: {
+                idleTimeoutMS: 600_000,
+                notificationTimeoutMS: 30_000,
+                maxSessions,
+                evictionIdleGraceMS: 120_000,
+            },
+            logger: createMockLogger(),
+            metrics,
+        });
+    }
+
+    function add(store: SessionStore, sessionId: string): Promise<void> {
+        return store.addSession({
+            sessionId,
+            transport: createMockTransport(),
+            logger: createMockLogger(),
+            session: createMockSession(),
+        });
+    }
+
+    // addSession has no await between the capacity check and the map insert (the eviction is a
+    // fire-and-forget closeSession that deletes the victim synchronously). So concurrently-issued
+    // admissions run to completion one at a time: each evicts exactly one LRU victim and the map
+    // never exceeds the cap. Were eviction ever awaited, a second admission could observe the
+    // freed slot mid-teardown and over-fill — these tests would catch that.
+    it("admits a full concurrent burst without over-evicting or exceeding the cap", async () => {
+        vi.useFakeTimers();
+        try {
+            const metrics = new MockMetrics();
+            const store = makeStore(3, metrics);
+
+            await add(store, "s1");
+            await add(store, "s2");
+            await add(store, "s3");
+
+            // All three incumbents idle past the grace, so all are evictable.
+            await vi.advanceTimersByTimeAsync(150_000);
+
+            // Three admissions issued in the same tick, each arriving at capacity.
+            await Promise.all([add(store, "s4"), add(store, "s5"), add(store, "s6")]);
+
+            // Each admission evicted one distinct LRU incumbent; every newcomer survived.
+            expect(store.hasSession("s1")).toBe(false);
+            expect(store.hasSession("s2")).toBe(false);
+            expect(store.hasSession("s3")).toBe(false);
+            expect(store.hasSession("s4")).toBe(true);
+            expect(store.hasSession("s5")).toBe(true);
+            expect(store.hasSession("s6")).toBe(true);
+
+            // Exactly one eviction per admission — not more (no over-eviction) — and the store is
+            // back at exactly the cap (no over-capacity).
+            expect(
+                (await metrics.get("sessionClosed").get()).values.find((v) => v.labels.reason === "evicted")?.value
+            ).toBe(3);
+            expect((await metrics.get("sessionsActive").get()).values[0]?.value).toBe(3);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("admits only as many as it can evict and rejects the excess, never evicting a fresh newcomer", async () => {
+        vi.useFakeTimers();
+        try {
+            const metrics = new MockMetrics();
+            const store = makeStore(2, metrics);
+
+            await add(store, "s1");
+            await add(store, "s2");
+
+            // Only the two incumbents are idle past the grace.
+            await vi.advanceTimersByTimeAsync(150_000);
+
+            // Four admissions at capacity, but only two idle victims exist to make room.
+            const results = await Promise.allSettled([
+                add(store, "s3"),
+                add(store, "s4"),
+                add(store, "s5"),
+                add(store, "s6"),
+            ]);
+
+            // Two admitted (evicting the two idle incumbents), two rejected — the fresh
+            // just-admitted sessions are protected by the grace, so the burst can't cascade into
+            // evicting its own newcomers.
+            expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(2);
+            expect(results.filter((r) => r.status === "rejected")).toHaveLength(2);
+            for (const r of results) {
+                if (r.status === "rejected") {
+                    expect(r.reason).toBeInstanceOf(SessionLimitExceededError);
+                }
+            }
+
+            expect(store.hasSession("s1")).toBe(false);
+            expect(store.hasSession("s2")).toBe(false);
+            expect(store.hasSession("s3")).toBe(true);
+            expect(store.hasSession("s4")).toBe(true);
+            expect(store.hasSession("s5")).toBe(false);
+            expect(store.hasSession("s6")).toBe(false);
+
+            // Only the two idle incumbents were evicted — never a freshly-admitted session.
+            expect(
+                (await metrics.get("sessionClosed").get()).values.find((v) => v.labels.reason === "evicted")?.value
+            ).toBe(2);
+            expect((await metrics.get("sessionsActive").get()).values[0]?.value).toBe(2);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});


### PR DESCRIPTION
## Proposed changes
When a server is at capacity for the maximum sessions it can hold, we will attempt to first evict the least recently used session that has passed an idle grace period and evict that to make some space for new session. If all the sessions in the session queue are active, only then we will reject.

The eviction is same as idle timeout, it just happen more aggressively to maintain a healthy capacity.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
