### PR TITLE
chore(metrics): classify tool errors as expected vs unexpected on the tool execution metric MCP-619

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,27 @@ npx -y mongodb-mcp-server@latest --transport http --monitoringServerHost 0.0.0.0
 
 > **💡 Note:** `healthCheckHost` / `healthCheckPort` are deprecated aliases for `monitoringServerHost` / `monitoringServerPort` and continue to serve the same `/health` endpoint.
 
+##### Metrics
+
+The `/metrics` endpoint exposes Prometheus metrics, including the `mcp_tool_execution_duration_seconds` histogram that tracks every tool execution:
+
+| Label            | Description                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `tool_name`      | Name of the executed tool.                                                                              |
+| `category`       | Tool category (`mongodb`, `atlas`, `atlas-local`, `assistant`, ...).                                    |
+| `status`         | `success` or `error`.                                                                                   |
+| `operation_type` | Operation category of the tool (`read`, `write`, `update`, ...).                                        |
+| `error_type`     | `Error` name or symbolic `ErrorCodes` name (e.g. `ForbiddenWriteOperation`, `UnexpectedError`); only set when the tool threw. |
+| `expected`       | `true` for successes and caller-addressable errors (Atlas API 4xx, rejected operations, declined confirmations); `false` for infrastructure errors. |
+
+Tools signal an infrastructure failure by throwing an `UnexpectedError` (checked first by the classifier), and caller-addressable failures by throwing typed errors or returning an `isError` result. **Error-rate alerts should count only `expected="false"`** so that rejected operations and user decisions are not paged:
+
+```promql
+sum(
+  rate(mcp_tool_execution_duration_seconds_count{expected="false"}[5m])
+) by (tool_name)
+```
+
 ### Atlas API Access
 
 To use the Atlas API tools, you'll need to create a service account in MongoDB Atlas:

--- a/README.md
+++ b/README.md
@@ -638,27 +638,6 @@ npx -y mongodb-mcp-server@latest --transport http --monitoringServerHost 0.0.0.0
 
 > **💡 Note:** `healthCheckHost` / `healthCheckPort` are deprecated aliases for `monitoringServerHost` / `monitoringServerPort` and continue to serve the same `/health` endpoint.
 
-##### Metrics
-
-The `/metrics` endpoint exposes Prometheus metrics, including the `mcp_tool_execution_duration_seconds` histogram that tracks every tool execution:
-
-| Label            | Description                                                                                             |
-| ---------------- | ------------------------------------------------------------------------------------------------------- |
-| `tool_name`      | Name of the executed tool.                                                                              |
-| `category`       | Tool category (`mongodb`, `atlas`, `atlas-local`, `assistant`, ...).                                    |
-| `status`         | `success` or `error`.                                                                                   |
-| `operation_type` | Operation category of the tool (`read`, `write`, `update`, ...).                                        |
-| `error_type`     | `Error` name or symbolic `ErrorCodes` name (e.g. `ForbiddenWriteOperation`, `UnexpectedError`); only set when the tool threw. |
-| `expected`       | `true` for successes and caller-addressable errors (Atlas API 4xx, rejected operations, declined confirmations); `false` for infrastructure errors. |
-
-Tools signal an infrastructure failure by throwing an `UnexpectedError` (checked first by the classifier), and caller-addressable failures by throwing typed errors or returning an `isError` result. **Error-rate alerts should count only `expected="false"`** so that rejected operations and user decisions are not paged:
-
-```promql
-sum(
-  rate(mcp_tool_execution_duration_seconds_count{expected="false"}[5m])
-) by (tool_name)
-```
-
 ### Atlas API Access
 
 To use the Atlas API tools, you'll need to create a service account in MongoDB Atlas:

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -251,6 +251,9 @@ export interface AuthProvider {
 // @public (undocumented)
 export type BaseEvent = TelemetryEvent<unknown>;
 
+// @public (undocumented)
+export function classifyToolError(error: unknown): ToolErrorKind;
+
 export { CloseableTransport }
 
 // @public
@@ -1226,6 +1229,9 @@ export { TelemetryEvents }
 export type ToolCategory = "mongodb" | "atlas" | "atlas-local" | "assistant";
 
 // @public
+export type ToolErrorKind = "expected" | "unexpected";
+
+// @public
 export type ToolExecutionContext = Pick<ServerRequestHandlerExtra, "signal"> & Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">> & {
     elicitationDurationMs?: number;
 };
@@ -1302,6 +1308,13 @@ export class UIRegistry {
 export type UIRegistryOptions = {
     customUIs?: (toolName: string) => string | null | Promise<string | null>;
 };
+
+// @public
+export class UnexpectedError extends Error {
+    constructor(message: string, options?: {
+        cause?: unknown;
+    });
+}
 
 // @public (undocumented)
 export type UserConfig = z.infer<typeof UserConfigSchema>;

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -6,6 +6,7 @@
 
 import type { AggregationCursor } from 'mongodb';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { classifyToolError } from './common/classifyToolError.ts';
 import type { Client } from '@mongodb-js/atlas-local';
 import type { components } from './openapi.js';
 import { ConnectionInfo } from '@mongosh/arg-parser';
@@ -32,6 +33,7 @@ import type { ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import type { ServerRequest } from '@modelcontextprotocol/sdk/types.js';
 import type { TelemetryEvents } from '@mongodb-js/mcp-types';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import { ToolErrorKind } from './common/classifyToolError.ts';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { TransportRequestContext } from '@mongodb-js/mcp-types';
 import { z } from 'zod';
@@ -269,6 +271,8 @@ export type AvailableExport = Pick<StoredExport, "exportName" | "exportTitle" | 
 
 // @public (undocumented)
 export type BaseEvent = TelemetryEvent<unknown>;
+
+export { classifyToolError }
 
 // @public (undocumented)
 export interface CommonExportData {
@@ -1108,6 +1112,8 @@ export type ToolConstructorParams<TUserConfig extends UserConfig = UserConfig, T
     context?: TContext;
 };
 
+export { ToolErrorKind }
+
 // @public
 export type ToolExecutionContext = Pick<ServerRequestHandlerExtra, "signal"> & Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">> & {
     elicitationDurationMs?: number;
@@ -1182,6 +1188,13 @@ export class UIRegistry {
         customUIs?: (toolName: string) => string | null | Promise<string | null>;
     });
     get(toolName: string): Promise<string | null>;
+}
+
+// @public
+export class UnexpectedError extends Error {
+    constructor(message: string, options?: {
+        cause?: unknown;
+    });
 }
 
 // @public (undocumented)

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -6,7 +6,6 @@
 
 import type { AggregationCursor } from 'mongodb';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { classifyToolError } from './common/classifyToolError.ts';
 import type { Client } from '@mongodb-js/atlas-local';
 import type { components } from './openapi.js';
 import { ConnectionInfo } from '@mongosh/arg-parser';
@@ -33,7 +32,6 @@ import type { ServerNotification } from '@modelcontextprotocol/sdk/types.js';
 import type { ServerRequest } from '@modelcontextprotocol/sdk/types.js';
 import type { TelemetryEvents } from '@mongodb-js/mcp-types';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import { ToolErrorKind } from './common/classifyToolError.ts';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { TransportRequestContext } from '@mongodb-js/mcp-types';
 import { z } from 'zod';
@@ -272,7 +270,8 @@ export type AvailableExport = Pick<StoredExport, "exportName" | "exportTitle" | 
 // @public (undocumented)
 export type BaseEvent = TelemetryEvent<unknown>;
 
-export { classifyToolError }
+// @public (undocumented)
+export function classifyToolError(error: unknown): ToolErrorKind;
 
 // @public (undocumented)
 export interface CommonExportData {
@@ -1112,7 +1111,8 @@ export type ToolConstructorParams<TUserConfig extends UserConfig = UserConfig, T
     context?: TContext;
 };
 
-export { ToolErrorKind }
+// @public
+export type ToolErrorKind = "expected" | "unexpected";
 
 // @public
 export type ToolExecutionContext = Pick<ServerRequestHandlerExtra, "signal"> & Partial<Pick<ServerRequestHandlerExtra, "_meta" | "requestId" | "requestInfo" | "sendNotification">> & {

--- a/packages/metrics/src/metricDefinitions.ts
+++ b/packages/metrics/src/metricDefinitions.ts
@@ -12,8 +12,8 @@ export function createDefaultMetrics() {
     return {
         toolExecutionDuration: new Histogram({
             name: "mcp_tool_execution_duration_seconds",
-            help: 'Duration of tool executions in seconds. expected="false" indicates an unexpected infrastructure error',
-            labelNames: ["tool_name", "category", "status", "operation_type", "error_type", "expected"] as const,
+            help: 'Duration of tool executions in seconds. error_expected="false" indicates an unexpected infrastructure error',
+            labelNames: ["tool_name", "category", "status", "operation_type", "error_type", "error_expected"] as const,
             buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2.5, 5, 10],
             registers: [],
         }),

--- a/packages/metrics/src/metricDefinitions.ts
+++ b/packages/metrics/src/metricDefinitions.ts
@@ -12,8 +12,8 @@ export function createDefaultMetrics() {
     return {
         toolExecutionDuration: new Histogram({
             name: "mcp_tool_execution_duration_seconds",
-            help: "Duration of tool executions in seconds",
-            labelNames: ["tool_name", "category", "status", "operation_type", "error_type"] as const,
+            help: 'Duration of tool executions in seconds. expected="false" indicates an unexpected infrastructure error',
+            labelNames: ["tool_name", "category", "status", "operation_type", "error_type", "expected"] as const,
             buckets: [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 2.5, 5, 10],
             registers: [],
         }),

--- a/src/common/classifyToolError.ts
+++ b/src/common/classifyToolError.ts
@@ -1,0 +1,47 @@
+import { MongoServerError } from "mongodb";
+import { ErrorCodes, isMongoDBError, UnexpectedError } from "./errors.js";
+import { ApiClientError } from "./atlas/apiClientError.js";
+
+export function classifyToolError(error: unknown): ToolErrorKind {
+    if (error instanceof UnexpectedError) {
+        return "unexpected";
+    }
+    if (error instanceof ApiClientError) {
+        return error.response.status >= 400 && error.response.status < 500 ? "expected" : "unexpected";
+    }
+    if (isMongoDBError(error)) {
+        return MONGODB_ERROR_KINDS[error.code];
+    }
+    // Data-plane operation rejections: the bulk/write-concern subclasses all
+    // extend `MongoServerError`, so one instanceof covers the family.
+    if (error instanceof MongoServerError) {
+        return "expected";
+    }
+
+    return "unexpected";
+}
+
+/**
+ * `"expected"` = caller-addressable (Atlas API 4xx, rejected operations,
+ * bad input); `"unexpected"` = infrastructure (Atlas API 5xx, broken
+ * connections) and what error-rate alerts should count. Throw
+ * {@link UnexpectedError} to force `"unexpected"`.
+ */
+export type ToolErrorKind = "expected" | "unexpected";
+
+// Exhaustive per-code map: new `ErrorCodes` members force a decision here
+// instead of silently defaulting to "expected". The "unexpected" pair mirrors
+// the connection-failure set in `connectionErrorHandler.ts`.
+const MONGODB_ERROR_KINDS = {
+    [ErrorCodes.NotConnectedToMongoDB]: "unexpected",
+    [ErrorCodes.MisconfiguredConnectionString]: "unexpected",
+    [ErrorCodes.ForbiddenCollscan]: "expected",
+    [ErrorCodes.ForbiddenWriteOperation]: "expected",
+    [ErrorCodes.AtlasSearchNotSupported]: "expected",
+    [ErrorCodes.AtlasVectorSearchIndexNotFound]: "expected",
+    [ErrorCodes.AtlasVectorSearchInvalidQuery]: "expected",
+    [ErrorCodes.InvalidPipeline]: "expected",
+    [ErrorCodes.ForbiddenServerSideJS]: "expected",
+    [ErrorCodes.UnknownConnectionId]: "expected",
+    [ErrorCodes.ConfirmationDeclined]: "expected",
+} as const satisfies Record<ErrorCodes, ToolErrorKind>;

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -29,7 +29,7 @@ export function isMongoDBError(error: unknown): error is MongoDBError<ErrorCodes
 
 /**
  * Marks a tool failure as infrastructure or unintentional rather than caller-addressable, so
- * `classifyToolError` records it as `expected="false"` on the tool metric.
+ * `classifyToolError` records it as `error_expected="false"` on the tool metric.
  */
 export class UnexpectedError extends Error {
     constructor(message: string, options?: { cause?: unknown }) {

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -18,5 +18,22 @@ export class MongoDBError<ErrorCode extends ErrorCodes = ErrorCodes> extends Err
         message: string
     ) {
         super(message);
+        this.name = "MongoDBError";
+    }
+}
+
+/** Type guard that also preserves the precise `ErrorCode` type parameter. */
+export function isMongoDBError(error: unknown): error is MongoDBError<ErrorCodes> {
+    return error instanceof MongoDBError;
+}
+
+/**
+ * Marks a tool failure as infrastructure or unintentional rather than caller-addressable, so
+ * `classifyToolError` records it as `expected="false"` on the tool metric.
+ */
+export class UnexpectedError extends Error {
+    constructor(message: string, options?: { cause?: unknown }) {
+        super(message, options);
+        this.name = "UnexpectedError";
     }
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -95,7 +95,8 @@ export {
     type ConnectionErrorUnhandled,
     type ConnectionErrorHandlerContext,
 } from "./common/connectionErrorHandler.js";
-export { ErrorCodes, MongoDBError } from "./common/errors.js";
+export { ErrorCodes, MongoDBError, UnexpectedError } from "./common/errors.js";
+export { classifyToolError, type ToolErrorKind } from "./common/classifyToolError.js";
 export { Telemetry } from "./telemetry/telemetry.js";
 export { type TelemetryEvent, type CommonProperties, type BaseEvent } from "./telemetry/types.js";
 export type { TelemetryEvents, TelemetryConfig } from "./telemetry/telemetry.js";

--- a/src/tools/assistant/listKnowledgeSources.ts
+++ b/src/tools/assistant/listKnowledgeSources.ts
@@ -2,6 +2,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { formatUntrustedData, type OperationType, type ToolCategory } from "../tool.js";
 import { AssistantToolBase } from "./assistantTool.js";
 import { LogId } from "../../common/logging/index.js";
+import { UnexpectedError } from "../../common/errors.js";
 import { stringify as yamlStringify } from "yaml";
 
 export type KnowledgeSource = {
@@ -43,15 +44,8 @@ export class ListKnowledgeSourcesTool extends AssistantToolBase {
                 context: "assistant-list-knowledge-sources",
                 message,
             });
-            return {
-                content: [
-                    {
-                        type: "text",
-                        text: message,
-                    },
-                ],
-                isError: true,
-            };
+            // Infrastructure failure: throw so it is classified as expected="false".
+            throw new UnexpectedError(message);
         }
         const { dataSources } = (await response.json()) as ListKnowledgeSourcesResponse;
 

--- a/src/tools/assistant/listKnowledgeSources.ts
+++ b/src/tools/assistant/listKnowledgeSources.ts
@@ -44,7 +44,7 @@ export class ListKnowledgeSourcesTool extends AssistantToolBase {
                 context: "assistant-list-knowledge-sources",
                 message,
             });
-            // Infrastructure failure: throw so it is classified as expected="false".
+            // Infrastructure failure: throw so it is classified as error_expected="false".
             throw new UnexpectedError(message);
         }
         const { dataSources } = (await response.json()) as ListKnowledgeSourcesResponse;

--- a/src/tools/assistant/searchKnowledge.ts
+++ b/src/tools/assistant/searchKnowledge.ts
@@ -70,7 +70,7 @@ export class SearchKnowledgeTool extends AssistantToolBase {
                 context: "assistant-search-knowledge",
                 message,
             });
-            // Infrastructure failure: throw so it is classified as expected="false".
+            // Infrastructure failure: throw so it is classified as error_expected="false".
             throw new UnexpectedError(message);
         }
         const { results } = (await response.json()) as SearchKnowledgeResponse;

--- a/src/tools/assistant/searchKnowledge.ts
+++ b/src/tools/assistant/searchKnowledge.ts
@@ -3,6 +3,7 @@ import { type CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { type ToolArgs, type OperationType, type ToolCategory, formatUntrustedData } from "../tool.js";
 import { AssistantToolBase } from "./assistantTool.js";
 import { LogId } from "../../common/logging/index.js";
+import { UnexpectedError } from "../../common/errors.js";
 import { stringify as yamlStringify } from "yaml";
 
 export const SearchKnowledgeToolArgs = {
@@ -69,15 +70,8 @@ export class SearchKnowledgeTool extends AssistantToolBase {
                 context: "assistant-search-knowledge",
                 message,
             });
-            return {
-                content: [
-                    {
-                        type: "text",
-                        text: message,
-                    },
-                ],
-                isError: true,
-            };
+            // Infrastructure failure: throw so it is classified as expected="false".
+            throw new UnexpectedError(message);
         }
         const { results } = (await response.json()) as SearchKnowledgeResponse;
 

--- a/src/tools/atlasLocal/atlasLocalTool.ts
+++ b/src/tools/atlasLocal/atlasLocalTool.ts
@@ -3,6 +3,7 @@ import type { ToolArgs, ToolCategory, ToolExecutionContext } from "../tool.js";
 import { ToolBase } from "../tool.js";
 import type { Client } from "@mongodb-js/atlas-local";
 import { LogId } from "../../common/logging/index.js";
+import { UnexpectedError } from "../../common/errors.js";
 import type { ConnectionMetadata } from "../../telemetry/types.js";
 
 export const AtlasLocalToolMetadataDeploymentIdKey = "deploymentId";
@@ -29,16 +30,11 @@ export abstract class AtlasLocalToolBase extends ToolBase {
         //   verifyAllowed would still return false preventing the tool from being registered,
         //   preventing the tool from being executed
         if (!client) {
-            return {
-                content: [
-                    {
-                        type: "text",
-                        text: `Something went wrong on our end, this tool should have been disabled but it was not.
-please log a ticket here: https://github.com/mongodb-js/mongodb-mcp-server/issues/new?template=bug_report.yml`,
-                    },
-                ],
-                isError: true,
-            };
+            // Server-side invariant violation: throw so it is classified as expected="false".
+            throw new UnexpectedError(
+                `Something went wrong on our end, this tool should have been disabled but it was not.
+please log a ticket here: https://github.com/mongodb-js/mongodb-mcp-server/issues/new?template=bug_report.yml`
+            );
         }
 
         return this.executeWithAtlasLocalClient(args, { client });

--- a/src/tools/atlasLocal/atlasLocalTool.ts
+++ b/src/tools/atlasLocal/atlasLocalTool.ts
@@ -30,7 +30,6 @@ export abstract class AtlasLocalToolBase extends ToolBase {
         //   verifyAllowed would still return false preventing the tool from being registered,
         //   preventing the tool from being executed
         if (!client) {
-            // Server-side invariant violation: throw so it is classified as expected="false".
             throw new UnexpectedError(
                 `Something went wrong on our end, this tool should have been disabled but it was not.
 please log a ticket here: https://github.com/mongodb-js/mongodb-mcp-server/issues/new?template=bug_report.yml`

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -24,6 +24,8 @@ import { getRandomUUID } from "../helpers/getRandomUUID.js";
 import { requestIdAttr } from "../helpers/requestIdAttr.js";
 import type { Metrics, DefaultMetrics } from "@mongodb-js/mcp-metrics";
 import { redact } from "mongodb-redact";
+import { classifyToolError } from "../common/classifyToolError.js";
+import { ErrorCodes, isMongoDBError } from "../common/errors.js";
 
 export type ToolArgs<T extends ZodRawShape> = {
     [K in keyof T]: z.infer<T[K]>;
@@ -65,6 +67,17 @@ type StructuredToolResult<OutputSchema extends ZodRawShape> = {
     isError?: boolean;
     structuredContent: z.infer<z.ZodObject<OutputSchema>>;
 };
+
+/** `error_type` metric label: symbolic `ErrorCodes` name for MongoDBError, `error.name` otherwise. */
+function errorTypeLabel(error: unknown): string {
+    if (isMongoDBError(error)) {
+        return ErrorCodes[error.code] ?? "MongoDBError";
+    }
+    if (error instanceof Error) {
+        return error.name;
+    }
+    return "unknown";
+}
 
 /**
  * The type of operation the tool performs. This is used when evaluating if a tool is allowed to run based on
@@ -533,9 +546,11 @@ export abstract class ToolBase<
         const startTime: number = Date.now();
 
         /**
-         * Records the outcome of the call, emitting its telemetry event and
-         * observing its execution duration. `error` is passed when the call
-         * failed, and its type is reported alongside the metric.
+         * Emits the telemetry event and observes execution duration. `expected`
+         * is "true" for success, caller-addressable errors and declined
+         * confirmations, "false" for infrastructure errors (what alerts should
+         * count). `error_type` is only recorded for thrown errors; an `isError`
+         * result without a thrown error is treated as expected.
          */
         const recordOutcome = (result: CallToolResult, error?: unknown): void => {
             // Time the user spent answering an elicitation is not time the tool
@@ -550,7 +565,8 @@ export abstract class ToolBase<
                     category: this.category,
                     status: error !== undefined || result.isError ? "error" : "success",
                     operation_type: this.operationType,
-                    ...(error !== undefined ? { error_type: error instanceof Error ? error.name : "unknown" } : {}),
+                    expected: error === undefined || classifyToolError(error) === "expected" ? "true" : "false",
+                    ...(error !== undefined ? { error_type: errorTypeLabel(error) } : {}),
                 },
                 (Date.now() - executionStartTime) / 1000
             );

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -546,11 +546,11 @@ export abstract class ToolBase<
         const startTime: number = Date.now();
 
         /**
-         * Emits the telemetry event and observes execution duration. `expected`
-         * is "true" for success, caller-addressable errors and declined
-         * confirmations, "false" for infrastructure errors (what alerts should
-         * count). `error_type` is only recorded for thrown errors; an `isError`
-         * result without a thrown error is treated as expected.
+         * Emits the telemetry event and observes execution duration. For thrown
+         * errors, `error_type` names the error and `error_expected` is "true"
+         * for caller-addressable errors, "false" for infrastructure errors
+         * (what alerts should count). Successes, declined confirmations and
+         * `isError` results without a thrown error record neither label.
          */
         const recordOutcome = (result: CallToolResult, error?: unknown): void => {
             // Time the user spent answering an elicitation is not time the tool
@@ -565,8 +565,12 @@ export abstract class ToolBase<
                     category: this.category,
                     status: error !== undefined || result.isError ? "error" : "success",
                     operation_type: this.operationType,
-                    expected: error === undefined || classifyToolError(error) === "expected" ? "true" : "false",
-                    ...(error !== undefined ? { error_type: errorTypeLabel(error) } : {}),
+                    ...(error !== undefined
+                        ? {
+                              error_type: errorTypeLabel(error),
+                              error_expected: classifyToolError(error) === "expected" ? "true" : "false",
+                          }
+                        : {}),
                 },
                 (Date.now() - executionStartTime) / 1000
             );

--- a/src/web.ts
+++ b/src/web.ts
@@ -99,7 +99,8 @@ export { Telemetry } from "./telemetry/telemetry.js";
 export type { TelemetryEvents, TelemetryConfig } from "./telemetry/telemetry.js";
 export type { TelemetryEvent, BaseEvent } from "./telemetry/types.js";
 export { EventCache } from "./telemetry/eventCache.js";
-export { ErrorCodes, MongoDBError } from "./common/errors.js";
+export { ErrorCodes, MongoDBError, UnexpectedError } from "./common/errors.js";
+export { classifyToolError, type ToolErrorKind } from "./common/classifyToolError.js";
 export { getRandomUUID } from "./helpers/getRandomUUID.js";
 export type { AuthProvider, Credentials } from "./common/atlas/auth/authProvider.js";
 export type {

--- a/tests/integration/metrics.test.ts
+++ b/tests/integration/metrics.test.ts
@@ -77,7 +77,7 @@ describe("/metrics endpoint", () => {
         ).toBeGreaterThanOrEqual(0);
     });
 
-    it("records error_type and expected labels on toolExecutionDuration histogram when a tool throws", async () => {
+    it("records error_type and error_expected labels on toolExecutionDuration histogram when a tool throws", async () => {
         runner = new StreamableHttpRunner({ userConfig: config, tools: [ErrorTool] });
         await runner.start();
 
@@ -92,12 +92,12 @@ describe("/metrics endpoint", () => {
                 status: "error",
                 operation_type: "read",
                 error_type: "TypeError",
-                expected: "false",
+                error_expected: "false",
             })
         ).toBe(1);
     });
 
-    it("records expected=true on toolExecutionDuration histogram for success", async () => {
+    it("does not record error_expected on toolExecutionDuration histogram for success", async () => {
         runner = new StreamableHttpRunner({ userConfig: config, tools: [EchoTool] });
         await runner.start();
 
@@ -110,9 +110,9 @@ describe("/metrics endpoint", () => {
             parsePrometheusValue(body, "mcp_tool_execution_duration_seconds_count", {
                 tool_name: "echo-tool",
                 status: "success",
-                expected: "true",
             })
         ).toBe(1);
+        expect(body).not.toMatch(/error_expected="true"/);
     });
 
     it("increments mcp_session_created when clients connect", async () => {

--- a/tests/integration/metrics.test.ts
+++ b/tests/integration/metrics.test.ts
@@ -77,7 +77,7 @@ describe("/metrics endpoint", () => {
         ).toBeGreaterThanOrEqual(0);
     });
 
-    it("records error_type label on toolExecutionDuration histogram when a tool throws", async () => {
+    it("records error_type and expected labels on toolExecutionDuration histogram when a tool throws", async () => {
         runner = new StreamableHttpRunner({ userConfig: config, tools: [ErrorTool] });
         await runner.start();
 
@@ -92,6 +92,25 @@ describe("/metrics endpoint", () => {
                 status: "error",
                 operation_type: "read",
                 error_type: "TypeError",
+                expected: "false",
+            })
+        ).toBe(1);
+    });
+
+    it("records expected=true on toolExecutionDuration histogram for success", async () => {
+        runner = new StreamableHttpRunner({ userConfig: config, tools: [EchoTool] });
+        await runner.start();
+
+        const client = await connectClient();
+        await client.callTool({ name: "echo-tool", arguments: {} });
+
+        const body = await (await fetch(monitoringUrl("/metrics"))).text();
+
+        expect(
+            parsePrometheusValue(body, "mcp_tool_execution_duration_seconds_count", {
+                tool_name: "echo-tool",
+                status: "success",
+                expected: "true",
             })
         ).toBe(1);
     });

--- a/tests/unit/common/classifyToolError.test.ts
+++ b/tests/unit/common/classifyToolError.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { MongoServerError, MongoBulkWriteError, MongoWriteConcernError, MongoNetworkError } from "mongodb";
+import { ErrorCodes, MongoDBError, UnexpectedError } from "../../../src/common/errors.js";
+import { ApiClientError } from "../../../src/common/atlas/apiClientError.js";
+import { classifyToolError } from "../../../src/common/classifyToolError.js";
+
+const atlasApiError = (status: number, message = "error calling Atlas API"): Error =>
+    ApiClientError.fromError(new Response(null, { status, statusText: String(status) }), message);
+
+describe("classifyToolError", () => {
+    describe("expected (caller-addressable) errors", () => {
+        it.each([400, 401, 402, 403, 404, 409, 429])("Atlas API %s", (status) => {
+            expect(classifyToolError(atlasApiError(status))).toBe("expected");
+        });
+
+        it.each([
+            [ErrorCodes.UnknownConnectionId],
+            [ErrorCodes.ForbiddenWriteOperation],
+            [ErrorCodes.InvalidPipeline],
+            [ErrorCodes.ForbiddenCollscan],
+            [ErrorCodes.AtlasSearchNotSupported],
+            [ErrorCodes.ConfirmationDeclined],
+            [ErrorCodes.ForbiddenServerSideJS],
+            [ErrorCodes.AtlasVectorSearchIndexNotFound],
+            [ErrorCodes.AtlasVectorSearchInvalidQuery],
+        ])("caller-addressable MongoDBError code %s", (code) => {
+            expect(classifyToolError(new MongoDBError(code, "rejected"))).toBe("expected");
+        });
+
+        it.each([
+            ["MongoServerError", new MongoServerError({ code: 11000, errmsg: "duplicate key" })],
+            [
+                "MongoBulkWriteError",
+                new MongoBulkWriteError({ message: "duplicate key", code: 11000 }, {
+                    n: 0,
+                } as unknown as ConstructorParameters<typeof MongoBulkWriteError>[1]),
+            ],
+            [
+                "MongoWriteConcernError",
+                new MongoWriteConcernError({
+                    ok: 1,
+                    writeConcernError: { code: 64, errmsg: "write concern failed" },
+                }),
+            ],
+        ])("data-plane operation rejection %s", (_name, error) => {
+            expect(classifyToolError(error)).toBe("expected");
+        });
+    });
+
+    describe("unexpected (infrastructure) errors", () => {
+        it.each([500, 502, 503])("Atlas API %s", (status) => {
+            expect(classifyToolError(atlasApiError(status))).toBe("unexpected");
+        });
+
+        it.each([
+            [ErrorCodes.NotConnectedToMongoDB, "NotConnectedToMongoDB"],
+            [ErrorCodes.MisconfiguredConnectionString, "MisconfiguredConnectionString"],
+        ])("connection-broken MongoDBError code %s", (code) => {
+            expect(classifyToolError(new MongoDBError(code, "dial failed"))).toBe("unexpected");
+        });
+
+        it.each([
+            ["a plain Error", new Error("boom")],
+            ["a driver network error", new MongoNetworkError("socket closed")],
+            ["a non-Error value", "boom"],
+            ["undefined", undefined],
+            ["null", null],
+        ])("%s", (_name, error) => {
+            expect(classifyToolError(error)).toBe("unexpected");
+        });
+
+        it.each([
+            ["an UnexpectedError", new UnexpectedError("infra broke")],
+            ["an UnexpectedError with a cause", new UnexpectedError("api down", { cause: new Error("ECONNREFUSED") })],
+        ])("%s", (_name, error) => {
+            expect(classifyToolError(error)).toBe("unexpected");
+        });
+
+        it("overrides heuristics: UnexpectedError wrapping an Atlas API 4xx is unexpected", () => {
+            const wrapped = new UnexpectedError("Atlas API misconfigured", {
+                cause: atlasApiError(401, "unauthorized"),
+            });
+            expect(classifyToolError(wrapped)).toBe("unexpected");
+        });
+
+        it("overrides heuristics: UnexpectedError wrapping a data-plane rejection is unexpected", () => {
+            const wrapped = new UnexpectedError("driver misbehaving", {
+                cause: new MongoServerError({ code: 11000, errmsg: "duplicate key" }),
+            });
+            expect(classifyToolError(wrapped)).toBe("unexpected");
+        });
+    });
+});

--- a/tests/unit/mocks/tools.ts
+++ b/tests/unit/mocks/tools.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MongoDBError, ErrorCodes, UnexpectedError } from "../../../src/common/errors.js";
 import { ToolBase } from "../../../src/tools/tool.js";
 import type { OperationType, ToolArgs, ToolCategory, ToolExecutionContext } from "../../../src/tools/tool.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
@@ -93,6 +94,40 @@ export class ErrorTool extends ToolBase {
 
     protected execute(): Promise<CallToolResult> {
         return Promise.reject(new TypeError("intentional error"));
+    }
+
+    protected resolveTelemetryMetadata(): TelemetryToolMetadata {
+        return {};
+    }
+}
+
+/** Tool whose execute() throws a caller-addressable MongoDBError – used by classification tests. */
+export class CallerAddressableErrorTool extends ToolBase {
+    static toolName = "caller-addressable-error-tool";
+    static category: ToolCategory = "mongodb";
+    static operationType: OperationType = "update";
+    public description = "A tool that throws a caller-addressable error";
+    public argsShape = {};
+
+    protected execute(): Promise<CallToolResult> {
+        return Promise.reject(new MongoDBError(ErrorCodes.ForbiddenWriteOperation, "not allowed"));
+    }
+
+    protected resolveTelemetryMetadata(): TelemetryToolMetadata {
+        return {};
+    }
+}
+
+/** Tool whose execute() throws an UnexpectedError – used by classification tests. */
+export class UnexpectedErrorTool extends ToolBase {
+    static toolName = "unexpected-error-tool";
+    static category: ToolCategory = "mongodb";
+    static operationType: OperationType = "read";
+    public description = "A tool that throws an infrastructure error";
+    public argsShape = {};
+
+    protected execute(): Promise<CallToolResult> {
+        return Promise.reject(new UnexpectedError("infrastructure failure"));
     }
 
     protected resolveTelemetryMetadata(): TelemetryToolMetadata {

--- a/tests/unit/toolBase.test.ts
+++ b/tests/unit/toolBase.test.ts
@@ -268,7 +268,7 @@ describe("ToolBase", () => {
             expect(result.isError).toBe(true);
             expect(result.content).toEqual([{ type: "text", text: "The operation was not performed." }]);
 
-            // Declining confirmation is a caller decision, so expected=true.
+            // Declining confirmation is a caller decision, not a thrown error, so error_expected is not recorded.
             const { values } = await mockMetrics.get("toolExecutionDuration").get();
             const count = values.find(
                 (v) =>
@@ -277,7 +277,7 @@ describe("ToolBase", () => {
                     v.labels.status === "error"
             );
             expect(count?.value).toBe(1);
-            expect(count?.labels.expected).toBe("true");
+            expect(count?.labels.error_expected).toBeUndefined();
         });
 
         it("excludes the time the user spent deciding from the duration metric", async () => {
@@ -722,7 +722,6 @@ describe("ToolBase", () => {
                     v.labels.operation_type === "delete"
             );
             expect(count?.value).toBe(1);
-            expect(count?.labels.expected).toBe("true");
 
             const sum = values.find(
                 (v) =>
@@ -735,7 +734,7 @@ describe("ToolBase", () => {
             expect(sum?.value).toBeGreaterThanOrEqual(0);
         });
 
-        it("records toolExecutionDuration with status=error and expected=false when execute() rejects with an unexpected error", async () => {
+        it("records toolExecutionDuration with status=error and error_expected=false when execute() rejects with an unexpected error", async () => {
             const result = await errorCallback({}, {} as never);
 
             expect(result.isError).toBe(true);
@@ -749,10 +748,10 @@ describe("ToolBase", () => {
                     v.labels.status === "error"
             );
             expect(count?.value).toBe(1);
-            expect(count?.labels.expected).toBe("false");
+            expect(count?.labels.error_expected).toBe("false");
         });
 
-        it("records toolExecutionDuration with status=error and expected=true when execute() rejects with a caller-addressable error", async () => {
+        it("records toolExecutionDuration with status=error and error_expected=true when execute() rejects with a caller-addressable error", async () => {
             await callerAddressableCallback({}, {} as never);
 
             const { values } = await mockMetrics.get("toolExecutionDuration").get();
@@ -764,11 +763,11 @@ describe("ToolBase", () => {
                     v.labels.status === "error"
             );
             expect(count?.value).toBe(1);
-            expect(count?.labels.expected).toBe("true");
+            expect(count?.labels.error_expected).toBe("true");
             expect(count?.labels.error_type).toBe("ForbiddenWriteOperation");
         });
 
-        it("records toolExecutionDuration with status=error and expected=false when execute() rejects with an UnexpectedError", async () => {
+        it("records toolExecutionDuration with status=error and error_expected=false when execute() rejects with an UnexpectedError", async () => {
             await unexpectedErrorCallback({}, {} as never);
 
             const { values } = await mockMetrics.get("toolExecutionDuration").get();
@@ -779,7 +778,7 @@ describe("ToolBase", () => {
                     v.labels.status === "error"
             );
             expect(count?.value).toBe(1);
-            expect(count?.labels.expected).toBe("false");
+            expect(count?.labels.error_expected).toBe("false");
             expect(count?.labels.error_type).toBe("UnexpectedError");
         });
     });

--- a/tests/unit/toolBase.test.ts
+++ b/tests/unit/toolBase.test.ts
@@ -21,6 +21,8 @@ import {
     TestToolWithOutputSchema,
     TestToolWithoutStructuredContent,
     ErrorTool,
+    CallerAddressableErrorTool,
+    UnexpectedErrorTool,
     ConfirmingTool,
 } from "./mocks/tools.js";
 import { MockMetrics } from "./mocks/metrics.js";
@@ -265,6 +267,17 @@ describe("ToolBase", () => {
 
             expect(result.isError).toBe(true);
             expect(result.content).toEqual([{ type: "text", text: "The operation was not performed." }]);
+
+            // Declining confirmation is a caller decision, so expected=true.
+            const { values } = await mockMetrics.get("toolExecutionDuration").get();
+            const count = values.find(
+                (v) =>
+                    v.metricName === "mcp_tool_execution_duration_seconds_count" &&
+                    v.labels.tool_name === "confirming-tool" &&
+                    v.labels.status === "error"
+            );
+            expect(count?.value).toBe(1);
+            expect(count?.labels.expected).toBe("true");
         });
 
         it("excludes the time the user spent deciding from the duration metric", async () => {
@@ -637,6 +650,8 @@ describe("ToolBase", () => {
     describe("metrics emission", () => {
         let successCallback: ToolCallback<(typeof testTool)["argsShape"]>;
         let errorCallback: ToolCallback<ZodRawShape>;
+        let callerAddressableCallback: ToolCallback<ZodRawShape>;
+        let unexpectedErrorCallback: ToolCallback<ZodRawShape>;
 
         function makeMockServer(capture: (cb: ToolCallback<ZodRawShape>) => void): Server {
             return {
@@ -667,6 +682,30 @@ describe("ToolBase", () => {
                 metrics: mockMetrics,
             });
             failingTool.register(makeMockServer((cb) => (errorCallback = cb)));
+
+            const callerAddressableTool = new CallerAddressableErrorTool({
+                name: CallerAddressableErrorTool.toolName,
+                category: CallerAddressableErrorTool.category,
+                operationType: CallerAddressableErrorTool.operationType,
+                session: mockSession,
+                config: mockConfig,
+                telemetry: mockTelemetry,
+                elicitation: mockElicitation,
+                metrics: mockMetrics,
+            });
+            callerAddressableTool.register(makeMockServer((cb) => (callerAddressableCallback = cb)));
+
+            const unexpectedErrorTool = new UnexpectedErrorTool({
+                name: UnexpectedErrorTool.toolName,
+                category: UnexpectedErrorTool.category,
+                operationType: UnexpectedErrorTool.operationType,
+                session: mockSession,
+                config: mockConfig,
+                telemetry: mockTelemetry,
+                elicitation: mockElicitation,
+                metrics: mockMetrics,
+            });
+            unexpectedErrorTool.register(makeMockServer((cb) => (unexpectedErrorCallback = cb)));
         });
 
         it("records toolExecutionDuration with status and operation_type on a successful execution", async () => {
@@ -683,6 +722,7 @@ describe("ToolBase", () => {
                     v.labels.operation_type === "delete"
             );
             expect(count?.value).toBe(1);
+            expect(count?.labels.expected).toBe("true");
 
             const sum = values.find(
                 (v) =>
@@ -695,7 +735,7 @@ describe("ToolBase", () => {
             expect(sum?.value).toBeGreaterThanOrEqual(0);
         });
 
-        it("records toolExecutionDuration with status=error when execute() rejects", async () => {
+        it("records toolExecutionDuration with status=error and expected=false when execute() rejects with an unexpected error", async () => {
             const result = await errorCallback({}, {} as never);
 
             expect(result.isError).toBe(true);
@@ -709,6 +749,38 @@ describe("ToolBase", () => {
                     v.labels.status === "error"
             );
             expect(count?.value).toBe(1);
+            expect(count?.labels.expected).toBe("false");
+        });
+
+        it("records toolExecutionDuration with status=error and expected=true when execute() rejects with a caller-addressable error", async () => {
+            await callerAddressableCallback({}, {} as never);
+
+            const { values } = await mockMetrics.get("toolExecutionDuration").get();
+            const count = values.find(
+                (v) =>
+                    v.metricName === "mcp_tool_execution_duration_seconds_count" &&
+                    v.labels.tool_name === "caller-addressable-error-tool" &&
+                    v.labels.category === "mongodb" &&
+                    v.labels.status === "error"
+            );
+            expect(count?.value).toBe(1);
+            expect(count?.labels.expected).toBe("true");
+            expect(count?.labels.error_type).toBe("ForbiddenWriteOperation");
+        });
+
+        it("records toolExecutionDuration with status=error and expected=false when execute() rejects with an UnexpectedError", async () => {
+            await unexpectedErrorCallback({}, {} as never);
+
+            const { values } = await mockMetrics.get("toolExecutionDuration").get();
+            const count = values.find(
+                (v) =>
+                    v.metricName === "mcp_tool_execution_duration_seconds_count" &&
+                    v.labels.tool_name === "unexpected-error-tool" &&
+                    v.labels.status === "error"
+            );
+            expect(count?.value).toBe(1);
+            expect(count?.labels.expected).toBe("false");
+            expect(count?.labels.error_type).toBe("UnexpectedError");
         });
     });
 


### PR DESCRIPTION
Classify tool errors as expected vs unexpected on the existing `mcp_tool_execution_duration_seconds` metric via a new `expected` label (`"true"|"false"`).

- `classifyToolError()` + `ToolErrorKind` in `src/common/classifyToolError.ts`; `UnexpectedError` in `errors.ts` for explicitly marking infrastructure failures
- `ToolBase.recordOutcome` sets `expected` on every observation
- assistant / atlas-local tools throw `UnexpectedError` for infrastructure failures
