### PR TITLE
feat: request elicitation for aggregations that include write stages MCP-615

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,9 @@ When a tool is marked as requiring confirmation, the server will send an elicita
 
 You can set the `confirmationRequiredTools` configuration option to specify the names of tools which require confirmation. By default, the following tools have this setting enabled: `drop-database`, `drop-collection`, `delete-many`, `drop-index`, `atlas-create-db-user`, `atlas-create-access-list`, `atlas-streams-manage`, `atlas-streams-teardown`.
 
-In addition, the `aggregate` and `aggregate-db` tools always request confirmation before running a pipeline that contains a `$out` or `$merge` stage, regardless of whether they appear in `confirmationRequiredTools`. Those stages write to a collection — `$out` replaces its contents entirely — so the confirmation names the affected collection and what will happen to it. Pipelines without a write stage are never confirmed, unless you add the tool to `confirmationRequiredTools` yourself.
+In addition, the `aggregate` and `aggregate-db` tools always request confirmation before running a pipeline that contains a `$out` or `$merge` stage, regardless of whether they appear in `confirmationRequiredTools`. Those stages write to a collection — `$out` replaces its contents entirely — so this confirmation names the affected collection and what will happen to it. Pipelines without a write stage are not confirmed.
+
+Adding either tool to `confirmationRequiredTools` is broader: every call is then confirmed up front with the standard tool-level message, and a write stage does not raise a second prompt.
 
 #### Read-Only Mode
 

--- a/README.md
+++ b/README.md
@@ -528,7 +528,9 @@ If your client supports [elicitation](https://modelcontextprotocol.io/specificat
 
 When a tool is marked as requiring confirmation, the server will send an elicitation request to the client. The client with elicitation support will then prompt the user for confirmation and send the response back to the server. If the client does not support elicitation, the tool will execute without confirmation.
 
-You can set the `confirmationRequiredTools` configuration option to specify the names of tools which require confirmation. By default, the following tools have this setting enabled: `drop-database`, `drop-collection`, `delete-many`, `atlas-create-db-user`, `atlas-create-access-list`.
+You can set the `confirmationRequiredTools` configuration option to specify the names of tools which require confirmation. By default, the following tools have this setting enabled: `drop-database`, `drop-collection`, `delete-many`, `drop-index`, `atlas-create-db-user`, `atlas-create-access-list`, `atlas-streams-manage`, `atlas-streams-teardown`.
+
+In addition, the `aggregate` and `aggregate-db` tools always request confirmation before running a pipeline that contains a `$out` or `$merge` stage, regardless of whether they appear in `confirmationRequiredTools`. Those stages write to a collection — `$out` replaces its contents entirely — so the confirmation names the affected collection and what will happen to it. Pipelines without a write stage are never confirmed, unless you add the tool to `confirmationRequiredTools` yourself.
 
 #### Read-Only Mode
 

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -634,6 +634,8 @@ export enum ErrorCodes {
     // (undocumented)
     AtlasVectorSearchInvalidQuery = 1000007,
     // (undocumented)
+    ConfirmationDeclined = 1000011,
+    // (undocumented)
     ForbiddenCollscan = 1000002,
     // (undocumented)
     ForbiddenServerSideJS = 1000009,
@@ -1224,7 +1226,9 @@ export { TelemetryEvents }
 export type ToolCategory = "mongodb" | "atlas" | "atlas-local" | "assistant";
 
 // @public
-export type ToolExecutionContext = Pick<ServerRequestHandlerExtra, "signal"> & Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">>;
+export type ToolExecutionContext = Pick<ServerRequestHandlerExtra, "signal"> & Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">> & {
+    elicitationDurationMs?: number;
+};
 
 export { TransportRequestContext }
 

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -46,7 +46,7 @@ export class AggregateDBTool extends MongoDBToolBase {
     // (undocumented)
     description: string;
     // (undocumented)
-    protected execute(input: ToolArgs<typeof AggregateDBTool.argsShape>, input2: ToolExecutionContext): Promise<ToolResult<typeof AggregateDBTool.outputSchema>>;
+    protected execute(input: ToolArgs<typeof AggregateDBTool.argsShape>, context: ToolExecutionContext): Promise<ToolResult<typeof AggregateDBTool.outputSchema>>;
     // (undocumented)
     static operationType: OperationType;
     // (undocumented)
@@ -102,7 +102,7 @@ export class AggregateTool extends MongoDBToolBase {
     // (undocumented)
     description: string;
     // (undocumented)
-    protected execute(input: ToolArgs<typeof AggregateTool.argsShape>, input2: ToolExecutionContext): Promise<ToolResult<typeof AggregateTool.outputSchema>>;
+    protected execute(input: ToolArgs<typeof AggregateTool.argsShape>, context: ToolExecutionContext): Promise<ToolResult<typeof AggregateTool.outputSchema>>;
     // (undocumented)
     static operationType: OperationType;
     // (undocumented)
@@ -1582,11 +1582,13 @@ export class LogsTool extends MongoDBToolBase {
 
 // @public (undocumented)
 export abstract class MongoDBToolBase extends ToolBase {
+    // (undocumented)
     protected assertMqlIsAllowed(...values: (Record<string, unknown> | Record<string, unknown>[] | undefined)[]): void;
     // (undocumented)
     protected assertSearchSupported(connectionId: string): Promise<void>;
     // (undocumented)
     static category: ToolCategory;
+    protected confirmWriteStages(targets: WriteStageTarget[], context: ToolExecutionContext): Promise<void>;
     protected getOperationOptions(signal?: AbortSignal): {
         signal?: AbortSignal;
         maxTimeMS?: number;
@@ -2144,6 +2146,7 @@ export abstract class ToolBase<TUserConfig extends UserConfig = UserConfig, TCon
     outputSchema?: ZodRawShape;
     // (undocumented)
     register(server: Server<TUserConfig, TContext, TMetrics>): boolean;
+    protected requestConfirmation(message: string, context: ToolExecutionContext): Promise<boolean>;
     requiresConfirmation(): boolean;
     protected abstract resolveTelemetryMetadata(args: ToolArgs<typeof ToolBase.argsShape>, input: {
         result: CallToolResult;
@@ -2182,7 +2185,9 @@ export type ToolConstructorParams<TUserConfig extends UserConfig = UserConfig, T
 };
 
 // @public
-export type ToolExecutionContext = Pick<ServerRequestHandlerExtra, "signal"> & Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">>;
+export type ToolExecutionContext = Pick<ServerRequestHandlerExtra, "signal"> & Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">> & {
+    elicitationDurationMs?: number;
+};
 
 // @public (undocumented)
 export type ToolResult<OutputSchema extends ZodRawShape | undefined = undefined> = OutputSchema extends ZodRawShape ? StructuredToolResult<OutputSchema> : {

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -1582,7 +1582,6 @@ export class LogsTool extends MongoDBToolBase {
 
 // @public (undocumented)
 export abstract class MongoDBToolBase extends ToolBase {
-    // (undocumented)
     protected assertMqlIsAllowed(...values: (Record<string, unknown> | Record<string, unknown>[] | undefined)[]): void;
     // (undocumented)
     protected assertSearchSupported(connectionId: string): Promise<void>;

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -2155,7 +2155,6 @@ export abstract class ToolBase<TUserConfig extends UserConfig = UserConfig, TCon
     protected get toolMeta(): Record<string, unknown>;
     // (undocumented)
     protected verifyAllowed(): boolean;
-    verifyConfirmed(args: ToolArgs<typeof ToolBase.argsShape>, context: ToolExecutionContext): Promise<boolean>;
 }
 
 // @public

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -1080,7 +1080,6 @@ export abstract class ToolBase<TUserConfig extends UserConfig = UserConfig, TCon
     protected get toolMeta(): Record<string, unknown>;
     // (undocumented)
     protected verifyAllowed(): boolean;
-    verifyConfirmed(args: ToolArgs<typeof ToolBase.argsShape>, context: ToolExecutionContext): Promise<boolean>;
 }
 
 // @public

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -634,6 +634,8 @@ export enum ErrorCodes {
     // (undocumented)
     AtlasVectorSearchInvalidQuery = 1000007,
     // (undocumented)
+    ConfirmationDeclined = 1000011,
+    // (undocumented)
     ForbiddenCollscan = 1000002,
     // (undocumented)
     ForbiddenServerSideJS = 1000009,
@@ -1068,6 +1070,7 @@ export abstract class ToolBase<TUserConfig extends UserConfig = UserConfig, TCon
     outputSchema?: ZodRawShape;
     // (undocumented)
     register(server: Server<TUserConfig, TContext, TMetrics>): boolean;
+    protected requestConfirmation(message: string, context: ToolExecutionContext): Promise<boolean>;
     requiresConfirmation(): boolean;
     protected abstract resolveTelemetryMetadata(args: ToolArgs<typeof ToolBase.argsShape>, input: {
         result: CallToolResult;
@@ -1106,7 +1109,9 @@ export type ToolConstructorParams<TUserConfig extends UserConfig = UserConfig, T
 };
 
 // @public
-export type ToolExecutionContext = Pick<ServerRequestHandlerExtra, "signal"> & Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">>;
+export type ToolExecutionContext = Pick<ServerRequestHandlerExtra, "signal"> & Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">> & {
+    elicitationDurationMs?: number;
+};
 
 export { TransportRequestContext }
 

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -9,6 +9,7 @@ export enum ErrorCodes {
     InvalidPipeline = 1_000_008,
     ForbiddenServerSideJS = 1_000_009,
     UnknownConnectionId = 1_000_010,
+    ConfirmationDeclined = 1_000_011,
 }
 
 export class MongoDBError<ErrorCode extends ErrorCodes = ErrorCodes> extends Error {

--- a/src/helpers/mqlGuards.ts
+++ b/src/helpers/mqlGuards.ts
@@ -77,23 +77,17 @@ export function isWriteStage(stage: Record<string, unknown>): boolean {
     return writeStageOperator(stage) !== undefined;
 }
 
-/**
- * The fully qualified namespace a write stage targets, or `undefined` when the
- * stage targets something other than a collection (such as an S3 bucket on
- * Atlas Data Federation) and no namespace can be resolved.
- */
-type WriteStageNamespace = { namespace: string | undefined };
-
 /** The collection a write stage targets, along with how it will write to it. */
-export type WriteStageTarget =
-    | ({ operator: "$out" } & WriteStageNamespace)
-    | ({
+export type WriteStageTarget = { namespace: string | undefined } & (
+    | { operator: "$out" }
+    | {
           operator: "$merge";
           /** The `whenMatched` mode, when the stage names one of the documented modes. */
           whenMatched?: string;
           /** The `whenNotMatched` mode, when the stage names one of the documented modes. */
           whenNotMatched?: string;
-      } & WriteStageNamespace);
+      }
+);
 
 /**
  * Describes the collections that the write stages of a pipeline target, so that

--- a/src/helpers/mqlGuards.ts
+++ b/src/helpers/mqlGuards.ts
@@ -54,9 +54,110 @@ export function assertNoServerSideJS(value: unknown): void {
 }
 
 /**
+ * The write operator of an aggregation stage, or `undefined` when the stage
+ * does not write to a collection.
+ */
+function writeStageOperator(stage: Record<string, unknown>): "$out" | "$merge" | undefined {
+    if ("$out" in stage) {
+        return "$out";
+    }
+
+    if ("$merge" in stage) {
+        return "$merge";
+    }
+
+    return undefined;
+}
+
+/**
  * Returns true when the given aggregation stage writes data to a collection,
  * i.e. it is a `$out` or `$merge` stage.
  */
 export function isWriteStage(stage: Record<string, unknown>): boolean {
-    return "$out" in stage || "$merge" in stage;
+    return writeStageOperator(stage) !== undefined;
+}
+
+/**
+ * The fully qualified namespace a write stage targets, or `undefined` when the
+ * stage targets something other than a collection (such as an S3 bucket on
+ * Atlas Data Federation) and no namespace can be resolved.
+ */
+type WriteStageNamespace = { namespace: string | undefined };
+
+/** The collection a write stage targets, along with how it will write to it. */
+export type WriteStageTarget =
+    | ({ operator: "$out" } & WriteStageNamespace)
+    | ({
+          operator: "$merge";
+          /** The `whenMatched` mode, when the stage names one of the documented modes. */
+          whenMatched?: string;
+          /** The `whenNotMatched` mode, when the stage names one of the documented modes. */
+          whenNotMatched?: string;
+      } & WriteStageNamespace);
+
+/**
+ * Describes the collections that the write stages of a pipeline target, so that
+ * the user can be told what a `$out` or `$merge` is about to affect before it
+ * runs.
+ *
+ * Only top-level stages are inspected, matching {@link isWriteStage}: `$out` and
+ * `$merge` are not permitted inside sub-pipelines. MongoDB also requires them to
+ * be the last stage, so in practice at most one target is returned; the array
+ * shape means a malformed pipeline is still described in full rather than
+ * partially.
+ *
+ * @param pipeline - The aggregation pipeline to inspect.
+ * @param defaultDatabase - The database the aggregation runs against, used to
+ * qualify stages that name only a collection.
+ */
+export function getWriteStageTargets(pipeline: Record<string, unknown>[], defaultDatabase: string): WriteStageTarget[] {
+    const targets: WriteStageTarget[] = [];
+
+    for (const stage of pipeline) {
+        switch (writeStageOperator(stage)) {
+            case "$out":
+                targets.push({ operator: "$out", namespace: resolveNamespace(stage.$out, defaultDatabase) });
+                break;
+            case "$merge": {
+                // The stage is either the target itself (`$merge: "coll"`) or a
+                // document describing it. `whenMatched` also accepts a custom
+                // update pipeline, which has no concise description, so only the
+                // documented string modes are reported.
+                const spec = isRecord(stage.$merge) ? stage.$merge : undefined;
+                targets.push({
+                    operator: "$merge",
+                    namespace: resolveNamespace(spec ? spec.into : stage.$merge, defaultDatabase),
+                    ...(typeof spec?.whenMatched === "string" ? { whenMatched: spec.whenMatched } : {}),
+                    ...(typeof spec?.whenNotMatched === "string" ? { whenNotMatched: spec.whenNotMatched } : {}),
+                });
+                break;
+            }
+            case undefined:
+                break;
+        }
+    }
+
+    return targets;
+}
+
+/**
+ * Resolves the target of a `$out` stage or the `into` of a `$merge` stage to a
+ * fully qualified namespace. Returns `undefined` for any other shape, such as
+ * the `{ s3: ... }` target supported by Atlas Data Federation.
+ */
+function resolveNamespace(target: unknown, defaultDatabase: string): string | undefined {
+    if (typeof target === "string") {
+        return `${defaultDatabase}.${target}`;
+    }
+
+    if (isRecord(target) && typeof target.coll === "string") {
+        const database = typeof target.db === "string" ? target.db : defaultDatabase;
+        return `${database}.${target.coll}`;
+    }
+
+    return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/helpers/writeStageConfirmation.ts
+++ b/src/helpers/writeStageConfirmation.ts
@@ -10,7 +10,7 @@ import type { WriteStageTarget } from "./mqlGuards.js";
  * @param targets - The write stage targets, as returned by `getWriteStageTargets`.
  */
 export function buildWriteStageConfirmationMessage(targets: WriteStageTarget[]): string {
-    return `This aggregation ends with ${targets.map(describeTarget).join(" and ")}. Proceed?`;
+    return `This aggregation contains ${targets.map(describeTarget).join(" and ")}. Proceed?`;
 }
 
 function describeTarget(target: WriteStageTarget): string {

--- a/src/helpers/writeStageConfirmation.ts
+++ b/src/helpers/writeStageConfirmation.ts
@@ -14,17 +14,18 @@ export function buildWriteStageConfirmationMessage(targets: WriteStageTarget[]):
 }
 
 function describeTarget(target: WriteStageTarget): string {
-    if (target.operator === "$out") {
-        return target.namespace
-            ? `a \`$out\` stage that will replace the entire contents of \`${target.namespace}\` with the pipeline output, permanently discarding any documents already in that collection`
-            : "a `$out` stage that will replace the entire contents of its target collection with the pipeline output, permanently discarding any documents already there";
-    }
-
     const collection = target.namespace ? `\`${target.namespace}\`` : "its target collection";
-    const modes = [
-        target.whenMatched !== undefined ? `whenMatched: ${target.whenMatched}` : undefined,
-        target.whenNotMatched !== undefined ? `whenNotMatched: ${target.whenNotMatched}` : undefined,
-    ].filter((mode) => mode !== undefined);
 
-    return `a \`$merge\` stage that will write the pipeline output into ${collection}, modifying data already in that collection${modes.length > 0 ? ` (${modes.join(", ")})` : ""}`;
+    switch (target.operator) {
+        case "$out":
+            return `a \`$out\` stage that will replace the entire contents of ${collection} with the pipeline output, permanently discarding any documents already there`;
+        case "$merge": {
+            const modes = [
+                target.whenMatched !== undefined ? `whenMatched: ${target.whenMatched}` : undefined,
+                target.whenNotMatched !== undefined ? `whenNotMatched: ${target.whenNotMatched}` : undefined,
+            ].filter((mode) => mode !== undefined);
+
+            return `a \`$merge\` stage that will write the pipeline output into ${collection}, modifying data already in that collection${modes.length > 0 ? ` (${modes.join(", ")})` : ""}`;
+        }
+    }
 }

--- a/src/helpers/writeStageConfirmation.ts
+++ b/src/helpers/writeStageConfirmation.ts
@@ -1,0 +1,30 @@
+import type { WriteStageTarget } from "./mqlGuards.js";
+
+/**
+ * Builds the message shown to the user before an aggregation containing a
+ * `$out` or `$merge` stage runs. The two operators differ in blast radius --
+ * `$out` replaces a collection wholesale while `$merge` modifies an existing
+ * one -- so each is described in its own terms, naming the affected namespace
+ * whenever it could be resolved.
+ *
+ * @param targets - The write stage targets, as returned by `getWriteStageTargets`.
+ */
+export function buildWriteStageConfirmationMessage(targets: WriteStageTarget[]): string {
+    return `This aggregation ends with ${targets.map(describeTarget).join(" and ")}. Proceed?`;
+}
+
+function describeTarget(target: WriteStageTarget): string {
+    if (target.operator === "$out") {
+        return target.namespace
+            ? `a \`$out\` stage that will replace the entire contents of \`${target.namespace}\` with the pipeline output, permanently discarding any documents already in that collection`
+            : "a `$out` stage that will replace the entire contents of its target collection with the pipeline output, permanently discarding any documents already there";
+    }
+
+    const collection = target.namespace ? `\`${target.namespace}\`` : "its target collection";
+    const modes = [
+        target.whenMatched !== undefined ? `whenMatched: ${target.whenMatched}` : undefined,
+        target.whenNotMatched !== undefined ? `whenNotMatched: ${target.whenNotMatched}` : undefined,
+    ].filter((mode) => mode !== undefined);
+
+    return `a \`$merge\` stage that will write the pipeline output into ${collection}, modifying data already in that collection${modes.length > 0 ? ` (${modes.join(", ")})` : ""}`;
+}

--- a/src/tools/mongodb/mongodbTool.ts
+++ b/src/tools/mongodb/mongodbTool.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { OperationType, ToolArgs, ToolCategory } from "../tool.js";
+import type { OperationType, ToolArgs, ToolCategory, ToolExecutionContext } from "../tool.js";
 import { ToolBase } from "../tool.js";
 import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -7,7 +7,8 @@ import { ErrorCodes, MongoDBError } from "../../common/errors.js";
 import type { ConnectionEntry } from "../../common/connectionRegistry.js";
 import type { Server } from "../../server.js";
 import type { ConnectionMetadata } from "../../telemetry/types.js";
-import { assertNoServerSideJS, isWriteStage } from "../../helpers/mqlGuards.js";
+import { assertNoServerSideJS, isWriteStage, type WriteStageTarget } from "../../helpers/mqlGuards.js";
+import { buildWriteStageConfirmationMessage } from "../../helpers/writeStageConfirmation.js";
 import { EXPORT_TOOL_NAME } from "../../helpers/constants.js";
 
 export const DBOperationArgs = {
@@ -103,6 +104,25 @@ export abstract class MongoDBToolBase extends ToolBase {
         }
     }
 
+    /**
+     * Asks the user to confirm the write stages of an aggregation pipeline,
+     * throwing when they decline so that the pipeline never runs.
+     */
+    protected async confirmWriteStages(targets: WriteStageTarget[], context: ToolExecutionContext): Promise<void> {
+        if (this.requiresConfirmation()) {
+            return;
+        }
+
+        if (await this.requestConfirmation(buildWriteStageConfirmationMessage(targets), context)) {
+            return;
+        }
+
+        throw new MongoDBError(
+            ErrorCodes.ConfirmationDeclined,
+            "User did not confirm the write stages of the aggregation pipeline so the aggregation was not performed."
+        );
+    }
+
     private assertSingleMqlValueIsAllowed(
         value: Record<string, unknown> | Record<string, unknown>[] | undefined
     ): void {
@@ -169,6 +189,7 @@ export abstract class MongoDBToolBase extends ToolBase {
 
                     return super.handleError(error, args);
                 }
+                case ErrorCodes.ConfirmationDeclined:
                 case ErrorCodes.ForbiddenCollscan:
                     return {
                         content: [

--- a/src/tools/mongodb/read/aggregate.ts
+++ b/src/tools/mongodb/read/aggregate.ts
@@ -22,7 +22,7 @@ import {
     assertVectorSearchFilterFieldsAreIndexed,
     type SearchIndex,
 } from "../../../helpers/assertVectorSearchFilterFieldsAreIndexed.js";
-import { isWriteStage } from "../../../helpers/mqlGuards.js";
+import { getWriteStageTargets } from "../../../helpers/mqlGuards.js";
 import { bsonToJson } from "../../../helpers/bsonToJson.js";
 
 export const pipelineDescriptionWithVectorSearch = `\
@@ -158,8 +158,9 @@ export class AggregateTool extends MongoDBToolBase {
 
     protected async execute(
         { connectionId, database, collection, pipeline, responseBytesLimit }: ToolArgs<typeof this.argsShape>,
-        { signal }: ToolExecutionContext
+        context: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
+        const { signal } = context;
         let aggregationCursor: AggregationCursor | undefined = undefined;
         try {
             const provider = await this.resolveConnection(connectionId);
@@ -233,7 +234,10 @@ export class AggregateTool extends MongoDBToolBase {
             let count: number | undefined;
             let appliedLimits: CursorLimitKey[] = [];
 
-            if (pipeline.some((stage) => isWriteStage(stage))) {
+            const writeStageTargets = getWriteStageTargets(pipeline, database);
+            if (writeStageTargets.length > 0) {
+                await this.confirmWriteStages(writeStageTargets, context);
+
                 // This is a write pipeline, so special-case it and don't attempt to apply limits or caps
                 aggregationCursor = provider.aggregate(database, collection, pipeline, {
                     signal,

--- a/src/tools/mongodb/read/aggregateDB.ts
+++ b/src/tools/mongodb/read/aggregateDB.ts
@@ -8,7 +8,7 @@ import { type Document } from "bson";
 import { ErrorCodes, MongoDBError } from "../../../common/errors.js";
 import { collectCursorUntilMaxBytesLimit } from "../../../helpers/collectCursorUntilMaxBytes.js";
 import { operationWithFallback } from "../../../helpers/operationWithFallback.js";
-import { isWriteStage } from "../../../helpers/mqlGuards.js";
+import { getWriteStageTargets } from "../../../helpers/mqlGuards.js";
 import {
     AGG_COUNT_MAX_TIME_MS_CAP,
     ONE_MB,
@@ -59,8 +59,9 @@ export class AggregateDBTool extends MongoDBToolBase {
 
     protected async execute(
         { connectionId, database, pipeline, responseBytesLimit }: ToolArgs<typeof this.argsShape>,
-        { signal }: ToolExecutionContext
+        context: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
+        const { signal } = context;
         let aggregationCursor: AggregationCursor | undefined = undefined;
         try {
             const provider = await this.resolveConnection(connectionId);
@@ -71,7 +72,10 @@ export class AggregateDBTool extends MongoDBToolBase {
             let aggResultsCount: number | undefined;
             let appliedLimits: CursorLimitKey[] = [];
 
-            if (pipeline.some((stage) => isWriteStage(stage))) {
+            const writeStageTargets = getWriteStageTargets(pipeline, database);
+            if (writeStageTargets.length > 0) {
+                await this.confirmWriteStages(writeStageTargets, context);
+
                 // This is a write pipeline, so special-case it and don't attempt to apply limits or caps
                 aggregationCursor = provider.aggregateDb(database, pipeline, {
                     ...this.getOperationOptions(signal),

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -567,7 +567,9 @@ export abstract class ToolBase<
                         noRedaction: true,
                         attributes: { ...requestIdAttr(context.requestInfo?.headers) },
                     });
-                    return { content: [{ type: "text", text }], isError: true };
+                    const declined: CallToolResult = { content: [{ type: "text", text }], isError: true };
+                    recordOutcome(declined);
+                    return declined;
                 }
             }
             this.session.logger.debug({

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -45,7 +45,16 @@ type ServerRequestHandlerExtra = RequestHandlerExtra<ServerRequest, ServerNotifi
  * running atop StreamableHttpTransport.
  */
 export type ToolExecutionContext = Pick<ServerRequestHandlerExtra, "signal"> &
-    Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">>;
+    Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">> & {
+        /**
+         * Total time spent waiting for the user to answer elicitation requests
+         * raised while handling this call. Accumulated by
+         * `ToolBase.requestConfirmation` and subtracted from the tool execution
+         * duration metric, so that the user's think-time is not reported as
+         * time the tool spent working.
+         */
+        elicitationDurationMs?: number;
+    };
 
 export type ToolResult<OutputSchema extends ZodRawShape | undefined = undefined> = OutputSchema extends ZodRawShape
     ? StructuredToolResult<OutputSchema>
@@ -521,32 +530,45 @@ export abstract class ToolBase<
 
     /** This is used internally by the server to invoke the tool. It can also be run manually to call the tool directly. */
     public async invoke(args: ToolArgs<typeof this.argsShape>, context: ToolExecutionContext): Promise<CallToolResult> {
-        let startTime: number = Date.now();
+        const startTime: number = Date.now();
+
+        /**
+         * Records the outcome of the call, emitting its telemetry event and
+         * observing its execution duration. `error` is passed when the call
+         * failed, and its type is reported alongside the metric.
+         */
+        const recordOutcome = (result: CallToolResult, error?: unknown): void => {
+            // Time the user spent answering an elicitation is not time the tool
+            // spent working, so it counts towards neither duration below.
+            const executionStartTime = startTime + (context.elicitationDurationMs ?? 0);
+
+            this.emitToolEvent(args, { startTime: executionStartTime, result });
+
+            this.metrics.get("toolExecutionDuration").observe(
+                {
+                    tool_name: this.name,
+                    category: this.category,
+                    status: error !== undefined || result.isError ? "error" : "success",
+                    operation_type: this.operationType,
+                    ...(error !== undefined ? { error_type: error instanceof Error ? error.name : "unknown" } : {}),
+                },
+                (Date.now() - executionStartTime) / 1000
+            );
+        };
 
         try {
             if (this.requiresConfirmation()) {
                 if (!(await this.verifyConfirmed(args, context))) {
+                    const text = `User did not confirm the execution of the \`${this.name}\` tool so the operation was not performed.`;
                     this.session.logger.debug({
                         id: LogId.toolExecute,
                         context: "tool",
-                        message: `User did not confirm the execution of the \`${this.name}\` tool so the operation was not performed.`,
+                        message: text,
                         noRedaction: true,
                         attributes: { ...requestIdAttr(context.requestInfo?.headers) },
                     });
-                    return {
-                        content: [
-                            {
-                                type: "text",
-                                text: `User did not confirm the execution of the \`${this.name}\` tool so the operation was not performed.`,
-                            },
-                        ],
-                        isError: true,
-                    };
+                    return { content: [{ type: "text", text }], isError: true };
                 }
-                // We do not want to include the elicitation time in the tool execution time
-                // so we reset the startTime to the current time. We may want to consider adding
-                // a separate field for elicitation time in the future.
-                startTime = Date.now();
             }
             this.session.logger.debug({
                 id: LogId.toolExecute,
@@ -559,19 +581,7 @@ export abstract class ToolBase<
             const toolCallResult = await this.execute(args, context);
             const result = await this.appendUIResource(toolCallResult);
 
-            this.emitToolEvent(args, { startTime, result });
-
-            const durationSeconds = (Date.now() - startTime) / 1000;
-
-            this.metrics.get("toolExecutionDuration").observe(
-                {
-                    tool_name: this.name,
-                    category: this.category,
-                    status: result.isError ? "error" : "success",
-                    operation_type: this.operationType,
-                },
-                durationSeconds
-            );
+            recordOutcome(result);
 
             this.session.logger.debug({
                 id: LogId.toolExecute,
@@ -589,19 +599,8 @@ export abstract class ToolBase<
                 attributes: { ...requestIdAttr(context.requestInfo?.headers) },
             });
             const toolResult = await this.handleError(error, args);
-            this.emitToolEvent(args, { startTime, result: toolResult });
 
-            const durationSeconds = (Date.now() - startTime) / 1000;
-            this.metrics.get("toolExecutionDuration").observe(
-                {
-                    tool_name: this.name,
-                    category: this.category,
-                    status: "error",
-                    operation_type: this.operationType,
-                    error_type: error instanceof Error ? error.name : "unknown",
-                },
-                durationSeconds
-            );
+            recordOutcome(toolResult, error);
 
             return toolResult;
         }
@@ -656,6 +655,28 @@ export abstract class ToolBase<
             return true;
         }
 
+        return this.requestConfirmation(this.getConfirmationMessage(args), context);
+    }
+
+    /**
+     * Asks the user to confirm an operation, resolving to `true` when they
+     * accept and `false` when they decline.
+     *
+     * Unlike `verifyConfirmed`, this does not consult
+     * `confirmationRequiredTools` -- the caller decides whether a confirmation
+     * is warranted. Tools can therefore call it at any point of their execution,
+     * which matters when the decision depends on the arguments or needs to happen
+     * after some preliminary work.
+     *
+     * Resolves to `true` without prompting when the client does not support
+     * elicitation, matching how confirmation-required tools behave there.
+     *
+     * @param message - The message to display to the user.
+     * @param context - The tool execution context, used to relate the
+     * confirmation request to the in-flight tool call and to record how long the
+     * user took to answer.
+     */
+    protected async requestConfirmation(message: string, context: ToolExecutionContext): Promise<boolean> {
         const relatedRequestId = this.elicitationRelatedRequestId(context);
         this.session.logger.info({
             id: LogId.toolConfirmationRequested,
@@ -690,7 +711,7 @@ export abstract class ToolBase<
 
         const startedAt = Date.now();
         try {
-            const confirmed = await this.elicitation.requestConfirmation(this.getConfirmationMessage(args), {
+            const confirmed = await this.elicitation.requestConfirmation(message, {
                 relatedRequestId,
                 progressToken: context._meta?.progressToken,
                 sendNotification: context.sendNotification,
@@ -712,6 +733,8 @@ export abstract class ToolBase<
                 attributes: { tool: this.name, ...requestIdAttr(context.requestInfo?.headers) },
             });
             throw error;
+        } finally {
+            context.elicitationDurationMs = (context.elicitationDurationMs ?? 0) + (Date.now() - startedAt);
         }
     }
 

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -557,20 +557,21 @@ export abstract class ToolBase<
         };
 
         try {
-            if (this.requiresConfirmation()) {
-                if (!(await this.verifyConfirmed(args, context))) {
-                    const text = `User did not confirm the execution of the \`${this.name}\` tool so the operation was not performed.`;
-                    this.session.logger.debug({
-                        id: LogId.toolExecute,
-                        context: "tool",
-                        message: text,
-                        noRedaction: true,
-                        attributes: { ...requestIdAttr(context.requestInfo?.headers) },
-                    });
-                    const declined: CallToolResult = { content: [{ type: "text", text }], isError: true };
-                    recordOutcome(declined);
-                    return declined;
-                }
+            if (
+                this.requiresConfirmation() &&
+                !(await this.requestConfirmation(this.getConfirmationMessage(args), context))
+            ) {
+                const text = `User did not confirm the execution of the \`${this.name}\` tool so the operation was not performed.`;
+                this.session.logger.debug({
+                    id: LogId.toolExecute,
+                    context: "tool",
+                    message: text,
+                    noRedaction: true,
+                    attributes: { ...requestIdAttr(context.requestInfo?.headers) },
+                });
+                const declined: CallToolResult = { content: [{ type: "text", text }], isError: true };
+                recordOutcome(declined);
+                return declined;
             }
             this.session.logger.debug({
                 id: LogId.toolExecute,
@@ -636,39 +637,12 @@ export abstract class ToolBase<
     }
 
     /**
-     * Check if the user has confirmed the tool execution (if required by
-     * configuration).
-     *
-     * This method automatically checks if the tool name is in the
-     * `confirmationRequiredTools` configuration list and requests user
-     * confirmation via the elicitation service if needed.
-     *
-     * @param args - The tool arguments
-     * @param context - The tool execution context, used to relate the
-     * confirmation request to the in-flight tool call
-     * @returns A promise resolving to `true` if confirmed or confirmation not
-     * required, `false` otherwise
-     */
-    public async verifyConfirmed(
-        args: ToolArgs<typeof this.argsShape>,
-        context: ToolExecutionContext
-    ): Promise<boolean> {
-        if (!this.requiresConfirmation()) {
-            return true;
-        }
-
-        return this.requestConfirmation(this.getConfirmationMessage(args), context);
-    }
-
-    /**
      * Asks the user to confirm an operation, resolving to `true` when they
      * accept and `false` when they decline.
      *
-     * Unlike `verifyConfirmed`, this does not consult
-     * `confirmationRequiredTools` -- the caller decides whether a confirmation
-     * is warranted. Tools can therefore call it at any point of their execution,
-     * which matters when the decision depends on the arguments or needs to happen
-     * after some preliminary work.
+     * This is automatically called by `invoke` for confirmationRequired tools.
+     * Other tools can call it at any point of their execution, which matters when
+     * the decision depends on the arguments or needs to happen after some preliminary work.
      *
      * Resolves to `true` without prompting when the client does not support
      * elicitation, matching how confirmation-required tools behave there.

--- a/tests/integration/tools/mongodb/read/aggregate.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregate.test.ts
@@ -747,7 +747,7 @@ describe("aggregate tool write stage confirmation", () => {
                 }
             });
 
-            it("asks only once when the tool is also in confirmationRequiredTools", async () => {
+            it("asks only once, with the tool level message, when the tool is also in confirmationRequiredTools", async () => {
                 mockElicitInput.confirmYes();
                 const connectionId = await integration.connectMcpClient();
                 integration.mcpServer().userConfig.confirmationRequiredTools = ["aggregate"];
@@ -763,7 +763,10 @@ describe("aggregate tool write stage confirmation", () => {
                         },
                     });
 
+                    // Confirming the tool call approves the aggregation as a
+                    // whole, so its write stages raise no prompt of their own.
                     expect(mockElicitInput.mock).toHaveBeenCalledTimes(1);
+                    expect(elicitedMessage(mockElicitInput)).toContain("You are about to execute the `aggregate` tool");
                 } finally {
                     integration.mcpServer().userConfig.confirmationRequiredTools = [];
                 }

--- a/tests/integration/tools/mongodb/read/aggregate.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregate.test.ts
@@ -27,6 +27,7 @@ import type { Client } from "@modelcontextprotocol/sdk/client";
 import { pipelineDescriptionWithVectorSearch } from "../../../../../src/tools/mongodb/read/aggregate.js";
 import { MongoServerError, type Collection } from "mongodb";
 import type { CursorLimitKey } from "../../../../../src/helpers/constants.js";
+import { createMockElicitInput } from "../../../../utils/elicitationMocks.js";
 
 type AggregateToolResponse = Awaited<ReturnType<Client["callTool"]>>;
 
@@ -604,6 +605,205 @@ describeWithMongoDB("aggregate tool", (integration) => {
             });
         });
     });
+});
+
+/** The message of the first elicitation request the client received. */
+function elicitedMessage(mockElicitInput: ReturnType<typeof createMockElicitInput>): string {
+    const [request] = mockElicitInput.mock.mock.calls[0] as unknown as [{ message: string }];
+    return request.message;
+}
+
+describe("aggregate tool write stage confirmation", () => {
+    const mockElicitInput = createMockElicitInput();
+
+    describeWithMongoDB(
+        "with a client that supports elicitation",
+        (integration) => {
+            beforeEach(async () => {
+                mockElicitInput.clear();
+                await integration
+                    .mongoClient()
+                    .db(integration.randomDbName())
+                    .collection("people")
+                    .insertMany([
+                        { name: "Peter", age: 5 },
+                        { name: "Laura", age: 10 },
+                    ]);
+            });
+
+            it("asks the user to confirm a $out stage, naming the collection it replaces", async () => {
+                mockElicitInput.confirmYes();
+                const connectionId = await integration.connectMcpClient();
+
+                const response = await integration.mcpClient().callTool({
+                    name: "aggregate",
+                    arguments: {
+                        connectionId,
+                        database: integration.randomDbName(),
+                        collection: "people",
+                        pipeline: [{ $out: "outpeople" }],
+                    },
+                });
+
+                expect(mockElicitInput.mock).toHaveBeenCalledTimes(1);
+                const message = elicitedMessage(mockElicitInput);
+                expect(message).toContain("`$out`");
+                expect(message).toContain(`\`${integration.randomDbName()}.outpeople\``);
+
+                expect(response.isError).toBeUndefined();
+                const copied = await integration
+                    .mongoClient()
+                    .db(integration.randomDbName())
+                    .collection("outpeople")
+                    .find()
+                    .toArray();
+                expect(copied).toHaveLength(2);
+            });
+
+            it("asks the user to confirm a $merge stage, naming the collection it writes into", async () => {
+                mockElicitInput.confirmYes();
+                const connectionId = await integration.connectMcpClient();
+
+                await integration.mcpClient().callTool({
+                    name: "aggregate",
+                    arguments: {
+                        connectionId,
+                        database: integration.randomDbName(),
+                        collection: "people",
+                        pipeline: [{ $merge: { into: "mergedpeople", whenMatched: "replace" } }],
+                    },
+                });
+
+                expect(mockElicitInput.mock).toHaveBeenCalledTimes(1);
+                const message = elicitedMessage(mockElicitInput);
+                expect(message).toContain("`$merge`");
+                expect(message).toContain(`\`${integration.randomDbName()}.mergedpeople\``);
+                expect(message).toContain("whenMatched: replace");
+            });
+
+            it("does not write anything when the user declines", async () => {
+                mockElicitInput.confirmNo();
+                const connectionId = await integration.connectMcpClient();
+
+                const response = await integration.mcpClient().callTool({
+                    name: "aggregate",
+                    arguments: {
+                        connectionId,
+                        database: integration.randomDbName(),
+                        collection: "people",
+                        pipeline: [{ $out: "declinedpeople" }],
+                    },
+                });
+
+                expect(response.isError).toBe(true);
+                expect(getResponseContent(response)).toContain("aggregation was not performed");
+
+                const collections = await integration
+                    .mongoClient()
+                    .db(integration.randomDbName())
+                    .listCollections({ name: "declinedpeople" })
+                    .toArray();
+                expect(collections).toHaveLength(0);
+            });
+
+            it("does not ask for confirmation for a pipeline without write stages", async () => {
+                const connectionId = await integration.connectMcpClient();
+
+                const response = await integration.mcpClient().callTool({
+                    name: "aggregate",
+                    arguments: {
+                        connectionId,
+                        database: integration.randomDbName(),
+                        collection: "people",
+                        pipeline: [{ $match: { name: "Peter" } }],
+                    },
+                });
+
+                expect(response.isError).toBeUndefined();
+                expect(mockElicitInput.mock).not.toHaveBeenCalled();
+            });
+
+            it("rejects a write pipeline in readOnly mode without asking for confirmation", async () => {
+                const connectionId = await integration.connectMcpClient();
+                integration.mcpServer().userConfig.readOnly = true;
+
+                try {
+                    const response = await integration.mcpClient().callTool({
+                        name: "aggregate",
+                        arguments: {
+                            connectionId,
+                            database: integration.randomDbName(),
+                            collection: "people",
+                            pipeline: [{ $out: "outpeople" }],
+                        },
+                    });
+
+                    expect(getResponseContent(response)).toEqual(
+                        "Error running aggregate: In readOnly mode you can not run pipelines with $out or $merge stages."
+                    );
+                    expect(mockElicitInput.mock).not.toHaveBeenCalled();
+                } finally {
+                    integration.mcpServer().userConfig.readOnly = false;
+                }
+            });
+
+            it("asks only once when the tool is also in confirmationRequiredTools", async () => {
+                mockElicitInput.confirmYes();
+                const connectionId = await integration.connectMcpClient();
+                integration.mcpServer().userConfig.confirmationRequiredTools = ["aggregate"];
+
+                try {
+                    await integration.mcpClient().callTool({
+                        name: "aggregate",
+                        arguments: {
+                            connectionId,
+                            database: integration.randomDbName(),
+                            collection: "people",
+                            pipeline: [{ $out: "outpeople" }],
+                        },
+                    });
+
+                    expect(mockElicitInput.mock).toHaveBeenCalledTimes(1);
+                } finally {
+                    integration.mcpServer().userConfig.confirmationRequiredTools = [];
+                }
+            });
+        },
+        {
+            getUserConfig: () => ({ ...defaultTestConfig, confirmationRequiredTools: [] }),
+            getMockElicitationInput: () => mockElicitInput,
+        }
+    );
+
+    describeWithMongoDB(
+        "with a client that does not support elicitation",
+        (integration) => {
+            it("runs a write pipeline without asking for confirmation", async () => {
+                await integration
+                    .mongoClient()
+                    .db(integration.randomDbName())
+                    .collection("people")
+                    .insertMany([{ name: "Peter", age: 5 }]);
+                const connectionId = await integration.connectMcpClient();
+
+                const response = await integration.mcpClient().callTool({
+                    name: "aggregate",
+                    arguments: {
+                        connectionId,
+                        database: integration.randomDbName(),
+                        collection: "people",
+                        pipeline: [{ $out: "outpeople" }],
+                    },
+                });
+
+                expect(response.isError).toBeUndefined();
+                expect(getResponseContent(response)).toEqual("The aggregation pipeline executed successfully.");
+            });
+        },
+        {
+            getUserConfig: () => ({ ...defaultTestConfig, confirmationRequiredTools: [] }),
+        }
+    );
 });
 
 describeWithMongoDB(

--- a/tests/integration/tools/mongodb/read/aggregateDB.test.ts
+++ b/tests/integration/tools/mongodb/read/aggregateDB.test.ts
@@ -6,7 +6,8 @@ import {
     defaultTestConfig,
     expectDefined,
 } from "../../../helpers.js";
-import { expect, it, afterEach } from "vitest";
+import { expect, it, afterEach, describe, beforeEach } from "vitest";
+import { createMockElicitInput } from "../../../../utils/elicitationMocks.js";
 import { describeWithMongoDB, getDocsFromUntrustedContent, validateAutoConnectBehavior } from "../mongodbHelpers.js";
 import type { Client } from "@modelcontextprotocol/sdk/client";
 import type { CursorLimitKey } from "../../../../../src/helpers/constants.js";
@@ -266,6 +267,104 @@ describeWithMongoDB("aggregate-db tool", (integration) => {
             },
         };
     });
+});
+
+describe("aggregate-db tool write stage confirmation", () => {
+    const mockElicitInput = createMockElicitInput();
+
+    describeWithMongoDB(
+        "with a client that supports elicitation",
+        (integration) => {
+            beforeEach(() => mockElicitInput.clear());
+
+            it("asks the user to confirm a $out stage, naming the collection it replaces", async () => {
+                mockElicitInput.confirmYes();
+                const connectionId = await integration.connectMcpClient();
+
+                const response = await integration.mcpClient().callTool({
+                    name: "aggregate-db",
+                    arguments: {
+                        connectionId,
+                        database: integration.randomDbName(),
+                        pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $out: "outpeople" }],
+                    },
+                });
+
+                expect(mockElicitInput.mock).toHaveBeenCalledTimes(1);
+                const [request] = mockElicitInput.mock.mock.calls[0] as unknown as [{ message: string }];
+                expect(request.message).toContain("`$out`");
+                expect(request.message).toContain(`\`${integration.randomDbName()}.outpeople\``);
+                expect(response.isError).toBeUndefined();
+            });
+
+            it("does not write anything when the user declines", async () => {
+                mockElicitInput.confirmNo();
+                const connectionId = await integration.connectMcpClient();
+
+                const response = await integration.mcpClient().callTool({
+                    name: "aggregate-db",
+                    arguments: {
+                        connectionId,
+                        database: integration.randomDbName(),
+                        pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $out: "declinedpeople" }],
+                    },
+                });
+
+                expect(response.isError).toBe(true);
+                expect(getResponseContent(response)).toContain("aggregation was not performed");
+
+                const collections = await integration
+                    .mongoClient()
+                    .db(integration.randomDbName())
+                    .listCollections({ name: "declinedpeople" })
+                    .toArray();
+                expect(collections).toHaveLength(0);
+            });
+
+            it("does not ask for confirmation for a pipeline without write stages", async () => {
+                const connectionId = await integration.connectMcpClient();
+
+                const response = await integration.mcpClient().callTool({
+                    name: "aggregate-db",
+                    arguments: {
+                        connectionId,
+                        database: integration.randomDbName(),
+                        pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }],
+                    },
+                });
+
+                expect(response.isError).toBeUndefined();
+                expect(mockElicitInput.mock).not.toHaveBeenCalled();
+            });
+
+            it("rejects a write pipeline in readOnly mode without asking for confirmation", async () => {
+                const connectionId = await integration.connectMcpClient();
+                integration.mcpServer().userConfig.readOnly = true;
+
+                try {
+                    const response = await integration.mcpClient().callTool({
+                        name: "aggregate-db",
+                        arguments: {
+                            connectionId,
+                            database: integration.randomDbName(),
+                            pipeline: [{ $documents: [{ name: "Peter", age: 5 }] }, { $out: "outpeople" }],
+                        },
+                    });
+
+                    expect(getResponseContent(response)).toEqual(
+                        "Error running aggregate-db: In readOnly mode you can not run pipelines with $out or $merge stages."
+                    );
+                    expect(mockElicitInput.mock).not.toHaveBeenCalled();
+                } finally {
+                    integration.mcpServer().userConfig.readOnly = false;
+                }
+            });
+        },
+        {
+            getUserConfig: () => ({ ...defaultTestConfig, confirmationRequiredTools: [] }),
+            getMockElicitationInput: () => mockElicitInput,
+        }
+    );
 });
 
 describeWithMongoDB(

--- a/tests/unit/helpers/mqlGuards.test.ts
+++ b/tests/unit/helpers/mqlGuards.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { assertNoServerSideJS, isWriteStage } from "../../../src/helpers/mqlGuards.js";
+import { assertNoServerSideJS, getWriteStageTargets, isWriteStage } from "../../../src/helpers/mqlGuards.js";
 import { ErrorCodes, MongoDBError } from "../../../src/common/errors.js";
 
 function expectForbiddenOperator(value: unknown, operator: string): void {
@@ -79,6 +79,72 @@ describe("mqlGuards", () => {
             expect(isWriteStage({ $match: { age: 5 } })).toBe(false);
             expect(isWriteStage({ $group: { _id: null } })).toBe(false);
             expect(isWriteStage({})).toBe(false);
+        });
+    });
+
+    describe("getWriteStageTargets", () => {
+        it("returns an empty array for pipelines without write stages", () => {
+            expect(getWriteStageTargets([{ $match: { age: 5 } }, { $sort: { name: 1 } }], "mydb")).toEqual([]);
+        });
+
+        it("resolves a $out stage naming a collection against the default database", () => {
+            expect(getWriteStageTargets([{ $out: "results" }], "mydb")).toEqual([
+                { operator: "$out", namespace: "mydb.results" },
+            ]);
+        });
+
+        it("resolves a $out stage naming an explicit database and collection", () => {
+            expect(getWriteStageTargets([{ $out: { db: "otherdb", coll: "results" } }], "mydb")).toEqual([
+                { operator: "$out", namespace: "otherdb.results" },
+            ]);
+        });
+
+        it("resolves a $merge stage naming a collection against the default database", () => {
+            expect(getWriteStageTargets([{ $merge: "results" }], "mydb")).toEqual([
+                { operator: "$merge", namespace: "mydb.results" },
+            ]);
+        });
+
+        it("resolves a $merge stage with an into string", () => {
+            expect(getWriteStageTargets([{ $merge: { into: "results" } }], "mydb")).toEqual([
+                { operator: "$merge", namespace: "mydb.results" },
+            ]);
+        });
+
+        it("resolves a $merge stage with an into document naming an explicit database", () => {
+            expect(getWriteStageTargets([{ $merge: { into: { db: "otherdb", coll: "results" } } }], "mydb")).toEqual([
+                { operator: "$merge", namespace: "otherdb.results" },
+            ]);
+        });
+
+        it("reports the whenMatched and whenNotMatched behaviours of a $merge stage", () => {
+            expect(
+                getWriteStageTargets(
+                    [{ $merge: { into: "results", whenMatched: "replace", whenNotMatched: "discard" } }],
+                    "mydb"
+                )
+            ).toEqual([
+                { operator: "$merge", namespace: "mydb.results", whenMatched: "replace", whenNotMatched: "discard" },
+            ]);
+        });
+
+        it("omits a whenMatched that is a custom pipeline rather than a documented mode", () => {
+            expect(
+                getWriteStageTargets([{ $merge: { into: "results", whenMatched: [{ $set: { seen: true } }] } }], "mydb")
+            ).toEqual([{ operator: "$merge", namespace: "mydb.results" }]);
+        });
+
+        it("leaves the namespace undefined for unrecognised write stage shapes", () => {
+            expect(getWriteStageTargets([{ $out: { s3: { bucket: "b", region: "us-east-1" } } }], "mydb")).toEqual([
+                { operator: "$out", namespace: undefined },
+            ]);
+            expect(getWriteStageTargets([{ $merge: { into: { s3: "bucket" } } }], "mydb")).toEqual([
+                { operator: "$merge", namespace: undefined },
+            ]);
+        });
+
+        it("only inspects top-level stages", () => {
+            expect(getWriteStageTargets([{ $unionWith: { pipeline: [{ $out: "results" }] } }], "mydb")).toEqual([]);
         });
     });
 });

--- a/tests/unit/helpers/writeStageConfirmation.test.ts
+++ b/tests/unit/helpers/writeStageConfirmation.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { buildWriteStageConfirmationMessage } from "../../../src/helpers/writeStageConfirmation.js";
+
+describe("buildWriteStageConfirmationMessage", () => {
+    it("names the collection a $out stage replaces and warns that its documents are lost", () => {
+        const message = buildWriteStageConfirmationMessage([{ operator: "$out", namespace: "mydb.results" }]);
+
+        expect(message).toContain("`$out`");
+        expect(message).toContain("`mydb.results`");
+        expect(message).toContain("replace");
+        expect(message).toContain("discarding");
+        expect(message).toContain("Proceed?");
+    });
+
+    it("names the collection a $merge stage writes into", () => {
+        const message = buildWriteStageConfirmationMessage([{ operator: "$merge", namespace: "mydb.results" }]);
+
+        expect(message).toContain("`$merge`");
+        expect(message).toContain("`mydb.results`");
+        expect(message).toContain("Proceed?");
+    });
+
+    it("reports the whenMatched and whenNotMatched behaviours of a $merge stage", () => {
+        const message = buildWriteStageConfirmationMessage([
+            { operator: "$merge", namespace: "mydb.results", whenMatched: "replace", whenNotMatched: "discard" },
+        ]);
+
+        expect(message).toContain("whenMatched: replace");
+        expect(message).toContain("whenNotMatched: discard");
+    });
+
+    it("omits the mode clause when the $merge stage does not name modes", () => {
+        const message = buildWriteStageConfirmationMessage([{ operator: "$merge", namespace: "mydb.results" }]);
+
+        expect(message).not.toContain("whenMatched");
+    });
+
+    it("describes the stage without a namespace when the target could not be resolved", () => {
+        const message = buildWriteStageConfirmationMessage([{ operator: "$out", namespace: undefined }]);
+
+        expect(message).toContain("`$out`");
+        expect(message).not.toContain("undefined");
+        expect(message).toContain("Proceed?");
+    });
+
+    it("lists every stage when a pipeline describes more than one write stage", () => {
+        const message = buildWriteStageConfirmationMessage([
+            { operator: "$out", namespace: "mydb.first" },
+            { operator: "$merge", namespace: "mydb.second" },
+        ]);
+
+        expect(message).toContain("`mydb.first`");
+        expect(message).toContain("`mydb.second`");
+        expect(message).toContain("Proceed?");
+    });
+});

--- a/tests/unit/mocks/tools.ts
+++ b/tests/unit/mocks/tools.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ToolBase } from "../../../src/tools/tool.js";
-import type { OperationType, ToolArgs, ToolCategory } from "../../../src/tools/tool.js";
+import type { OperationType, ToolArgs, ToolCategory, ToolExecutionContext } from "../../../src/tools/tool.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { TelemetryToolMetadata } from "../../../src/telemetry/types.js";
 
@@ -110,6 +110,33 @@ export class EchoTool extends ToolBase {
 
     protected execute(): Promise<CallToolResult> {
         return Promise.resolve({ content: [{ type: "text", text: "ok" }] });
+    }
+
+    protected resolveTelemetryMetadata(): TelemetryToolMetadata {
+        return {};
+    }
+}
+
+/**
+ * Tool that asks for confirmation from within execute(), the way aggregate does
+ * once it knows the pipeline contains a write stage.
+ */
+export class ConfirmingTool extends ToolBase {
+    static toolName = "confirming-tool";
+    static category: ToolCategory = "mongodb";
+    static operationType: OperationType = "read";
+    public description = "Requests confirmation while executing";
+    public argsShape = {};
+
+    protected async execute(
+        _args: ToolArgs<typeof this.argsShape>,
+        context: ToolExecutionContext
+    ): Promise<CallToolResult> {
+        if (!(await this.requestConfirmation("Proceed?", context))) {
+            return { content: [{ type: "text" as const, text: "The operation was not performed." }], isError: true };
+        }
+
+        return { content: [{ type: "text" as const, text: "executed" }] };
     }
 
     protected resolveTelemetryMetadata(): TelemetryToolMetadata {

--- a/tests/unit/toolBase.test.ts
+++ b/tests/unit/toolBase.test.ts
@@ -131,6 +131,28 @@ describe("ToolBase", () => {
             );
         });
 
+        it("records the outcome of a declined confirmation", async () => {
+            mockConfig.confirmationRequiredTools = ["test-tool"];
+            mockRequestConfirmation.mockResolvedValue(false);
+
+            const result = await testTool["invoke"]({ param1: "test" }, { signal: new AbortController().signal });
+
+            expect(result.isError).toBe(true);
+
+            const { values } = await mockMetrics.get("toolExecutionDuration").get();
+            const count = values.find(
+                (v) =>
+                    v.metricName === "mcp_tool_execution_duration_seconds_count" &&
+                    v.labels.tool_name === "test-tool" &&
+                    v.labels.status === "error"
+            );
+            expect(count?.value).toBe(1);
+
+            const event = ((mockTelemetry.emitEvents as Mock).mock.lastCall?.[0] as ToolEvent[])[0];
+            expectDefined(event);
+            expect(event.properties.result).toBe("failure");
+        });
+
         it("should return false when user declines confirmation", async () => {
             mockConfig.confirmationRequiredTools = ["test-tool"];
             mockRequestConfirmation.mockResolvedValue(false);

--- a/tests/unit/toolBase.test.ts
+++ b/tests/unit/toolBase.test.ts
@@ -84,41 +84,35 @@ describe("ToolBase", () => {
         testTool = new TestTool(constructorParams);
     });
 
-    describe("verifyConfirmed", () => {
-        it("should return true when tool is not in confirmationRequiredTools list", async () => {
+    describe("confirmation required by configuration", () => {
+        it("does not ask when the tool is not in the confirmationRequiredTools list", async () => {
             mockConfig.confirmationRequiredTools = ["other-tool", "another-tool"];
 
-            const args = { param1: "test" };
-            const result = await testTool.verifyConfirmed(args, {
-                signal: new AbortController().signal,
-            });
+            const result = await testTool["invoke"]({ param1: "test" }, { signal: new AbortController().signal });
 
-            expect(result).toBe(true);
+            expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
             expect(mockRequestConfirmation).not.toHaveBeenCalled();
         });
 
-        it("should return true when confirmationRequiredTools list is empty", async () => {
+        it("does not ask when the confirmationRequiredTools list is empty", async () => {
             mockConfig.confirmationRequiredTools = [];
 
-            const args = { param1: "test" };
-            const result = await testTool.verifyConfirmed(args, {
-                signal: new AbortController().signal,
-            });
+            const result = await testTool["invoke"]({ param1: "test" }, { signal: new AbortController().signal });
 
-            expect(result).toBe(true);
+            expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
             expect(mockRequestConfirmation).not.toHaveBeenCalled();
         });
 
-        it("should call requestConfirmation when tool is in confirmationRequiredTools list", async () => {
+        it("asks with the tool's confirmation message when the tool is in the list", async () => {
             mockConfig.confirmationRequiredTools = ["test-tool"];
             mockRequestConfirmation.mockResolvedValue(true);
 
-            const args = { param1: "test", param2: 42 };
-            const result = await testTool.verifyConfirmed(args, {
-                signal: new AbortController().signal,
-            });
+            const result = await testTool["invoke"](
+                { param1: "test", param2: 42 },
+                { signal: new AbortController().signal }
+            );
 
-            expect(result).toBe(true);
+            expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
             expect(mockRequestConfirmation).toHaveBeenCalledTimes(1);
             expect(mockRequestConfirmation).toHaveBeenCalledWith(
                 "You are about to execute the `test-tool` tool which requires additional confirmation. Would you like to proceed?",
@@ -153,67 +147,20 @@ describe("ToolBase", () => {
             expect(event.properties.result).toBe("failure");
         });
 
-        it("should return false when user declines confirmation", async () => {
+        it("does not run the tool when the user declines", async () => {
             mockConfig.confirmationRequiredTools = ["test-tool"];
             mockRequestConfirmation.mockResolvedValue(false);
 
-            const args = { param1: "test" };
-            const result = await testTool.verifyConfirmed(args, {
-                signal: new AbortController().signal,
-            });
+            const result = await testTool["invoke"]({ param1: "test" }, { signal: new AbortController().signal });
 
-            expect(result).toBe(false);
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([
+                {
+                    type: "text",
+                    text: "User did not confirm the execution of the `test-tool` tool so the operation was not performed.",
+                },
+            ]);
             expect(mockRequestConfirmation).toHaveBeenCalledTimes(1);
-        });
-
-        it("should relate the confirmation request to the in-flight tool call", async () => {
-            mockConfig.confirmationRequiredTools = ["test-tool"];
-            mockRequestConfirmation.mockResolvedValue(true);
-
-            const context: ToolExecutionContext = { signal: new AbortController().signal, requestId: 42 };
-            await testTool.verifyConfirmed({ param1: "test" }, context);
-
-            expect(mockRequestConfirmation).toHaveBeenCalledWith(expect.any(String), {
-                relatedRequestId: 42,
-                signal: context.signal,
-            });
-        });
-
-        it("should pass progress heartbeat inputs from the execution context", async () => {
-            mockConfig.confirmationRequiredTools = ["test-tool"];
-            mockRequestConfirmation.mockResolvedValue(true);
-            const sendNotification = vi.fn();
-
-            const context: ToolExecutionContext = {
-                signal: new AbortController().signal,
-                requestId: 42,
-                _meta: { progressToken: "progress-token" },
-                sendNotification,
-            };
-            await testTool.verifyConfirmed({ param1: "test" }, context);
-
-            expect(mockRequestConfirmation).toHaveBeenCalledWith(expect.any(String), {
-                relatedRequestId: 42,
-                progressToken: "progress-token",
-                sendNotification,
-                signal: context.signal,
-            });
-        });
-
-        it("should not relate the confirmation request to the tool call in JSON response mode", async () => {
-            // In JSON response mode the in-flight POST cannot carry server->client
-            // messages, so the confirmation must use the standalone SSE stream.
-            mockConfig.confirmationRequiredTools = ["test-tool"];
-            mockConfig.httpResponseType = "json";
-            mockRequestConfirmation.mockResolvedValue(true);
-
-            const context: ToolExecutionContext = { signal: new AbortController().signal, requestId: 42 };
-            await testTool.verifyConfirmed({ param1: "test" }, context);
-
-            expect(mockRequestConfirmation).toHaveBeenCalledWith(expect.any(String), {
-                relatedRequestId: undefined,
-                signal: context.signal,
-            });
         });
     });
 
@@ -230,6 +177,41 @@ describe("ToolBase", () => {
                 relatedRequestId: 7,
                 progressToken: undefined,
                 sendNotification: undefined,
+                signal: context.signal,
+            });
+        });
+
+        it("passes the progress heartbeat inputs from the execution context", async () => {
+            mockRequestConfirmation.mockResolvedValue(true);
+            const sendNotification = vi.fn();
+
+            const context: ToolExecutionContext = {
+                signal: new AbortController().signal,
+                requestId: 42,
+                _meta: { progressToken: "progress-token" },
+                sendNotification,
+            };
+            await testTool["requestConfirmation"]("confirm?", context);
+
+            expect(mockRequestConfirmation).toHaveBeenCalledWith("confirm?", {
+                relatedRequestId: 42,
+                progressToken: "progress-token",
+                sendNotification,
+                signal: context.signal,
+            });
+        });
+
+        it("does not relate the confirmation request to the tool call in JSON response mode", async () => {
+            // In JSON response mode the in-flight POST cannot carry server->client
+            // messages, so the confirmation must use the standalone SSE stream.
+            mockConfig.httpResponseType = "json";
+            mockRequestConfirmation.mockResolvedValue(true);
+
+            const context: ToolExecutionContext = { signal: new AbortController().signal, requestId: 42 };
+            await testTool["requestConfirmation"]("confirm?", context);
+
+            expect(mockRequestConfirmation).toHaveBeenCalledWith("confirm?", {
+                relatedRequestId: undefined,
                 signal: context.signal,
             });
         });

--- a/tests/unit/toolBase.test.ts
+++ b/tests/unit/toolBase.test.ts
@@ -16,7 +16,13 @@ import type { PreviewFeature } from "../../src/common/schemas.js";
 import { UIRegistry } from "../../src/ui/registry/index.js";
 import { TRANSPORT_PAYLOAD_LIMITS } from "../../src/transports/constants.js";
 import { expectDefined } from "../integration/helpers.js";
-import { TestTool, TestToolWithOutputSchema, TestToolWithoutStructuredContent, ErrorTool } from "./mocks/tools.js";
+import {
+    TestTool,
+    TestToolWithOutputSchema,
+    TestToolWithoutStructuredContent,
+    ErrorTool,
+    ConfirmingTool,
+} from "./mocks/tools.js";
 import { MockMetrics } from "./mocks/metrics.js";
 import { Keychain } from "../../src/common/keychain.js";
 
@@ -186,6 +192,98 @@ describe("ToolBase", () => {
                 relatedRequestId: undefined,
                 signal: context.signal,
             });
+        });
+    });
+
+    describe("requestConfirmation", () => {
+        it("requests confirmation regardless of the confirmationRequiredTools list", async () => {
+            mockConfig.confirmationRequiredTools = [];
+            mockRequestConfirmation.mockResolvedValue(true);
+
+            const context: ToolExecutionContext = { signal: new AbortController().signal, requestId: 7 };
+            const result = await testTool["requestConfirmation"]("Custom message", context);
+
+            expect(result).toBe(true);
+            expect(mockRequestConfirmation).toHaveBeenCalledWith("Custom message", {
+                relatedRequestId: 7,
+                progressToken: undefined,
+                sendNotification: undefined,
+                signal: context.signal,
+            });
+        });
+
+        it("accumulates the time spent waiting on the execution context", async () => {
+            vi.useFakeTimers();
+            try {
+                mockRequestConfirmation.mockImplementation(() => {
+                    vi.advanceTimersByTime(5000);
+                    return Promise.resolve(true);
+                });
+
+                const context: ToolExecutionContext = { signal: new AbortController().signal };
+                await testTool["requestConfirmation"]("first", context);
+                await testTool["requestConfirmation"]("second", context);
+
+                expect(context.elicitationDurationMs).toBe(10_000);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+    });
+
+    describe("confirmation requested during execution", () => {
+        function createConfirmingTool(): ConfirmingTool {
+            return new ConfirmingTool({
+                name: ConfirmingTool.toolName,
+                category: ConfirmingTool.category,
+                operationType: ConfirmingTool.operationType,
+                session: mockSession,
+                config: mockConfig,
+                telemetry: mockTelemetry,
+                elicitation: mockElicitation,
+                metrics: mockMetrics,
+            });
+        }
+
+        it("runs the operation when the user confirms", async () => {
+            mockRequestConfirmation.mockResolvedValue(true);
+
+            const result = await createConfirmingTool()["invoke"]({}, { signal: new AbortController().signal });
+
+            expect(result.isError).toBeUndefined();
+            expect(result.content).toEqual([{ type: "text", text: "executed" }]);
+        });
+
+        it("aborts the operation when the user declines", async () => {
+            mockRequestConfirmation.mockResolvedValue(false);
+
+            const result = await createConfirmingTool()["invoke"]({}, { signal: new AbortController().signal });
+
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([{ type: "text", text: "The operation was not performed." }]);
+        });
+
+        it("excludes the time the user spent deciding from the duration metric", async () => {
+            vi.useFakeTimers();
+            try {
+                mockRequestConfirmation.mockImplementation(() => {
+                    vi.advanceTimersByTime(5000);
+                    return Promise.resolve(true);
+                });
+
+                const result = await createConfirmingTool()["invoke"]({}, { signal: new AbortController().signal });
+                expect(result.content).toEqual([{ type: "text", text: "executed" }]);
+            } finally {
+                vi.useRealTimers();
+            }
+
+            const { values } = await mockMetrics.get("toolExecutionDuration").get();
+            const sum = values.find(
+                (v) =>
+                    v.metricName === "mcp_tool_execution_duration_seconds_sum" &&
+                    v.labels.tool_name === "confirming-tool"
+            );
+            expect(sum?.value).toBeLessThan(1);
         });
     });
 


### PR DESCRIPTION
## Proposed changes

Updates the aggregate and aggregate-db tools to always request elicitation when the aggregation contains write stages.