### PR TITLE
fix: handle createCluster region in a backwards-compatible way CLOUDP-407395

### DIFF
--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -418,6 +418,7 @@ export class CreateClusterTool extends AtlasToolBase {
     protected execute(args: ToolArgs<typeof CreateClusterTool.argsShape>, context: ToolExecutionContext): Promise<ToolResult<typeof CreateClusterTool.outputSchema>>;
     // (undocumented)
     protected handleError(error: unknown, args: ToolArgs<typeof CreateClusterTool.argsShape>): CallToolResult;
+    normalizeRawArgs(args: Record<string, unknown>): Record<string, unknown>;
     // (undocumented)
     static operationType: OperationType;
     // (undocumented)
@@ -2138,6 +2139,7 @@ export abstract class ToolBase<TUserConfig extends UserConfig = UserConfig, TCon
     protected isFeatureEnabled(feature: PreviewFeature): boolean;
     protected readonly metrics: Metrics<TMetrics>;
     readonly name: string;
+    normalizeRawArgs(args: Record<string, unknown>): Record<string, unknown>;
     readonly operationType: OperationType;
     outputSchema?: ZodRawShape;
     // (undocumented)

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -1056,6 +1056,7 @@ export abstract class ToolBase<TUserConfig extends UserConfig = UserConfig, TCon
     protected isFeatureEnabled(feature: PreviewFeature): boolean;
     protected readonly metrics: Metrics<TMetrics>;
     readonly name: string;
+    normalizeRawArgs(args: Record<string, unknown>): Record<string, unknown>;
     readonly operationType: OperationType;
     outputSchema?: ZodRawShape;
     // (undocumented)

--- a/src/server.ts
+++ b/src/server.ts
@@ -173,7 +173,10 @@ export class Server<
         // TODO: Eventually we might want to make tools reactive too instead of relying on custom logic.
         this.registerTools();
 
-        // This is a workaround for an issue we've seen with some models, where they'll see that everything in the `arguments`
+        // Wrapping the tool call handler to normalize the arguments before the SDK validates them against the
+        // tool's schema. This gives tools a chance to map deprecated arguments through `normalizeRawArgs`.
+        //
+        // It also works around an issue we've seen with some models, where they'll see that everything in the `arguments`
         // object is optional, and then not pass it at all. However, the MCP server expects the `arguments` object to be if
         // the tool accepts any arguments, even if they're all optional.
         //
@@ -191,9 +194,9 @@ export class Server<
         }
 
         this.mcpServer.server.setRequestHandler(CallToolRequestSchema, (request, extra): Promise<CallToolResult> => {
-            if (!request.params.arguments) {
-                request.params.arguments = {};
-            }
+            const args = request.params.arguments ?? {};
+            const tool = this.tools.find((t) => t.name === request.params.name);
+            request.params.arguments = tool ? tool.normalizeRawArgs(args) : args;
 
             return existingHandler(request, extra);
         });

--- a/src/tools/atlas/create/createCluster.ts
+++ b/src/tools/atlas/create/createCluster.ts
@@ -233,6 +233,16 @@ export class CreateClusterTool extends AtlasToolBase {
     public override outputSchema = CreateClusterOutputSchema;
     public argsShape = CreateClusterArgsShape;
 
+    /** Accepts the `region` argument that `regions` replaced, mapping it to a single-region cluster. */
+    public override normalizeRawArgs(args: Record<string, unknown>): Record<string, unknown> {
+        if (typeof args.region !== "string") {
+            return args;
+        }
+
+        const { region, ...rest } = args;
+        return { ...rest, regions: rest.regions ?? [region] };
+    }
+
     protected async execute(
         args: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -395,6 +395,25 @@ export abstract class ToolBase<
      */
     public outputSchema?: ZodRawShape;
 
+    /**
+     * Normalizes the raw arguments of a tool call before they are validated against `argsShape`.
+     *
+     * Override this to keep accepting arguments that are no longer part of the tool's schema,
+     * such as a renamed argument. Arguments that are not mapped to a key of `argsShape` are
+     * rejected by the schema validation that follows.
+     *
+     * @example
+     * ```typescript
+     * public override normalizeRawArgs(args: Record<string, unknown>): Record<string, unknown> {
+     *   const { limit, ...rest } = args;
+     *   return limit === undefined ? args : { ...rest, maxResults: limit };
+     * }
+     * ```
+     */
+    public normalizeRawArgs(args: Record<string, unknown>): Record<string, unknown> {
+        return args;
+    }
+
     private registeredTool: RegisteredTool | undefined;
 
     public get annotations(): ToolAnnotations {

--- a/tests/integration/customTools.test.ts
+++ b/tests/integration/customTools.test.ts
@@ -8,7 +8,7 @@ import { defaultTestConfig, setupIntegrationTest } from "./helpers.js";
 describe("Custom Tools", () => {
     const { mcpClient, mcpServer } = setupIntegrationTest(() => ({ ...defaultTestConfig }), {
         serverOptions: {
-            tools: [CustomGreetingTool, CustomCalculatorTool],
+            tools: [CustomGreetingTool, CustomCalculatorTool, CustomRenamedArgTool],
         },
     });
 
@@ -64,6 +64,23 @@ describe("Custom Tools", () => {
         ]);
     });
 
+    it("should normalize deprecated arguments before validating them", async () => {
+        const tools = await mcpClient().listTools();
+        const renamedArgTool = tools.tools.find((t) => t.name === "custom_renamed_arg");
+
+        // The deprecated argument is not advertised, the replacement stays required.
+        expect(Object.keys(renamedArgTool?.inputSchema.properties ?? {})).toEqual(["names"]);
+        expect(renamedArgTool?.inputSchema.required).toEqual(["names"]);
+
+        const result = await mcpClient().callTool({
+            name: "custom_renamed_arg",
+            arguments: { name: "World" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        expect(result.content).toEqual([{ type: "text", text: "Hello, World!" }]);
+    });
+
     it("should respect tool categories and operation types from custom tools", () => {
         const customGreetingTool = mcpServer().tools.find((t) => t.name === "custom_greeting");
         expect(customGreetingTool?.category).toBe("mongodb");
@@ -95,6 +112,38 @@ class CustomGreetingTool extends ToolBase {
                     text: `Hello, ${name}! This is a custom tool.`,
                 },
             ],
+        });
+    }
+
+    protected resolveTelemetryMetadata(): TelemetryToolMetadata {
+        return {};
+    }
+}
+
+/**
+ * Example custom tool that keeps accepting an argument that has been renamed
+ */
+class CustomRenamedArgTool extends ToolBase {
+    static toolName = "custom_renamed_arg";
+    static category = "mongodb" as const;
+    static operationType = "read" as const;
+    public description = "A custom tool with a renamed argument";
+    public argsShape = {
+        names: z.array(z.string()).min(1).describe("The names to greet"),
+    };
+
+    public override normalizeRawArgs(args: Record<string, unknown>): Record<string, unknown> {
+        if (typeof args.name !== "string") {
+            return args;
+        }
+
+        const { name, ...rest } = args;
+        return { ...rest, names: rest.names ?? [name] };
+    }
+
+    public execute({ names }: ToolArgs<typeof this.argsShape>): Promise<CallToolResult> {
+        return Promise.resolve({
+            content: [{ type: "text", text: `Hello, ${names.join(", ")}!` }],
         });
     }
 

--- a/tests/unit/tools/atlas/create/createCluster.test.ts
+++ b/tests/unit/tools/atlas/create/createCluster.test.ts
@@ -13,10 +13,14 @@ import { MockMetrics } from "../../../mocks/metrics.js";
 import type { Keychain } from "../../../../../src/lib.js";
 import { ApiClientError } from "../../../../../src/common/atlas/apiClientError.js";
 
-const BASE_ARGS = {
+const BASE_ARGS_WITHOUT_REGIONS = {
     projectId: "507f1f77bcf86cd799439011",
     clusterName: "my-cluster",
     provider: "AWS" as const,
+};
+
+const BASE_ARGS = {
+    ...BASE_ARGS_WITHOUT_REGIONS,
     regions: ["US_EAST_1"],
 };
 
@@ -85,7 +89,10 @@ describe("CreateClusterTool", () => {
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["invoke"](z.object(CreateClusterArgsShape).parse(args) as never, {} as never);
+        tool["invoke"](
+            z.object(CreateClusterArgsShape).strict().parse(tool.normalizeRawArgs(args)) as never,
+            {} as never
+        );
 
     beforeEach(() => {
         tool = buildTool();
@@ -210,6 +217,26 @@ describe("CreateClusterTool", () => {
                     electableSpecs: { nodeCount: expectedNodeCounts[i] },
                 }))
             );
+        });
+
+        it("accepts the deprecated region argument as a single region", async () => {
+            const result = await exec({ ...BASE_ARGS_WITHOUT_REGIONS, region: "EU_WEST_1" });
+
+            expect(result.isError).toBeFalsy();
+            expect(result.structuredContent).toMatchObject({ regions: ["EU_WEST_1"] });
+            const createRequest = mockApiClient.createCluster?.mock.calls[0]?.[0] as {
+                body: { replicationSpecs: [{ regionConfigs: unknown }] };
+            };
+            expect(createRequest.body.replicationSpecs[0].regionConfigs).toMatchObject([
+                { providerName: "AWS", regionName: "EU_WEST_1", priority: 7, electableSpecs: { nodeCount: 3 } },
+            ]);
+        });
+
+        it("ignores the deprecated region argument when regions is also provided", async () => {
+            const result = await exec({ ...BASE_ARGS, region: "EU_WEST_1" });
+
+            expect(result.isError).toBeFalsy();
+            expect(result.structuredContent).toMatchObject({ regions: ["US_EAST_1"] });
         });
     });
 
@@ -532,6 +559,13 @@ describe("CreateClusterTool", () => {
             ["more than three regions", ["US_EAST_1", "US_WEST_2", "EU_WEST_1", "AP_SOUTHEAST_1"]],
         ] as const)("returns error when passing %s", (_case, regions) => {
             expect(() => z.object(CreateClusterArgsShape).parse({ ...BASE_ARGS, regions })).toThrow();
+        });
+
+        it.each([
+            ["no regions and no deprecated region", BASE_ARGS_WITHOUT_REGIONS],
+            ["a non-string deprecated region", { ...BASE_ARGS_WITHOUT_REGIONS, region: 42 }],
+        ])("returns error when passing %s", (_case, args) => {
+            expect(() => z.object(CreateClusterArgsShape).strict().parse(tool.normalizeRawArgs(args))).toThrow();
         });
 
         it("returns error when createCluster API call fails", async () => {


### PR DESCRIPTION
## Proposed changes

https://github.com/mongodb-js/mongodb-mcp-server/pull/1399 replaced region with regions for the create-cluster tool which may be a breaking change for clients that cache/lock down schemas. This PR proposes a mechanism to handle these types of changes in a backwards compatible way - it introduces a tool-specific normalizeArgs hook that can mutate the model-supplied args to match the desired shape. In this specific case, we look for `region` in the payload and use it to populate `regions` if not supplied.