### PR TITLE
fix: propagate connection error from db tools MCP-627

### DIFF
--- a/packages/integration-tests/src/tools/mongodb/connect/connect.test.ts
+++ b/packages/integration-tests/src/tools/mongodb/connect/connect.test.ts
@@ -180,7 +180,7 @@ describeWithMongoDB("Connect tool", (integration) => {
                 arguments: { connectionString: "mangodb://localhost:12345" },
             });
             const content = getResponseContent(response.content);
-            expect(content).toContain("The configured connection string is not valid.");
+            expect(content).toContain("Could not connect to MongoDB.");
             expect(response.structuredContent).toBeUndefined();
         });
     });

--- a/packages/integration-tests/src/tools/mongodb/mongodbTool.test.ts
+++ b/packages/integration-tests/src/tools/mongodb/mongodbTool.test.ts
@@ -255,9 +255,12 @@ describe("MongoDBTool implementations", () => {
                 });
                 expect(toolResponse?.isError).to.equal(true);
                 const content = toolResponse?.content as CallToolResult["content"];
-                expect(
-                    content.some((c) => c.type === "text" && c.text.startsWith("Could not connect to MongoDB."))
-                ).toBe(true);
+                const message = content.find(
+                    (c) => c.type === "text" && c.text.startsWith("Could not connect to MongoDB.")
+                );
+                expect(message?.type).toBe("text");
+                const messageText = message?.type === "text" ? message.text : "";
+                expect(messageText).toMatch(/^Could not connect to MongoDB\. Last error: .+/);
             });
         });
 

--- a/packages/integration-tests/src/tools/mongodb/mongodbTool.test.ts
+++ b/packages/integration-tests/src/tools/mongodb/mongodbTool.test.ts
@@ -254,14 +254,10 @@ describe("MongoDBTool implementations", () => {
                     arguments: { connectionId: "preconfigured" },
                 });
                 expect(toolResponse?.isError).to.equal(true);
-                expect(toolResponse?.content).toEqual(
-                    expect.arrayContaining([
-                        {
-                            type: "text",
-                            text: "The configured connection string is not valid. Please check the connection string and confirm it points to a valid MongoDB instance.",
-                        },
-                    ])
-                );
+                const content = toolResponse?.content as CallToolResult["content"];
+                expect(
+                    content.some((c) => c.type === "text" && c.text.startsWith("Could not connect to MongoDB."))
+                ).toBe(true);
             });
         });
 

--- a/packages/tools-mongodb/package.json
+++ b/packages/tools-mongodb/package.json
@@ -35,6 +35,7 @@
     "mongodb": "^7.1.1",
     "mongodb-build-info": "^1.9.7",
     "mongodb-connection-string-url": "^7.0.1",
+    "mongodb-redact": "^1.1.6",
     "mongodb-schema": "^12.7.0",
     "node-machine-id": "1.1.12",
     "zod": "^4.4.2"

--- a/packages/tools-mongodb/src/common/connectionRegistry.test.ts
+++ b/packages/tools-mongodb/src/common/connectionRegistry.test.ts
@@ -158,6 +158,7 @@ describe("ConnectionRegistry", () => {
             (managers[0] as FakeConnectionManager).failNextConnect = new Error("bad string");
             const error = await registry.resolve(PRECONFIGURED_CONNECTION_ID).catch((e: unknown) => e);
             expect((error as MongoDBError).code).toBe(ErrorCodes.MisconfiguredConnectionString);
+            expect((error as MongoDBError).message).toBe("bad string");
             expect((await registry.peek(PRECONFIGURED_CONNECTION_ID))?.lastError).toBe("bad string");
         });
     });

--- a/packages/tools-mongodb/src/common/connectionStore.ts
+++ b/packages/tools-mongodb/src/common/connectionStore.ts
@@ -299,7 +299,7 @@ export class MCPConnectionStore {
             });
             throw new MongoDBError(
                 ErrorCodes.MisconfiguredConnectionString,
-                "The configured connection string is not valid or the server is unreachable."
+                entry.lastError ?? "The configured connection string is not valid or the server is unreachable."
             );
         }
     }

--- a/packages/tools-mongodb/src/common/connectionStore.ts
+++ b/packages/tools-mongodb/src/common/connectionStore.ts
@@ -297,10 +297,8 @@ export class MCPConnectionStore {
                 context: "connectionRegistry",
                 message: `Failed to connect using the configured connection string: ${error as string}`,
             });
-            throw new MongoDBError(
-                ErrorCodes.MisconfiguredConnectionString,
-                entry.lastError ?? "The configured connection string is not valid or the server is unreachable."
-            );
+            const fallbackMessage = error instanceof Error ? error.message : String(error);
+            throw new MongoDBError(ErrorCodes.MisconfiguredConnectionString, entry.lastError ?? fallbackMessage);
         }
     }
 

--- a/packages/tools-mongodb/src/connectionErrorHandler.ts
+++ b/packages/tools-mongodb/src/connectionErrorHandler.ts
@@ -118,7 +118,7 @@ export const connectionErrorHandler: ConnectionErrorHandler = (error, { availabl
                     content: [
                         {
                             type: "text",
-                            text: "The configured connection string is not valid. Please check the connection string and confirm it points to a valid MongoDB instance.",
+                            text: `Could not connect to MongoDB. Last error: ${error.message}`,
                         },
                         {
                             type: "text",

--- a/packages/tools-mongodb/src/mongodbTool.ts
+++ b/packages/tools-mongodb/src/mongodbTool.ts
@@ -12,6 +12,7 @@ import type {
 } from "@mongodb-js/mcp-types";
 import type { ConnectionMetadata } from "@mongodb-js/mcp-atlas-telemetry";
 import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import { redact } from "mongodb-redact";
 import { ErrorCodes, MongoDBError } from "./common/errors.js";
 import type { ConnectionEntry, ConnectionRegistry } from "./common/connectionRegistry.js";
 import { assertNoServerSideJS, isWriteStage, type WriteStageTarget } from "./helpers/mqlGuards.js";
@@ -239,11 +240,18 @@ export abstract class MongoDBToolBase extends ToolBase<IMongoDBSession> {
                 case ErrorCodes.NotConnectedToMongoDB:
                 case ErrorCodes.MisconfiguredConnectionString:
                 case ErrorCodes.UnknownConnectionId: {
-                    const connectionError = error as MongoDBError<
+                    const rawConnectionError = error as MongoDBError<
                         | typeof ErrorCodes.NotConnectedToMongoDB
                         | typeof ErrorCodes.MisconfiguredConnectionString
                         | typeof ErrorCodes.UnknownConnectionId
                     >;
+                    // The message may embed a driver error verbatim (e.g. MisconfiguredConnectionString),
+                    // which can contain secrets from the connection string; redact before it is
+                    // interpolated into any handler's (default or injected) output.
+                    const connectionError = new MongoDBError(
+                        rawConnectionError.code,
+                        redact(rawConnectionError.message, this.session.keychain.allSecrets)
+                    ) as typeof rawConnectionError;
                     const outcome = await this.session.connectionErrorHandler(connectionError, {
                         availableTools: this.server?.tools ?? [],
                         connectionState: (await this.peekConnection(args.connectionId as string | undefined))?.state,

--- a/packages/tools-mongodb/src/mongodbTool.ts
+++ b/packages/tools-mongodb/src/mongodbTool.ts
@@ -251,7 +251,7 @@ export abstract class MongoDBToolBase extends ToolBase<IMongoDBSession> {
                     const connectionError = new MongoDBError(
                         rawConnectionError.code,
                         redact(rawConnectionError.message, this.session.keychain.allSecrets)
-                    ) as typeof rawConnectionError;
+                    );
                     const outcome = await this.session.connectionErrorHandler(connectionError, {
                         availableTools: this.server?.tools ?? [],
                         connectionState: (await this.peekConnection(args.connectionId as string | undefined))?.state,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1036,6 +1036,9 @@ importers:
       mongodb-connection-string-url:
         specifier: ^7.0.1
         version: 7.0.1
+      mongodb-redact:
+        specifier: ^1.1.6
+        version: 1.4.7
       mongodb-schema:
         specifier: ^12.7.0
         version: 12.7.0(@aws-sdk/credential-providers@3.1003.0)(gcp-metadata@7.0.1)(kerberos@7.0.0)(mongodb-client-encryption@7.0.0)(socks@2.8.9)


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/mongodb-js/mongodb-mcp-server/issues/1448
