### PR TITLE
feat: Add multi-region support in atlas-create-cluster

### DIFF
--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -376,7 +376,7 @@ export class CreateClusterTool extends AtlasToolBase {
             AZURE: "AZURE";
             GCP: "GCP";
         }>;
-        region: z.ZodString;
+        regions: z.ZodArray<z.ZodString>;
         clusterType: z.ZodDefault<z.ZodEnum<{
             REPLICASET: "REPLICASET";
             SHARDED: "SHARDED";
@@ -428,7 +428,7 @@ export class CreateClusterTool extends AtlasToolBase {
             AZURE: "AZURE";
             GCP: "GCP";
         }>;
-        region: z.ZodString;
+        regions: z.ZodArray<z.ZodString>;
         instanceSize: z.ZodEnum<{
             M10: "M10";
             M20: "M20";

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -296,7 +296,7 @@ export type PauseResumeClusterMetadata = AtlasMetadata & {
 export type CreateClusterMetadata = AtlasMetadata & {
     cluster_id?: string;
     provider?: string;
-    region?: string;
+    regions?: string[];
     instance_size?: string;
     cluster_type?: "REPLICASET" | "SHARDED";
     backup?: "OFF" | "SNAPSHOT" | "CONTINUOUS";

--- a/src/tools/atlas/create/createCluster.ts
+++ b/src/tools/atlas/create/createCluster.ts
@@ -81,24 +81,29 @@ function buildAutoScaling(
     };
 }
 
+const ELECTABLE_NODE_DISTRIBUTIONS = [[3], [2, 1], [2, 2, 1]] as const;
+
 function buildReplicationSpecs(
     provider: CloudProvider,
-    region: string,
+    regions: string[],
     instanceSize: InstanceSize,
     autoScaling: AutoScalingConfig,
     diskSizeGB?: number
 ): ReplicationSpec[] {
+    const nodeDistribution = ELECTABLE_NODE_DISTRIBUTIONS[regions.length - 1] ?? [];
+
     return [
         {
-            regionConfigs: [
-                {
+            regionConfigs: regions.map((regionName, i) => {
+                const nodeCount = nodeDistribution[i] ?? 3;
+                return {
                     providerName: provider,
-                    regionName: region,
-                    priority: 7,
-                    electableSpecs: { instanceSize, nodeCount: 3, diskSizeGB },
+                    regionName,
+                    priority: 7 - i,
+                    electableSpecs: { instanceSize, nodeCount, diskSizeGB },
                     autoScaling,
-                },
-            ],
+                };
+            }),
         },
     ];
 }
@@ -138,9 +143,13 @@ export const CreateClusterArgsShape = {
 
     provider: cloudProviderEnum.describe("Cloud provider for the cluster."),
 
-    region: AtlasArgs.region().describe(
-        "Cloud provider region in Atlas format using uppercase letters and underscores (e.g. US_EAST_1)."
-    ),
+    regions: z
+        .array(AtlasArgs.region())
+        .min(1)
+        .max(3)
+        .describe(
+            "Cloud provider regions in Atlas format using uppercase letters and underscores (e.g. US_EAST_1). The first region has the highest priority. Do not include duplicate regions."
+        ),
 
     clusterType: clusterTypeEnum
         .default("REPLICASET")
@@ -198,7 +207,7 @@ export const CreateClusterArgsShape = {
 const CreateClusterOutputSchema = {
     clusterId: z.string().optional(),
     provider: cloudProviderEnum,
-    region: z.string(),
+    regions: z.array(z.string()),
     instanceSize: instanceSizeEnum,
     clusterType: clusterTypeEnum,
     mongoDBVersion: mongoDBVersionEnum,
@@ -213,13 +222,13 @@ export class CreateClusterTool extends AtlasToolBase {
     static toolName = "atlas-create-cluster";
     static operationType: OperationType = "create";
     public description =
-        "Create a MongoDB Atlas cluster (M10–M80, replica set or single shard). " +
+        "Create a MongoDB Atlas cluster (M10–M80, replica set or single shard, single or multi-region). " +
         "Compute autoscaling is enabled by default: min instance size is set to the selected instance size, max is set two tiers above. " +
         "Disk autoscaling is always enabled. " +
         "For encryption at rest, the CMK provider must already have a valid configuration in the Atlas project. " +
         "The tool returns immediately, use the atlas-inspect-cluster tool to poll the cluster state for readiness (state: IDLE). " +
         "Connection strings are unavailable until the cluster reaches IDLE state. " +
-        "Note to LLM: Omit instance size unless specified by the user. If provider and region are not already known, ask for both together in a single question before calling this tool. " +
+        "Note to LLM: Omit instance size unless specified by the user. If provider and regions are not already known, ask for both together in a single question before calling this tool. " +
         REGION_RECOMMENDATIONS;
     public override outputSchema = CreateClusterOutputSchema;
     public argsShape = CreateClusterArgsShape;
@@ -228,7 +237,7 @@ export class CreateClusterTool extends AtlasToolBase {
         args: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
-        const { projectId, clusterName, provider, region, clusterType, terminationProtectionEnabled } = args;
+        const { projectId, clusterName, provider, regions, clusterType, terminationProtectionEnabled } = args;
 
         if (clusterType === "SHARDED" && (args.instanceSize === "M10" || args.instanceSize === "M20")) {
             throw new CreateClusterError("SHARDED clusters require M30 or higher instance size.");
@@ -246,7 +255,7 @@ export class CreateClusterTool extends AtlasToolBase {
         }
 
         const autoScaling = buildAutoScaling(instanceSize, args.computeAutoScaling, provider);
-        const replicationSpecs = buildReplicationSpecs(provider, region, instanceSize, autoScaling, args.diskSizeGB);
+        const replicationSpecs = buildReplicationSpecs(provider, regions, instanceSize, autoScaling, args.diskSizeGB);
         const backupConfig = buildBackupConfig(args.backup);
         const versionConfig = buildVersionConfig(args.mongoDBVersion);
 
@@ -283,7 +292,7 @@ export class CreateClusterTool extends AtlasToolBase {
                 {
                     type: "text",
                     text:
-                        `Cluster "${clusterName}" is being created in project "${projectId}" (${instanceSize} ${clusterType} on ${provider}/${region}). ` +
+                        `Cluster "${clusterName}" is being created in project "${projectId}" (${instanceSize} ${clusterType} on ${provider}/${regions.join(", ")}). ` +
                         `Use the atlas-inspect-cluster tool with projectId "${projectId}" and clusterName "${clusterName}" to poll for readiness. ` +
                         `The cluster is ready when its state is IDLE, connection strings are unavailable until then.`,
                 },
@@ -292,7 +301,7 @@ export class CreateClusterTool extends AtlasToolBase {
             structuredContent: {
                 clusterId: result.id,
                 provider,
-                region,
+                regions,
                 instanceSize,
                 clusterType,
                 mongoDBVersion: args.mongoDBVersion,
@@ -360,7 +369,7 @@ export class CreateClusterTool extends AtlasToolBase {
             ...parentMetadata,
             cluster_id: sc?.clusterId,
             provider: sc?.provider,
-            region: sc?.region,
+            regions: sc?.regions,
             instance_size: sc?.instanceSize,
             cluster_type: sc?.clusterType,
             backup: sc?.backup,

--- a/tests/accuracy/createCluster.test.ts
+++ b/tests/accuracy/createCluster.test.ts
@@ -17,23 +17,23 @@ interface ClusterMockParams {
     mongoDBVersion?: string;
     clusterType?: string;
     provider?: string;
-    region?: string;
+    regions?: string[];
 }
 
 function mockCreateClusterResponse({
     projectId,
     clusterName,
     provider,
-    region,
+    regions,
     instanceSize = "M10",
     clusterType = "REPLICASET",
-}: ClusterMockParams): () => CallToolResult {
+}: ClusterMockParams & { regions: string[] }): () => CallToolResult {
     return () => ({
         content: [
             {
                 type: "text",
                 text:
-                    `Cluster "${clusterName}" is being created in project "${projectId}" (${instanceSize} ${clusterType} on ${provider}/${region}). ` +
+                    `Cluster "${clusterName}" is being created in project "${projectId}" (${instanceSize} ${clusterType} on ${provider}/${regions.join(", ")}). ` +
                     `Use the atlas-inspect-cluster tool with projectId "${projectId}" and clusterName "${clusterName}" to poll for readiness. ` +
                     `The cluster is ready when its state is IDLE, connection strings are unavailable until then.`,
             },
@@ -41,26 +41,16 @@ function mockCreateClusterResponse({
     });
 }
 
-function mockInspectClusterResponse({
-    clusterName,
-    instanceSize,
-    mongoDBVersion,
-    provider,
-    region,
-}: ClusterMockParams): () => CallToolResult {
+function mockInspectClusterResponse(name: string): () => CallToolResult {
     return (): CallToolResult => ({
         content: [
             {
                 type: "text",
                 text: JSON.stringify({
-                    name: clusterName,
+                    name,
                     paused: false,
                     state: "IDLE",
-                    instanceSize,
-                    mongoDBVersion,
-                    provider,
-                    region,
-                    connectionStrings: { standardSrv: `mongodb+srv://${clusterName}.example.mongodb.net` },
+                    connectionStrings: { standardSrv: `mongodb+srv://${name}.example.mongodb.net` },
                 }),
             },
         ],
@@ -84,7 +74,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "AWS",
-                region: "US_EAST_1",
+                regions: ["US_EAST_1"],
             }),
         },
         expectedToolCalls: [
@@ -95,7 +85,57 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "AWS",
-                    region: "US_EAST_1",
+                    regions: ["US_EAST_1"],
+                    clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
+                },
+            },
+        ],
+    },
+    {
+        prompt: `Create a cluster named "${CLUSTER_NAME}" in project "${PROJECT_ID}" on AWS with US_EAST_1 as the highest-priority region and US_WEST_2 as the second region`,
+        mockedTools: {
+            ...mockListProjects,
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "AWS",
+                regions: ["US_EAST_1", "US_WEST_2"],
+            }),
+        },
+        expectedToolCalls: [
+            ...optionalListProjects,
+            {
+                toolName: "atlas-create-cluster",
+                parameters: {
+                    projectId: PROJECT_ID,
+                    clusterName: CLUSTER_NAME,
+                    provider: "AWS",
+                    regions: ["US_EAST_1", "US_WEST_2"],
+                    clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
+                },
+            },
+        ],
+    },
+    {
+        prompt: `Create a cluster named "${CLUSTER_NAME}" in project "${PROJECT_ID}" on AWS EU_WEST_1, EU_CENTRAL_1 and EU_WEST_2`,
+        mockedTools: {
+            ...mockListProjects,
+            "atlas-create-cluster": mockCreateClusterResponse({
+                projectId: PROJECT_ID,
+                clusterName: CLUSTER_NAME,
+                provider: "AWS",
+                regions: ["EU_WEST_1", "EU_CENTRAL_1", "EU_WEST_2"],
+            }),
+        },
+        expectedToolCalls: [
+            ...optionalListProjects,
+            {
+                toolName: "atlas-create-cluster",
+                parameters: {
+                    projectId: PROJECT_ID,
+                    clusterName: CLUSTER_NAME,
+                    provider: "AWS",
+                    regions: ["EU_WEST_1", "EU_CENTRAL_1", "EU_WEST_2"],
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },
             },
@@ -109,7 +149,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "GCP",
-                region: "CENTRAL_US",
+                regions: ["CENTRAL_US"],
                 instanceSize: "M30",
             }),
         },
@@ -121,7 +161,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "GCP",
-                    region: "CENTRAL_US",
+                    regions: ["CENTRAL_US"],
                     instanceSize: "M30",
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },
@@ -136,7 +176,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "AZURE",
-                region: "EUROPE_WEST",
+                regions: ["EUROPE_WEST"],
             }),
         },
         expectedToolCalls: [
@@ -147,7 +187,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "AZURE",
-                    region: "EUROPE_WEST",
+                    regions: ["EUROPE_WEST"],
                     mongoDBVersion: "7.0",
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },
@@ -162,7 +202,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "AWS",
-                region: "US_EAST_1",
+                regions: ["US_EAST_1"],
             }),
         },
         expectedToolCalls: [
@@ -173,7 +213,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "AWS",
-                    region: "US_EAST_1",
+                    regions: ["US_EAST_1"],
                     backup: "CONTINUOUS",
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },
@@ -188,7 +228,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "GCP",
-                region: "SOUTH_AMERICA_EAST_1",
+                regions: ["SOUTH_AMERICA_EAST_1"],
             }),
         },
         expectedToolCalls: [
@@ -199,7 +239,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "GCP",
-                    region: "SOUTH_AMERICA_EAST_1",
+                    regions: ["SOUTH_AMERICA_EAST_1"],
                     backup: "OFF",
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },
@@ -214,7 +254,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "AZURE",
-                region: "EUROPE_NORTH",
+                regions: ["EUROPE_NORTH"],
                 instanceSize: "M30",
             }),
         },
@@ -226,7 +266,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "AZURE",
-                    region: "EUROPE_NORTH",
+                    regions: ["EUROPE_NORTH"],
                     instanceSize: "M30",
                     computeAutoScaling: false,
                     backup: "OFF",
@@ -243,7 +283,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "AWS",
-                region: "EU_WEST_1",
+                regions: ["EU_WEST_1"],
             }),
         },
         expectedToolCalls: [
@@ -254,7 +294,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "AWS",
-                    region: "EU_WEST_1",
+                    regions: ["EU_WEST_1"],
                     terminationProtectionEnabled: true,
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },
@@ -269,7 +309,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "GCP",
-                region: "US_EAST_4",
+                regions: ["US_EAST_4"],
                 clusterType: "SHARDED",
                 instanceSize: "M30",
             }),
@@ -282,7 +322,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "GCP",
-                    region: "US_EAST_4",
+                    regions: ["US_EAST_4"],
                     clusterType: "SHARDED",
                     instanceSize: Matcher.anyOf(Matcher.undefined, Matcher.value("M30")),
                 },
@@ -300,7 +340,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "AWS",
-                region: "US_EAST_1",
+                regions: ["US_EAST_1"],
             }),
         },
         expectedToolCalls: [
@@ -314,7 +354,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "AWS",
-                    region: "US_EAST_1",
+                    regions: ["US_EAST_1"],
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },
             },
@@ -329,9 +369,9 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "AWS",
-                region: "US_EAST_1",
+                regions: ["US_EAST_1"],
             }),
-            "atlas-inspect-cluster": mockInspectClusterResponse({ projectId: PROJECT_ID, clusterName: CLUSTER_NAME }),
+            "atlas-inspect-cluster": mockInspectClusterResponse(CLUSTER_NAME),
         },
         expectedToolCalls: [
             ...optionalListProjects,
@@ -341,7 +381,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "AWS",
-                    region: "US_EAST_1",
+                    regions: ["US_EAST_1"],
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },
             },
@@ -406,7 +446,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: SOURCE_CLUSTER_NAME,
                 provider: "AWS",
-                region: "EU_WEST_1",
+                regions: ["EU_WEST_1"],
                 instanceSize: "M40",
             }),
         },
@@ -433,7 +473,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: SOURCE_CLUSTER_NAME,
                     provider: "AWS",
-                    region: "EU_WEST_1",
+                    regions: ["EU_WEST_1"],
                     instanceSize: "M40",
                     mongoDBVersion: "7.0",
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
@@ -449,7 +489,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "AWS",
-                region: "US_EAST_1",
+                regions: ["US_EAST_1"],
             }),
         },
         expectedToolCalls: [
@@ -460,7 +500,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "AWS",
-                    region: "US_EAST_1",
+                    regions: ["US_EAST_1"],
                     encryptionAtRestProvider: "AWS",
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },
@@ -475,7 +515,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "AZURE",
-                region: "EUROPE_WEST",
+                regions: ["EUROPE_WEST"],
             }),
         },
         expectedToolCalls: [
@@ -486,7 +526,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "AZURE",
-                    region: "EUROPE_WEST",
+                    regions: ["EUROPE_WEST"],
                     encryptionAtRestProvider: "GCP",
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },
@@ -501,7 +541,7 @@ describeAccuracyTests([
                 projectId: PROJECT_ID,
                 clusterName: CLUSTER_NAME,
                 provider: "AWS",
-                region: "US_EAST_1",
+                regions: ["US_EAST_1"],
             }),
         },
         expectedToolCalls: [
@@ -512,7 +552,7 @@ describeAccuracyTests([
                     projectId: PROJECT_ID,
                     clusterName: CLUSTER_NAME,
                     provider: "AWS",
-                    region: "US_EAST_1",
+                    regions: ["US_EAST_1"],
                     encryptionAtRestProvider: "NONE",
                     clusterType: Matcher.anyOf(Matcher.undefined, Matcher.value("REPLICASET")),
                 },

--- a/tests/integration/tools/atlas/clusters.test.ts
+++ b/tests/integration/tools/atlas/clusters.test.ts
@@ -471,7 +471,7 @@ describeWithAtlas("clusters", (integration) => {
                 expect(properties).toHaveProperty("projectId");
                 expect(properties).toHaveProperty("clusterName");
                 expect(properties).toHaveProperty("provider");
-                expect(properties).toHaveProperty("region");
+                expect(properties).toHaveProperty("regions");
                 expect(properties).toHaveProperty("clusterType");
                 expect(properties).toHaveProperty("instanceSize");
                 expect(properties).toHaveProperty("computeAutoScaling");
@@ -485,10 +485,10 @@ describeWithAtlas("clusters", (integration) => {
                 expect(required).toContain("projectId");
                 expect(required).toContain("clusterName");
                 expect(required).toContain("provider");
-                expect(required).toContain("region");
+                expect(required).toContain("regions");
             });
 
-            it("creates a dedicated cluster", async () => {
+            it("creates a multi-region dedicated cluster", async () => {
                 clusterName = "ClusterTest-" + randomId();
                 const projectId = getProjectId();
 
@@ -498,7 +498,7 @@ describeWithAtlas("clusters", (integration) => {
                         projectId,
                         clusterName,
                         provider: "AWS",
-                        region: "US_EAST_1",
+                        regions: ["US_EAST_1", "US_WEST_2"],
                         instanceSize: "M10",
                         diskSizeGB: 20,
                         encryptionAtRestProvider: "NONE",
@@ -510,12 +510,13 @@ describeWithAtlas("clusters", (integration) => {
                 const content = getResponseContent(response.content);
                 expect(content).toContain(clusterName);
                 expect(content).toContain(projectId);
+                expect(content).toContain("US_EAST_1, US_WEST_2");
                 expect(content).toContain("atlas-inspect-cluster");
                 expect(content).toContain("IDLE");
 
                 expect(response.structuredContent).toMatchObject({
                     provider: "AWS",
-                    region: "US_EAST_1",
+                    regions: ["US_EAST_1", "US_WEST_2"],
                     instanceSize: "M10",
                     clusterType: "REPLICASET",
                     mongoDBVersion: "LATEST",
@@ -587,7 +588,7 @@ describeWithAtlas("clusters", (integration) => {
                             projectId,
                             clusterName: clusterName,
                             provider: "AZURE",
-                            region: "US_EAST_2",
+                            regions: ["US_EAST_2"],
                             instanceSize: "M10",
                         },
                     });

--- a/tests/unit/tools/atlas/create/createCluster.test.ts
+++ b/tests/unit/tools/atlas/create/createCluster.test.ts
@@ -17,7 +17,7 @@ const BASE_ARGS = {
     projectId: "507f1f77bcf86cd799439011",
     clusterName: "my-cluster",
     provider: "AWS" as const,
-    region: "US_EAST_1",
+    regions: ["US_EAST_1"],
 };
 
 const CREATE_RESULT = { id: "new-cluster-id" };
@@ -179,6 +179,36 @@ describe("CreateClusterTool", () => {
                     },
                 },
                 expect.anything()
+            );
+        });
+
+        it.each([
+            [["US_EAST_1"], [3]],
+            [
+                ["US_EAST_1", "US_WEST_2"],
+                [2, 1],
+            ],
+            [
+                ["US_EAST_1", "US_WEST_2", "EU_WEST_1"],
+                [2, 2, 1],
+            ],
+        ] as const)("builds the expected region configs for %j", async (regions, expectedNodeCounts) => {
+            const result = await exec({
+                ...BASE_ARGS,
+                regions,
+            });
+
+            expect(result.isError).toBeFalsy();
+            const createRequest = mockApiClient.createCluster?.mock.calls[0]?.[0] as {
+                body: { replicationSpecs: [{ regionConfigs: unknown }] };
+            };
+            expect(createRequest.body.replicationSpecs[0].regionConfigs).toMatchObject(
+                regions.map((regionName, i) => ({
+                    providerName: "AWS",
+                    regionName,
+                    priority: 7 - i,
+                    electableSpecs: { nodeCount: expectedNodeCounts[i] },
+                }))
             );
         });
     });
@@ -376,17 +406,23 @@ describe("CreateClusterTool", () => {
 
     describe("response", () => {
         it("returns expected text content and structuredContent", async () => {
-            const result = await exec({ ...BASE_ARGS, instanceSize: "M10", encryptionAtRestProvider: "AZURE" });
+            const result = await exec({
+                ...BASE_ARGS,
+                regions: ["US_EAST_1", "US_WEST_2"],
+                instanceSize: "M10",
+                encryptionAtRestProvider: "AZURE",
+            });
 
             expect(result.isError).toBeFalsy();
             const text = (result.content[0] as { text: string }).text;
             expect(text).toContain("my-cluster");
             expect(text).toContain("507f1f77bcf86cd799439011");
+            expect(text).toContain("US_EAST_1, US_WEST_2");
             expect(text).toContain("atlas-inspect-cluster");
             expect(result.structuredContent).toMatchObject({
                 clusterId: "new-cluster-id",
                 provider: "AWS",
-                region: "US_EAST_1",
+                regions: ["US_EAST_1", "US_WEST_2"],
                 instanceSize: "M10",
                 clusterType: "REPLICASET",
                 mongoDBVersion: "LATEST",
@@ -436,13 +472,19 @@ describe("CreateClusterTool", () => {
 
     describe("telemetry metadata", () => {
         it("resolves all fields from structuredContent", async () => {
-            const args = { ...BASE_ARGS, instanceSize: "M30", diskSizeGB: 20, encryptionAtRestProvider: "GCP" };
+            const args = {
+                ...BASE_ARGS,
+                regions: ["US_EAST_1", "US_WEST_2"],
+                instanceSize: "M30",
+                diskSizeGB: 20,
+                encryptionAtRestProvider: "GCP",
+            };
             const result = await exec(args);
 
             const metadata = await tool["resolveTelemetryMetadata"](args as never, { result: result as never });
             expect(metadata.cluster_id).toBe("new-cluster-id");
             expect(metadata.provider).toBe("AWS");
-            expect(metadata.region).toBe("US_EAST_1");
+            expect(metadata.regions).toEqual(["US_EAST_1", "US_WEST_2"]);
             expect(metadata.instance_size).toBe("M30");
             expect(metadata.cluster_type).toBe("REPLICASET");
             expect(metadata.backup).toBe("SNAPSHOT");
@@ -460,7 +502,7 @@ describe("CreateClusterTool", () => {
 
             expect(metadata.cluster_id).toBeUndefined();
             expect(metadata.provider).toBeUndefined();
-            expect(metadata.region).toBeUndefined();
+            expect(metadata.regions).toBeUndefined();
             expect(metadata.instance_size).toBeUndefined();
             expect(metadata.cluster_type).toBeUndefined();
             expect(metadata.backup).toBeUndefined();
@@ -484,6 +526,13 @@ describe("CreateClusterTool", () => {
                 );
             }
         );
+
+        it.each([
+            ["no regions", []],
+            ["more than three regions", ["US_EAST_1", "US_WEST_2", "EU_WEST_1", "AP_SOUTHEAST_1"]],
+        ] as const)("returns error when passing %s", (_case, regions) => {
+            expect(() => z.object(CreateClusterArgsShape).parse({ ...BASE_ARGS, regions })).toThrow();
+        });
 
         it("returns error when createCluster API call fails", async () => {
             mockApiClient.createCluster!.mockRejectedValue(new Error("network error"));


### PR DESCRIPTION
## Description

Adding multi-region cluster support to the `atlas-create-cluster` tool.
* The tool now takes a `regions` array of 1 to 3 regions in priority order.
* Electable node distribution is abstracted following Atlas's recommended resiliency pattern.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
