### PR TITLE
revert(ci): push third-party notices directly to main instead of opening a PR

### DIFF
--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -29,9 +29,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
-          # This workflow's job is to keep THIRD_PARTY_NOTICES.md on main up to
-          # date. A manual workflow_dispatch can target any branch, so always
-          # operate on main (fetched fresh from origin) rather than the dispatch ref.
           ref: main
 
       - name: Set up Node.js and pnpm

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -73,9 +73,7 @@ jobs:
       - name: Generate SBOM and upload to Kondukto via SilkBomb
         if: always()
         env:
-          # The SBOM is generated from the checkout above, which is always main,
-          # so label it as main even for manual dispatches from other branches.
-          KONDUKTO_BRANCH: "main"
+          KONDUKTO_BRANCH: ${{ github.ref_name }}
           KONDUKTO_TOKEN: ${{ secrets.KONDUKTO_TOKEN }}
 
         run: |

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
+          # This workflow's job is to keep THIRD_PARTY_NOTICES.md on main up to
+          # date. A manual workflow_dispatch can target any branch, so always
+          # operate on main (fetched fresh from origin) rather than the dispatch ref.
+          ref: main
 
       - name: Set up Node.js and pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -55,7 +59,8 @@ jobs:
             echo "No THIRD_PARTY_NOTICES.md changes to commit"
           else
             git commit -m "docs: update third-party notices [skip actions]"
-            git push
+
+            git push origin main
           fi
 
       - name: Configure AWS credentials for DevProd Platforms ECR
@@ -68,7 +73,9 @@ jobs:
       - name: Generate SBOM and upload to Kondukto via SilkBomb
         if: always()
         env:
-          KONDUKTO_BRANCH: ${{ github.ref_name }}
+          # The SBOM is generated from the checkout above, which is always main,
+          # so label it as main even for manual dispatches from other branches.
+          KONDUKTO_BRANCH: "main"
           KONDUKTO_TOKEN: ${{ secrets.KONDUKTO_TOKEN }}
 
         run: |

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -40,7 +40,7 @@ jobs:
         if: always()
         run: pnpm run update-third-party-notices
 
-      - name: Commit and open a PR with updated third-party notices
+      - name: Commit and push updated third-party notices
         if: always()
         env:
           # Skip pre-commit hooks, since this is a bot commit.
@@ -49,27 +49,14 @@ jobs:
           GIT_AUTHOR_EMAIL: "${{ steps.app-token.outputs.app-email }}"
           GIT_COMMITTER_NAME: "${{ steps.app-token.outputs.app-slug}}[bot]"
           GIT_COMMITTER_EMAIL: "${{ steps.app-token.outputs.app-email }}"
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git add THIRD_PARTY_NOTICES.md
           if git diff --cached --quiet; then
             echo "No THIRD_PARTY_NOTICES.md changes to commit"
-            exit 0
+          else
+            git commit -m "docs: update third-party notices [skip actions]"
+            git push
           fi
-
-          git config user.name "$GIT_AUTHOR_NAME"
-          git config user.email "$GIT_AUTHOR_EMAIL"
-          git commit -m "docs: update third-party notices [skip actions]"
-
-          BRANCH="bot/update-third-party-notices/${{ github.run_id }}-${{ github.run_attempt }}"
-          git checkout -b "$BRANCH"
-          git push -u origin "$BRANCH"
-
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "docs: update third-party notices" \
-            --body $'Automated update of THIRD_PARTY_NOTICES.md by the Dependency Health workflow.\n\n[skip actions]'
 
       - name: Configure AWS credentials for DevProd Platforms ECR
         if: always()

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -14,6 +14,9 @@ jobs:
   generate:
     name: Scan dependencies and update notices
     runs-on: ubuntu-latest
+    # This workflow maintains THIRD_PARTY_NOTICES.md on main: never run it
+    # against any other branch, even for manual workflow_dispatch runs.
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: mongodb-js/devtools-shared/actions/setup-bot-token@04e390e1e6157b3edbc120f3d9359d3fb47ab839 # main
         id: app-token


### PR DESCRIPTION
Revert of #1411. The Dependency Health workflow now again commits `THIRD_PARTY_NOTICES.md` updates and pushes directly to `main`, matching the original setup. Branch protection will be relaxed for the bot.

Bot exception was added to the repo for this to work.