### PR TITLE
ci: fix accuracy and braintrust tests

### DIFF
--- a/.github/workflows/braintrust-evals.yml
+++ b/.github/workflows/braintrust-evals.yml
@@ -39,6 +39,8 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build
       - name: Push eval to Braintrust
         if: github.ref == 'refs/heads/main'
         run: pnpm run eval:push

--- a/packages/accuracy-tests/runAccuracyTests.sh
+++ b/packages/accuracy-tests/runAccuracyTests.sh
@@ -24,9 +24,6 @@ export MDB_MCP_API_CLIENT_SECRET=${MDB_MCP_API_CLIENT_SECRET:-"test-atlas-client
 # specified in the command line. Such as:
 # pnpm run test:accuracy -- packages/accuracy-tests/some-test.test.ts
 
-# vitest.config.ts lives at the repository root and its accuracy project's
-# include/setupFiles paths are resolved against the repository root, so run
-# vitest from there (the pre-monorepo script did the same).
 PROJECT_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$PROJECT_ROOT"
 

--- a/packages/accuracy-tests/runAccuracyTests.sh
+++ b/packages/accuracy-tests/runAccuracyTests.sh
@@ -23,6 +23,13 @@ export MDB_MCP_API_CLIENT_SECRET=${MDB_MCP_API_CLIENT_SECRET:-"test-atlas-client
 # By default we run all the tests in this package unless a path is
 # specified in the command line. Such as:
 # pnpm run test:accuracy -- packages/accuracy-tests/some-test.test.ts
+
+# vitest.config.ts lives at the repository root and its accuracy project's
+# include/setupFiles paths are resolved against the repository root, so run
+# vitest from there (the pre-monorepo script did the same).
+PROJECT_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
 echo "Running accuracy tests with MDB_ACCURACY_RUN_ID '$MDB_ACCURACY_RUN_ID'"
 vitest --config vitest.config.ts --project=accuracy --coverage=false --max-workers=2 --run "$@"
 

--- a/packages/accuracy-tests/src/sdk/constants.ts
+++ b/packages/accuracy-tests/src/sdk/constants.ts
@@ -7,8 +7,6 @@ export const ROOT_DIR = path.join(__dirname, "..", "..", "..", "..");
 
 export const DIST_DIR = path.join(ROOT_DIR, "dist");
 
-// The accuracy test summary template was moved into the CLI package during the
-// v3 monorepo restructure; root-level resources/ no longer exists.
 export const RESOURCES_DIR = path.join(ROOT_DIR, "packages", "cli", "resources");
 
 export const MCP_SERVER_CLI_SCRIPT = path.join(DIST_DIR, "index.js");

--- a/packages/accuracy-tests/src/sdk/constants.ts
+++ b/packages/accuracy-tests/src/sdk/constants.ts
@@ -1,13 +1,15 @@
 import path from "path";
 import { fileURLToPath } from "url";
 
-const __dirname = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ROOT_DIR = path.join(__dirname, "..", "..", "..", "..");
 
 export const DIST_DIR = path.join(ROOT_DIR, "dist");
 
-export const RESOURCES_DIR = path.join(ROOT_DIR, "resources");
+// The accuracy test summary template was moved into the CLI package during the
+// v3 monorepo restructure; root-level resources/ no longer exists.
+export const RESOURCES_DIR = path.join(ROOT_DIR, "packages", "cli", "resources");
 
 export const MCP_SERVER_CLI_SCRIPT = path.join(DIST_DIR, "index.js");
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -63,8 +63,7 @@ export default defineConfig({
                 extends: true,
                 test: {
                     name: "accuracy",
-                    root: "./packages/accuracy-tests",
-                    include: ["src/**/*.test.ts"],
+                    include: ["packages/accuracy-tests/src/**/*.test.ts"],
                 },
             },
             {


### PR DESCRIPTION
Fixes eval:push failing in CI: workspace packages (mcp-core, mcp-cli, mongodb-mcp-server) weren't built before bundling. Adds a `pnpm run build` step to braintrust-evals.yml, matching check.yml/mcpb.yml.