### PR TITLE
chore: allow embedders to provide an implementation for fetch agent CLOUDP-427202

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -221,6 +221,7 @@ export interface ApiClientOptions {
     baseUrl: string;
     // (undocumented)
     credentials?: Credentials;
+    httpClient?: HttpClient;
     // (undocumented)
     requestContext?: RequestContext;
     supportsCurrentIpLookup?: boolean;
@@ -695,6 +696,12 @@ export class ExportsManager extends EventEmitter<ExportsManagerEvents> {
 export { Gauge }
 
 export { Histogram }
+
+// @public
+export type HttpClient = {
+    fetch: typeof fetch;
+    Request: typeof globalThis.Request;
+};
 
 // @public
 export interface ISessionStore<T extends CloseableTransport = CloseableTransport> {

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -208,6 +208,7 @@ export interface ApiClientOptions {
     baseUrl: string;
     // (undocumented)
     credentials?: Credentials;
+    httpClient?: HttpClient;
     // (undocumented)
     requestContext?: RequestContext;
     supportsCurrentIpLookup?: boolean;
@@ -704,6 +705,12 @@ export type ExportsManagerEvents = {
 
 // @public
 export function getRandomUUID(): string;
+
+// @public
+export type HttpClient = {
+    fetch: typeof fetch;
+    Request: typeof globalThis.Request;
+};
 
 // @public (undocumented)
 export interface InProgressExport extends CommonExportData {

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -6,6 +6,7 @@ import type { CommonProperties, TelemetryEvent } from "../../telemetry/types.js"
 import { packageInfo } from "../packageInfo.js";
 import type { LoggerBase } from "../logging/index.js";
 import { Request as NodeFetchRequest } from "node-fetch";
+import type { HttpClient } from "../proxyFetch.js";
 import { getSharedProxyFetch } from "../proxyFetch.js";
 import type { Credentials, AuthProvider } from "./auth/authProvider.js";
 import { AuthProviderFactory } from "./auth/authProvider.js";
@@ -28,6 +29,13 @@ export interface ApiClientOptions {
      * setup and direct users to provide IP addresses explicitly.
      */
     supportsCurrentIpLookup?: boolean;
+    /**
+     * Overrides the default proxy-aware `fetch` used for Atlas API and OAuth token
+     * requests. Embedders that don't need environment-variable proxy support or
+     * system CA trust can inject the platform `fetch`/`Request`, which pools
+     * connections and avoids rebuilding a TLS context per request.
+     */
+    httpClient?: HttpClient;
 }
 
 export type RequestContext = {
@@ -80,7 +88,7 @@ export class ApiClient {
         public readonly logger: LoggerBase,
         public readonly authProvider?: AuthProvider
     ) {
-        this.customFetch = getSharedProxyFetch();
+        this.customFetch = options.httpClient?.fetch ?? getSharedProxyFetch();
         this.options = {
             ...options,
             userAgent:
@@ -96,6 +104,7 @@ export class ApiClient {
                     apiBaseUrl: this.options.baseUrl,
                     userAgent: this.options.userAgent,
                     credentials: options.credentials ?? {},
+                    httpClient: options.httpClient,
                 },
                 logger
             );
@@ -110,7 +119,8 @@ export class ApiClient {
             // NodeFetchRequest has more overloadings than the native Request
             // so it complains here. However, the interfaces are actually compatible
             // so it's not a real problem, just a type checking problem.
-            Request: (isNodeRuntime() ? NodeFetchRequest : globalThis.Request) as unknown as ClientOptions["Request"],
+            Request: (options.httpClient?.Request ??
+                (isNodeRuntime() ? NodeFetchRequest : globalThis.Request)) as unknown as ClientOptions["Request"],
         });
 
         if (this.authProvider) {

--- a/src/common/atlas/apiClient.ts
+++ b/src/common/atlas/apiClient.ts
@@ -1,13 +1,12 @@
 import createClient from "openapi-fetch";
-import type { ClientOptions, FetchOptions, Client, Middleware } from "openapi-fetch";
+import type { FetchOptions, Client, Middleware } from "openapi-fetch";
 import { ApiClientError } from "./apiClientError.js";
 import type { components, paths, operations } from "./openapi.js";
 import type { CommonProperties, TelemetryEvent } from "../../telemetry/types.js";
 import { packageInfo } from "../packageInfo.js";
 import type { LoggerBase } from "../logging/index.js";
-import { Request as NodeFetchRequest } from "node-fetch";
 import type { HttpClient } from "../proxyFetch.js";
-import { getSharedProxyFetch } from "../proxyFetch.js";
+import { getDefaultHttpClient } from "../proxyFetch.js";
 import type { Credentials, AuthProvider } from "./auth/authProvider.js";
 import { AuthProviderFactory } from "./auth/authProvider.js";
 import { isNodeRuntime } from "../../helpers/isNodeRuntime.js";
@@ -75,8 +74,6 @@ export class ApiClient {
         supportsCurrentIpLookup: boolean;
     };
 
-    private customFetch: typeof fetch;
-
     private client: Client<paths>;
 
     public isAuthConfigured(): boolean {
@@ -88,7 +85,7 @@ export class ApiClient {
         public readonly logger: LoggerBase,
         public readonly authProvider?: AuthProvider
     ) {
-        this.customFetch = options.httpClient?.fetch ?? getSharedProxyFetch();
+        const httpClient = options.httpClient ?? getDefaultHttpClient();
         this.options = {
             ...options,
             userAgent:
@@ -104,7 +101,7 @@ export class ApiClient {
                     apiBaseUrl: this.options.baseUrl,
                     userAgent: this.options.userAgent,
                     credentials: options.credentials ?? {},
-                    httpClient: options.httpClient,
+                    httpClient,
                 },
                 logger
             );
@@ -115,12 +112,8 @@ export class ApiClient {
                 "User-Agent": this.options.userAgent,
                 Accept: `application/vnd.atlas.${ATLAS_API_VERSION}+json`,
             },
-            fetch: this.customFetch,
-            // NodeFetchRequest has more overloadings than the native Request
-            // so it complains here. However, the interfaces are actually compatible
-            // so it's not a real problem, just a type checking problem.
-            Request: (options.httpClient?.Request ??
-                (isNodeRuntime() ? NodeFetchRequest : globalThis.Request)) as unknown as ClientOptions["Request"],
+            fetch: httpClient.fetch,
+            Request: httpClient.Request,
         });
 
         if (this.authProvider) {

--- a/src/common/atlas/auth/authProvider.ts
+++ b/src/common/atlas/auth/authProvider.ts
@@ -1,4 +1,5 @@
 import type { LoggerBase } from "../../logging/index.js";
+import type { HttpClient } from "../../proxyFetch.js";
 import { ClientCredentialsAuthProvider } from "./clientCredentials.js";
 
 export interface AccessToken {
@@ -30,6 +31,7 @@ export interface AuthProviderOptions {
     apiBaseUrl: string;
     userAgent: string;
     credentials: Credentials;
+    httpClient?: HttpClient;
 }
 
 export class AuthProviderFactory {
@@ -41,6 +43,7 @@ export class AuthProviderFactory {
                     userAgent: options.userAgent,
                     clientId: options.credentials.clientId,
                     clientSecret: options.credentials.clientSecret,
+                    httpClient: options.httpClient,
                 },
                 logger
             );

--- a/src/common/atlas/auth/clientCredentials.ts
+++ b/src/common/atlas/auth/clientCredentials.ts
@@ -1,6 +1,7 @@
 import * as oauth from "oauth4webapi";
 import type { LoggerBase } from "../../logging/index.js";
 import { LogId } from "../../logging/index.js";
+import type { HttpClient } from "../../proxyFetch.js";
 import { getSharedProxyFetch } from "../../proxyFetch.js";
 import type { AccessToken, AuthProvider } from "./authProvider.js";
 
@@ -9,6 +10,7 @@ export interface ClientCredentialsAuthOptions {
     clientSecret: string;
     baseUrl: string;
     userAgent: string;
+    httpClient?: HttpClient;
 }
 
 export class ClientCredentialsAuthProvider implements AuthProvider {
@@ -30,7 +32,7 @@ export class ClientCredentialsAuthProvider implements AuthProvider {
             grant_types_supported: ["client_credentials"],
         };
 
-        this.customFetch = getSharedProxyFetch();
+        this.customFetch = options.httpClient?.fetch ?? getSharedProxyFetch();
     }
 
     public async getAuthHeaders(): Promise<Record<string, string> | undefined> {

--- a/src/common/proxyFetch.ts
+++ b/src/common/proxyFetch.ts
@@ -1,4 +1,5 @@
 import { createFetch } from "@mongodb-js/devtools-proxy-support";
+import { Request as NodeFetchRequest } from "node-fetch";
 import { isNodeRuntime } from "../helpers/isNodeRuntime.js";
 
 let sharedProxyFetch: typeof fetch | undefined;
@@ -44,4 +45,18 @@ export function getSharedProxyFetch(): typeof fetch {
             : globalThis.fetch.bind(globalThis);
     }
     return sharedProxyFetch;
+}
+
+/**
+ * The `HttpClient` used when an embedder doesn't provide one: the shared
+ * proxy-aware `fetch` paired with the `Request` implementation it understands.
+ */
+export function getDefaultHttpClient(): HttpClient {
+    return {
+        fetch: getSharedProxyFetch(),
+        // NodeFetchRequest has more overloadings than the native Request so it
+        // complains here. However, the interfaces are actually compatible so
+        // it's not a real problem, just a type checking problem.
+        Request: (isNodeRuntime() ? NodeFetchRequest : globalThis.Request) as unknown as typeof globalThis.Request,
+    };
 }

--- a/src/common/proxyFetch.ts
+++ b/src/common/proxyFetch.ts
@@ -4,6 +4,16 @@ import { isNodeRuntime } from "../helpers/isNodeRuntime.js";
 let sharedProxyFetch: typeof fetch | undefined;
 
 /**
+ * A matched `fetch`/`Request` pair. Both must come from the same implementation:
+ * a `Request` built by one implementation is not recognized as a `Request` by
+ * another and gets coerced to a string, producing a bogus URL.
+ */
+export type HttpClient = {
+    fetch: typeof fetch;
+    Request: typeof globalThis.Request;
+};
+
+/**
  * Process-wide memoized `fetch`. In Node it is backed by
  * devtools-proxy-support's `createFetch` (env-var proxy config + system-CA
  * trust); elsewhere it falls back to the platform `fetch`.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -125,6 +125,7 @@ export {
     type ApiClientFactoryFn,
     type RequestContext,
 } from "./common/atlas/apiClient.js";
+export type { HttpClient } from "./common/proxyFetch.js";
 export type { AuthProvider, Credentials } from "./common/atlas/auth/authProvider.js";
 export { type UIRegistryOptions, UIRegistry } from "./ui/registry/registry.js";
 export { type ToolExecutionContext, type AnyToolBase } from "./tools/tool.js";

--- a/src/web.ts
+++ b/src/web.ts
@@ -83,6 +83,7 @@ export {
     type ApiClientFactoryFn,
     type RequestContext,
 } from "./common/atlas/apiClient.js";
+export type { HttpClient } from "./common/proxyFetch.js";
 export type { AtlasLocalClientFactoryFn, LibraryLoader } from "./common/atlasLocal.js";
 export { UIRegistry } from "./ui/registry/registry.js";
 export {

--- a/tests/unit/common/apiClient.test.ts
+++ b/tests/unit/common/apiClient.test.ts
@@ -79,6 +79,66 @@ describe("ApiClient", () => {
         });
     });
 
+    describe("httpClient", () => {
+        it("uses the injected fetch and Request instead of the shared proxy fetch", async () => {
+            let requestCount = 0;
+            class TrackedRequest extends Request {
+                constructor(input: RequestInfo | URL, init?: RequestInit) {
+                    super(input, init);
+                    requestCount++;
+                }
+            }
+            const injectedFetch = vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ results: [] }), {
+                    status: 200,
+                    headers: { "Content-Type": "application/json" },
+                })
+            );
+            const globalFetch = vi.spyOn(global, "fetch");
+
+            const client = new ApiClient(
+                {
+                    baseUrl: "https://api.test.com",
+                    userAgent: "test-user-agent",
+                    httpClient: {
+                        fetch: injectedFetch as unknown as typeof fetch,
+                        Request: TrackedRequest,
+                    },
+                },
+                new NullLogger()
+            );
+
+            await client.listClusterDetails();
+
+            expect(injectedFetch).toHaveBeenCalledTimes(1);
+            expect(requestCount).toBe(1);
+            expect(globalFetch).not.toHaveBeenCalled();
+        });
+
+        it("passes the injected fetch to the auth provider it creates", () => {
+            const injectedFetch = vi.fn();
+
+            const client = new ApiClient(
+                {
+                    baseUrl: "https://api.test.com",
+                    userAgent: "test-user-agent",
+                    credentials: {
+                        clientId: "test-client-id",
+                        clientSecret: "test-client-secret",
+                    },
+                    httpClient: {
+                        fetch: injectedFetch as unknown as typeof fetch,
+                        Request: globalThis.Request,
+                    },
+                },
+                new NullLogger()
+            );
+
+            // @ts-expect-error accessing private property for testing
+            expect(client.authProvider.customFetch).toBe(injectedFetch);
+        });
+    });
+
     describe("User-Agent", () => {
         it("should use custom userAgent when provided in options", async () => {
             const mockFetch = vi.spyOn(global, "fetch");

--- a/tests/unit/common/apiClient.test.ts
+++ b/tests/unit/common/apiClient.test.ts
@@ -94,7 +94,9 @@ describe("ApiClient", () => {
                     headers: { "Content-Type": "application/json" },
                 })
             );
-            const globalFetch = vi.spyOn(global, "fetch");
+            const globalFetch = vi
+                .spyOn(global, "fetch")
+                .mockRejectedValue(new Error("global fetch should not be called"));
 
             const client = new ApiClient(
                 {


### PR DESCRIPTION
## Proposed changes
This change will allow embedders of the library to provide their own
fetch agent and not rely on our default proxy-aware fetch agent.

We plan to use this atlas-mcp to provide our own simple fetch agent
to cut down on unnecessary system CA mergers we are doing and not
keeping the connection alive per session.

## Checklist


- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
