### PR TITLE
fix(ci): open a PR for third-party notices instead of pushing to main

### DIFF
--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -67,10 +67,6 @@ jobs:
           git checkout -b "$BRANCH"
           git push -u origin "$BRANCH"
 
-          # Deliberately do not swallow failures here: if the PR cannot be
-          # opened, the job must fail loudly rather than go green with no PR.
-          # The branch name is unique per run, so a pre-existing PR is not a
-          # realistic failure mode.
           gh pr create \
             --base main \
             --head "$BRANCH" \

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -61,8 +61,6 @@ jobs:
           git config user.email "$GIT_AUTHOR_EMAIL"
           git commit -m "docs: update third-party notices [skip actions]"
 
-          # run_id + run_attempt are unique per workflow execution, so branch
-          # names never collide (unlike date-based names on concurrent runs).
           BRANCH="bot/update-third-party-notices/${{ github.run_id }}-${{ github.run_attempt }}"
           git checkout -b "$BRANCH"
           git push -u origin "$BRANCH"

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -61,11 +61,21 @@ jobs:
           git config user.email "$GIT_AUTHOR_EMAIL"
           git commit -m "docs: update third-party notices [skip actions]"
 
-          BRANCH="bot/update-third-party-notices/$(date +%s)"
+          # run_id + run_attempt are unique per workflow execution, so branch
+          # names never collide (unlike date-based names on concurrent runs).
+          BRANCH="bot/update-third-party-notices/${{ github.run_id }}-${{ github.run_attempt }}"
           git checkout -b "$BRANCH"
           git push -u origin "$BRANCH"
 
-          gh pr create --base main --head "$BRANCH" --title "docs: update third-party notices" --body "Automated update of THIRD_PARTY_NOTICES.md by the Dependency Health workflow.\n\n[skip actions]" || echo "PR already exists or creation failed; changes are on branch $BRANCH"
+          # Deliberately do not swallow failures here: if the PR cannot be
+          # opened, the job must fail loudly rather than go green with no PR.
+          # The branch name is unique per run, so a pre-existing PR is not a
+          # realistic failure mode.
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "docs: update third-party notices" \
+            --body $'Automated update of THIRD_PARTY_NOTICES.md by the Dependency Health workflow.\n\n[skip actions]'
 
       - name: Configure AWS credentials for DevProd Platforms ECR
         if: always()

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -40,7 +40,7 @@ jobs:
         if: always()
         run: pnpm run update-third-party-notices
 
-      - name: Commit and push updated third-party notices
+      - name: Commit and open a PR with updated third-party notices
         if: always()
         env:
           # Skip pre-commit hooks, since this is a bot commit.
@@ -49,14 +49,23 @@ jobs:
           GIT_AUTHOR_EMAIL: "${{ steps.app-token.outputs.app-email }}"
           GIT_COMMITTER_NAME: "${{ steps.app-token.outputs.app-slug}}[bot]"
           GIT_COMMITTER_EMAIL: "${{ steps.app-token.outputs.app-email }}"
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git add THIRD_PARTY_NOTICES.md
           if git diff --cached --quiet; then
             echo "No THIRD_PARTY_NOTICES.md changes to commit"
-          else
-            git commit -m "docs: update third-party notices [skip actions]"
-            git push
+            exit 0
           fi
+
+          git config user.name "$GIT_AUTHOR_NAME"
+          git config user.email "$GIT_AUTHOR_EMAIL"
+          git commit -m "docs: update third-party notices [skip actions]"
+
+          BRANCH="bot/update-third-party-notices/$(date +%s)"
+          git checkout -b "$BRANCH"
+          git push -u origin "$BRANCH"
+
+          gh pr create --base main --head "$BRANCH" --title "docs: update third-party notices" --body "Automated update of THIRD_PARTY_NOTICES.md by the Dependency Health workflow.\n\n[skip actions]" || echo "PR already exists or creation failed; changes are on branch $BRANCH"
 
       - name: Configure AWS credentials for DevProd Platforms ECR
         if: always()


### PR DESCRIPTION
## Problem

The Dependency Health workflow (`dependency-health.yml`) commits updated `THIRD_PARTY_NOTICES.md` and pushes directly to `main`. The repo's branch protection on `main` so, as a result, every push is rejected. We could consider adjusting our protection rules in the future.

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 3 of 3 required status checks are expected.
! [remote rejected] main -> main (push declined due to repository rule violations)
```

Failing runs:
- https://github.com/mongodb-js/mongodb-mcp-server/actions/runs/31003625456

## Fix

Instead of pushing to `main`, this workflow now:
1. Commits the `THIRD_PARTY_NOTICES.md` updates
2. Pushes them to a fresh `bot/update-third-party-notices/<timestamp>` branch
3. Opens a PR against `main` using the bot token

This mirrors how bots handle branch-protected main branches without a human in the loop.