### PR TITLE
fix(tests): increase mongot healthcheck wait timeouts

### DIFF
--- a/tests/integration/tools/mongodb/mongodbClusterProcess.ts
+++ b/tests/integration/tools/mongodb/mongodbClusterProcess.ts
@@ -98,8 +98,8 @@ export class MongoDBClusterProcess {
                     VOYAGE_QUERY_KEY: config.voyageQueryKey,
                     VOYAGE_INDEXING_KEY: config.voyageIndexingKey,
                 })
-                .withWaitStrategy("mongod-1", Wait.forHealthCheck())
-                .withWaitStrategy("mongot-1", Wait.forHealthCheck())
+                .withWaitStrategy("mongod-1", Wait.forHealthCheck().withStartupTimeout(180_000))
+                .withWaitStrategy("mongot-1", Wait.forHealthCheck().withStartupTimeout(300_000))
                 .up();
 
             const mongodContainer = environment.getContainer("mongod-1");


### PR DESCRIPTION
## Problem

The `Run MongoDB tests (ubuntu-latest, 26)` job intermittently fails when spinning up the mongod+mongot docker-compose cluster for the auto-embed index test suites (e.g. `dropIndex.test.ts`) with:

```
Error: Health check failed: unhealthy
 ❯ HealthCheckWaitStrategy.waitUntilReady .../testcontainers/build/wait-strategies/health-check-wait-strategy.js:21:19
 ❯ MongoDBClusterProcess.spinUp tests/integration/tools/mongodb/mongodbClusterProcess.ts:95:33
```

## Root cause

- testcontainers v12.0.3 has a default **60s** wait budget for `Wait.forHealthCheck()` (`startupTimeoutMs = 60_000`).
- The compose healthcheck for `mongot` (`tests/integration/tools/mongodb/mongot-community-setup/docker-compose.yml`) allows **40s start_period + up to 10 retries × 5s interval ≈ 90s** before reporting healthy.
- On slower/cold runners (image pull, replica set election, mongot reaching SERVING), the container can exceed 60s, so testcontainers aborts with `Health check failed: unhealthy` even though the containers eventually become healthy — making the auto-embed suites flaky.

## Change

Give the testcontainers healthcheck waits headroom matching the compose configuration:

- `mongod-1`: `Wait.forHealthCheck().withStartupTimeout(180_000)`
- `mongot-1`: `Wait.forHealthCheck().withStartupTimeout(300_000)`

## Validation

- `npx prettier --check tests/integration/tools/mongodb/mongodbClusterProcess.ts` passes
- `tsc --noEmit` passes
