### PR TITLE
chore: allow generic Metric type to be provided by subclass CLOUDP-427202

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -826,8 +826,10 @@ export class MCPConnectionStore {
 }
 
 // @public (undocumented)
-export class MCPHttpServer<TUserConfig extends UserConfig = UserConfig, TContext = unknown> extends ExpressBasedHttpServer {
-    constructor(input: MCPHttpServerConstructorArgs<TUserConfig, TContext>);
+export class MCPHttpServer<TUserConfig extends UserConfig = UserConfig, TContext = unknown, TMetrics extends DefaultMetrics = DefaultMetrics> extends ExpressBasedHttpServer {
+    constructor(input: MCPHttpServerConstructorArgs<TUserConfig, TContext, TMetrics>);
+    // (undocumented)
+    protected readonly metrics: Metrics<TMetrics>;
     // (undocumented)
     protected readonly sessionStore: ISessionStore<StreamableHTTPServerTransport>;
     // (undocumented)
@@ -841,7 +843,7 @@ export class MCPHttpServer<TUserConfig extends UserConfig = UserConfig, TContext
 }
 
 // @public (undocumented)
-export type MCPHttpServerConstructorArgs<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = {
+export type MCPHttpServerConstructorArgs<TUserConfig extends UserConfig = UserConfig, TContext = unknown, TMetrics extends DefaultMetrics = DefaultMetrics> = {
     userConfig: TUserConfig;
     createServerForRequest: (createParams: {
         request: TransportRequestContext;
@@ -851,7 +853,7 @@ export type MCPHttpServerConstructorArgs<TUserConfig extends UserConfig = UserCo
     logger: LoggerBase;
     serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
     sessionOptions?: CustomizableSessionOptions<TUserConfig>;
-    metrics: Metrics<DefaultMetrics>;
+    metrics: Metrics<TMetrics>;
     sessionStore: ISessionStore<StreamableHTTPServerTransport>;
 };
 

--- a/src/transports/mcpHttpServer.ts
+++ b/src/transports/mcpHttpServer.ts
@@ -26,7 +26,11 @@ import {
     JSON_RPC_ERROR_CODE_SESSION_LIMIT_EXCEEDED,
 } from "./jsonRpcErrorCodes.js";
 
-export type MCPHttpServerConstructorArgs<TUserConfig extends UserConfig = UserConfig, TContext = unknown> = {
+export type MCPHttpServerConstructorArgs<
+    TUserConfig extends UserConfig = UserConfig,
+    TContext = unknown,
+    TMetrics extends DefaultMetrics = DefaultMetrics,
+> = {
     userConfig: TUserConfig;
     createServerForRequest: (createParams: {
         request: TransportRequestContext;
@@ -36,19 +40,20 @@ export type MCPHttpServerConstructorArgs<TUserConfig extends UserConfig = UserCo
     logger: LoggerBase;
     serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
     sessionOptions?: CustomizableSessionOptions<TUserConfig>;
-    metrics: Metrics<DefaultMetrics>;
+    metrics: Metrics<TMetrics>;
     sessionStore: ISessionStore<StreamableHTTPServerTransport>;
 };
 
 export class MCPHttpServer<
     TUserConfig extends UserConfig = UserConfig,
     TContext = unknown,
+    TMetrics extends DefaultMetrics = DefaultMetrics,
 > extends ExpressBasedHttpServer {
     protected readonly sessionStore: ISessionStore<StreamableHTTPServerTransport>;
     private readonly serverOptions?: CustomizableServerOptions<TUserConfig, TContext>;
     private readonly sessionOptions?: CustomizableSessionOptions<TUserConfig>;
     protected readonly userConfig: TUserConfig;
-    private readonly metrics: Metrics<DefaultMetrics>;
+    protected readonly metrics: Metrics<TMetrics>;
     private readonly pendingInitializations = new Map<string, Promise<void>>();
 
     private createServerForRequest: (createParams: {
@@ -65,7 +70,7 @@ export class MCPHttpServer<
         logger,
         metrics,
         sessionStore,
-    }: MCPHttpServerConstructorArgs<TUserConfig, TContext>) {
+    }: MCPHttpServerConstructorArgs<TUserConfig, TContext, TMetrics>) {
         super({
             port: userConfig.httpPort,
             hostname: userConfig.httpHost,


### PR DESCRIPTION
## Proposed changes

Atlas MCP server injects its own metrics instance and would benefit from a generic typed metrics instance.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
