### PR TITLE
ci: build before atlas cleanup - CLOUDP-438227

### DIFF
--- a/.github/workflows/cleanup-atlas-env.yml
+++ b/.github/workflows/cleanup-atlas-env.yml
@@ -22,6 +22,8 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build
       - name: Run cleanup script
         env:
           MDB_MCP_API_CLIENT_ID: ${{ secrets.TEST_ATLAS_CLIENT_ID }}


### PR DESCRIPTION
## Summary
* Add a build step before the scheduled Atlas cleanup workflow runs `pnpm run atlas:cleanup`.
* The cleanup Vitest file imports workspace packages whose package exports point at `dist`; a clean checkout needs those packages built first.

## Failure
The cleanup job failed before running tests:

```
Error: Failed to resolve entry for package "@mongodb-js/mcp-atlas-api-client"
```

Job: https://github.com/mongodb-js/mongodb-mcp-server/actions/runs/32656855387/job/97236818321

## Testing
* `pnpm prettier --check ".github/workflows/cleanup-atlas-env.yml"`
* `pnpm run build`
* `pnpm --filter @mongodb-js/mcp-scripts exec node --input-type=module -e "await import('@mongodb-js/mcp-atlas-api-client'); await import('@mongodb-js/mcp-core'); await import('@mongodb-js/mcp-logging'); console.log('cleanup imports resolved')"`

I did not run `pnpm run atlas:cleanup` locally because it targets live Atlas test resources.