### PR TITLE
fix(atlas): report the full total count in atlas-list-orgs and atlas-list-projects

### DIFF
--- a/packages/tools-atlas/src/tools/read/listOrgs.test.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.test.ts
@@ -64,19 +64,20 @@ describe("ListOrganizationsTool", () => {
                 { name: "Org A", id: "org-a" },
                 { name: "Org B", id: "org-b" },
             ],
+            totalCount: 2,
         });
 
         const result = await exec();
 
         const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-        expect(text).toContain("Found 2 organizations in your MongoDB Atlas account.");
+        expect(text).toContain("Found 2 of 2 organizations in your MongoDB Atlas account.");
         expect(text).toContain("Org A");
         expect(text).toContain("Org B");
         expect(text).toContain("<untrusted-user-data-");
     });
 
     it("returns empty message when no organizations found", async () => {
-        mockApiClient.listOrgs!.mockResolvedValue({ results: [] });
+        mockApiClient.listOrgs!.mockResolvedValue({ results: [], totalCount: 0 });
 
         const result = await exec();
 
@@ -85,19 +86,19 @@ describe("ListOrganizationsTool", () => {
         );
     });
 
-    it("calls listOrgs API", async () => {
-        mockApiClient.listOrgs!.mockResolvedValue({ results: [] });
+    it("calls listOrgs API with includeCount", async () => {
+        mockApiClient.listOrgs!.mockResolvedValue({ results: [], totalCount: 0 });
 
         await exec();
 
         expect(mockApiClient.listOrgs).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 10, pageNum: 1 } } },
+            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: true } } },
             expect.anything()
         );
     });
 
     it("defaults limit/pageNum to 10/1 when the caller passes no args, same as the real MCP client path", async () => {
-        mockApiClient.listOrgs!.mockResolvedValue({ results: [] });
+        mockApiClient.listOrgs!.mockResolvedValue({ results: [], totalCount: 0 });
 
         // The real invocation path parses incoming args against argsShape (applying zod
         // defaults) before execute() ever runs; exec() here calls execute() directly, so
@@ -106,24 +107,24 @@ describe("ListOrganizationsTool", () => {
         await exec(parsedArgs);
 
         expect(mockApiClient.listOrgs).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 10, pageNum: 1 } } },
+            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: true } } },
             expect.anything()
         );
     });
 
     it("passes limit and pageNum to the API", async () => {
-        mockApiClient.listOrgs!.mockResolvedValue({ results: [] });
+        mockApiClient.listOrgs!.mockResolvedValue({ results: [], totalCount: 0 });
 
         await exec({ limit: 10, pageNum: 3 });
 
         expect(mockApiClient.listOrgs).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 10, pageNum: 3 } } },
+            { params: { query: { itemsPerPage: 10, pageNum: 3, includeCount: true } } },
             expect.anything()
         );
     });
 
     it("handles null results gracefully", async () => {
-        mockApiClient.listOrgs!.mockResolvedValue({ results: null });
+        mockApiClient.listOrgs!.mockResolvedValue({ results: null, totalCount: 0 });
 
         const result = await exec();
 
@@ -133,15 +134,79 @@ describe("ListOrganizationsTool", () => {
     });
 
     describe("structuredContent", () => {
-        it("returns totalCount as the number of organizations actually returned, ignoring any API-reported total", async () => {
+        it("returns the API-reported total count so callers know more pages may exist", async () => {
             mockApiClient.listOrgs!.mockResolvedValue({
                 results: [
                     { name: "Org A", id: "org-a" },
                     { name: "Org B", id: "org-b" },
                 ],
-                // Atlas-wide total across all pages, distinct from what this call returned -
-                // must not leak into totalCount below.
-                totalCount: 999,
+                // Total across all pages, distinct from what this page returned.
+                totalCount: 13,
+            });
+
+            const result = await exec();
+
+            expect(result.structuredContent).toEqual({
+                organizations: [
+                    { name: "Org A", id: "org-a" },
+                    { name: "Org B", id: "org-b" },
+                ],
+                totalCount: 13,
+            });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Use pagination if more results are needed.");
+        });
+
+        it("does not suggest pagination when all organizations are returned", async () => {
+            mockApiClient.listOrgs!.mockResolvedValue({
+                results: [
+                    { name: "Org A", id: "org-a" },
+                    { name: "Org B", id: "org-b" },
+                ],
+                totalCount: 2,
+            });
+
+            const result = await exec();
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Found 2 of 2 organizations in your MongoDB Atlas account.");
+            expect(text).not.toContain("pagination");
+        });
+
+        it("does not suggest pagination on the last page", async () => {
+            mockApiClient.listOrgs!.mockResolvedValue({
+                results: [{ name: "Org A", id: "org-a" }],
+                totalCount: 11,
+            });
+
+            // Page 2 of 2: page 1 returned 10 of 11, this page returns the remaining 1.
+            const result = await exec({ limit: 10, pageNum: 2 });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Found 1 of 11 organizations in your MongoDB Atlas account.");
+            expect(text).not.toContain("pagination");
+        });
+
+        it("suggests pagination on a middle page", async () => {
+            mockApiClient.listOrgs!.mockResolvedValue({
+                results: [{ name: "Org A", id: "org-a" }],
+                totalCount: 25,
+            });
+
+            // Page 2 of 3: pages 1-2 returned 20 of 25, page 3 still has more.
+            const result = await exec({ limit: 10, pageNum: 2 });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Use pagination if more results are needed.");
+        });
+
+        it("falls back to the number of organizations returned when totalCount is missing", async () => {
+            mockApiClient.listOrgs!.mockResolvedValue({
+                results: [
+                    { name: "Org A", id: "org-a" },
+                    { name: "Org B", id: "org-b" },
+                ],
             });
 
             const result = await exec();
@@ -156,7 +221,7 @@ describe("ListOrganizationsTool", () => {
         });
 
         it("returns totalCount 0 when no organizations are found", async () => {
-            mockApiClient.listOrgs!.mockResolvedValue({ results: [] });
+            mockApiClient.listOrgs!.mockResolvedValue({ results: [], totalCount: 0 });
 
             const result = await exec();
 

--- a/packages/tools-atlas/src/tools/read/listOrgs.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.ts
@@ -37,13 +37,21 @@ export class ListOrganizationsTool extends AtlasToolBase {
                     query: {
                         itemsPerPage: limit,
                         pageNum,
+                        includeCount: true,
                     },
                 },
             },
             context
         );
 
-        if (!data?.results?.length) {
+        const orgs = (data?.results ?? []).map((org) => ({
+            name: org.name,
+            id: org.id,
+        }));
+        const totalCount = data?.totalCount ?? orgs.length;
+        const moreResultsAvailable = (pageNum - 1) * limit + orgs.length < totalCount;
+
+        if (!orgs.length) {
             return {
                 content: [{ type: "text", text: "No organizations found in your MongoDB Atlas account." }],
                 structuredContent: {
@@ -53,19 +61,16 @@ export class ListOrganizationsTool extends AtlasToolBase {
             };
         }
 
-        const orgs = data.results.map((org) => ({
-            name: org.name,
-            id: org.id,
-        }));
-
         return {
             content: formatUntrustedData(
-                `Found ${orgs.length} organizations in your MongoDB Atlas account.`,
+                `Found ${orgs.length} of ${totalCount} organizations in your MongoDB Atlas account.${
+                    moreResultsAvailable ? " Use pagination if more results are needed." : ""
+                }`,
                 JSON.stringify(orgs)
             ),
             structuredContent: {
                 organizations: orgs,
-                totalCount: orgs.length,
+                totalCount,
             },
         };
     }

--- a/packages/tools-atlas/src/tools/read/listProjects.test.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.test.ts
@@ -78,32 +78,32 @@ describe("ListProjectsTool", () => {
         });
 
     it("returns projects when orgId filter is provided", async () => {
-        mockApiClient.getOrgGroups!.mockResolvedValue({ results: [projectApiResponse] });
+        mockApiClient.getOrgGroups!.mockResolvedValue({ results: [projectApiResponse], totalCount: 1 });
 
         const result = await exec({ orgId });
 
         const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-        expect(text).toContain("Found 1 projects");
+        expect(text).toContain("Found 1 of 1 projects.");
         expect(text).toContain("my-project");
         expect(text).toContain("<untrusted-user-data-");
     });
 
     it("returns projects for all orgs when orgId is omitted", async () => {
-        mockApiClient.listGroups!.mockResolvedValue({ results: [projectApiResponse] });
+        mockApiClient.listGroups!.mockResolvedValue({ results: [projectApiResponse], totalCount: 1 });
 
         const result = await exec();
 
         const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-        expect(text).toContain("Found 1 projects");
+        expect(text).toContain("Found 1 of 1 projects.");
         expect(mockApiClient.getOrgGroups).not.toHaveBeenCalled();
         expect(mockApiClient.listGroups).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 10, pageNum: 1 } } },
+            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: true } } },
             expect.anything()
         );
     });
 
     it("calls getOrgGroups when orgId is provided", async () => {
-        mockApiClient.getOrgGroups!.mockResolvedValue({ results: [] });
+        mockApiClient.getOrgGroups!.mockResolvedValue({ results: [], totalCount: 0 });
 
         await exec({ orgId });
 
@@ -111,7 +111,7 @@ describe("ListProjectsTool", () => {
             {
                 params: {
                     path: { orgId },
-                    query: { itemsPerPage: 10, pageNum: 1 },
+                    query: { itemsPerPage: 10, pageNum: 1, includeCount: true },
                 },
             },
             expect.anything()
@@ -119,7 +119,7 @@ describe("ListProjectsTool", () => {
     });
 
     it("defaults limit/pageNum to 10/1 when the caller passes no args, same as the real MCP client path", async () => {
-        mockApiClient.listGroups!.mockResolvedValue({ results: [] });
+        mockApiClient.listGroups!.mockResolvedValue({ results: [], totalCount: 0 });
 
         // The real invocation path parses incoming args against argsShape (applying zod
         // defaults) before execute() ever runs; exec() here calls execute() directly, so
@@ -128,13 +128,13 @@ describe("ListProjectsTool", () => {
         await exec(parsedArgs);
 
         expect(mockApiClient.listGroups).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 10, pageNum: 1 } } },
+            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: true } } },
             expect.anything()
         );
     });
 
     it("passes limit and pageNum to getOrgGroups", async () => {
-        mockApiClient.getOrgGroups!.mockResolvedValue({ results: [] });
+        mockApiClient.getOrgGroups!.mockResolvedValue({ results: [], totalCount: 0 });
 
         await exec({ orgId, limit: 25, pageNum: 2 });
 
@@ -142,7 +142,7 @@ describe("ListProjectsTool", () => {
             {
                 params: {
                     path: { orgId },
-                    query: { itemsPerPage: 25, pageNum: 2 },
+                    query: { itemsPerPage: 25, pageNum: 2, includeCount: true },
                 },
             },
             expect.anything()
@@ -150,27 +150,36 @@ describe("ListProjectsTool", () => {
     });
 
     it("passes limit and pageNum to listGroups", async () => {
-        mockApiClient.listGroups!.mockResolvedValue({ results: [] });
+        mockApiClient.listGroups!.mockResolvedValue({ results: [], totalCount: 0 });
 
         await exec({ limit: 25, pageNum: 2 });
 
         expect(mockApiClient.listGroups).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 25, pageNum: 2 } } },
+            { params: { query: { itemsPerPage: 25, pageNum: 2, includeCount: true } } },
             expect.anything()
         );
     });
 
     it("returns empty message when org has no projects", async () => {
-        mockApiClient.getOrgGroups!.mockResolvedValue({ results: [] });
+        mockApiClient.getOrgGroups!.mockResolvedValue({ results: [], totalCount: 0 });
 
         const result = await exec({ orgId });
 
         expect((result.content[0] as { text: string }).text).toBe(`No projects found in organization ${orgId}.`);
     });
 
+    it("returns empty message without orgId when listing projects for all orgs", async () => {
+        mockApiClient.listGroups!.mockResolvedValue({ results: [], totalCount: 0 });
+
+        const result = await exec();
+
+        expect((result.content[0] as { text: string }).text).toBe("No projects found in your MongoDB Atlas account.");
+    });
+
     it("uses N/A for created when project has no created date", async () => {
         mockApiClient.getOrgGroups!.mockResolvedValue({
             results: [{ ...projectApiResponse, created: undefined }],
+            totalCount: 1,
         });
 
         const result = await exec({ orgId });
@@ -179,19 +188,59 @@ describe("ListProjectsTool", () => {
     });
 
     describe("structuredContent", () => {
-        it("returns totalCount as the number of projects actually returned with orgId filter", async () => {
-            mockApiClient.getOrgGroups!.mockResolvedValue({ results: [projectApiResponse] });
+        it("reports the API total count so callers know more pages may exist", async () => {
+            mockApiClient.getOrgGroups!.mockResolvedValue({ results: [projectApiResponse], totalCount: 13 });
 
             const result = await exec({ orgId });
 
             expect(result.structuredContent).toEqual({
                 orgId,
                 projects: [formattedProject],
-                totalCount: 1,
+                totalCount: 13,
             });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Use pagination if more results are needed.");
         });
 
-        it("returns totalCount as the number of projects actually returned when unfiltered", async () => {
+        it("does not suggest pagination when all projects are returned", async () => {
+            mockApiClient.getOrgGroups!.mockResolvedValue({ results: [projectApiResponse], totalCount: 1 });
+
+            const result = await exec({ orgId });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Found 1 of 1 projects.");
+            expect(text).not.toContain("pagination");
+        });
+
+        it("does not suggest pagination on the last page", async () => {
+            mockApiClient.getOrgGroups!.mockResolvedValue({
+                results: [projectApiResponse],
+                totalCount: 11,
+            });
+
+            // Page 2 of 2: page 1 returned 10 of 11, this page returns the remaining 1.
+            const result = await exec({ orgId, limit: 10, pageNum: 2 });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Found 1 of 11 projects.");
+            expect(text).not.toContain("pagination");
+        });
+
+        it("suggests pagination on a middle page", async () => {
+            mockApiClient.getOrgGroups!.mockResolvedValue({
+                results: [projectApiResponse],
+                totalCount: 25,
+            });
+
+            // Page 2 of 3: pages 1-2 returned 20 of 25, page 3 still has more.
+            const result = await exec({ orgId, limit: 10, pageNum: 2 });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Use pagination if more results are needed.");
+        });
+
+        it("falls back to the number of projects returned when totalCount is missing", async () => {
             mockApiClient.listGroups!.mockResolvedValue({ results: [projectApiResponse] });
 
             const result = await exec();
@@ -204,7 +253,7 @@ describe("ListProjectsTool", () => {
         });
 
         it("returns empty projects when org has no projects", async () => {
-            mockApiClient.getOrgGroups!.mockResolvedValue({ results: [] });
+            mockApiClient.getOrgGroups!.mockResolvedValue({ results: [], totalCount: 0 });
 
             const result = await exec({ orgId });
 

--- a/packages/tools-atlas/src/tools/read/listProjects.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.ts
@@ -50,6 +50,7 @@ export class ListProjectsTool extends AtlasToolBase {
                           query: {
                               itemsPerPage: limit,
                               pageNum,
+                              includeCount: true,
                           },
                       },
                   },
@@ -61,15 +62,33 @@ export class ListProjectsTool extends AtlasToolBase {
                           query: {
                               itemsPerPage: limit,
                               pageNum,
+                              includeCount: true,
                           },
                       },
                   },
                   context
               );
 
-        if (!data?.results?.length) {
+        const projects = (data?.results ?? []).map((project) => ({
+            name: project.name,
+            id: project.id,
+            orgId: project.orgId,
+            created: project.created ? new Date(project.created).toLocaleString() : "N/A",
+        }));
+        const totalCount = data?.totalCount ?? projects.length;
+        const moreResultsAvailable = (pageNum - 1) * limit + projects.length < totalCount;
+
+        if (!projects.length) {
             return {
-                content: [{ type: "text", text: `No projects found in organization ${orgId}.` }],
+                content: [
+                    {
+                        type: "text",
+                        text:
+                            orgId !== undefined
+                                ? `No projects found in organization ${orgId}.`
+                                : "No projects found in your MongoDB Atlas account.",
+                    },
+                ],
                 structuredContent: {
                     ...(orgId !== undefined && { orgId }),
                     projects: [],
@@ -78,19 +97,17 @@ export class ListProjectsTool extends AtlasToolBase {
             };
         }
 
-        const projects = data.results.map((project) => ({
-            name: project.name,
-            id: project.id,
-            orgId: project.orgId,
-            created: project.created ? new Date(project.created).toLocaleString() : "N/A",
-        }));
-
         return {
-            content: formatUntrustedData(`Found ${projects.length} projects`, JSON.stringify(projects, null, 2)),
+            content: formatUntrustedData(
+                `Found ${projects.length} of ${totalCount} projects.${
+                    moreResultsAvailable ? " Use pagination if more results are needed." : ""
+                }`,
+                JSON.stringify(projects, null, 2)
+            ),
             structuredContent: {
                 ...(orgId !== undefined && { orgId }),
                 projects,
-                totalCount: projects.length,
+                totalCount,
             },
         };
     }


### PR DESCRIPTION
Pagination in `atlas-list-orgs` and `atlas-list-projects` passes `limit`/`pageNum` to the Atlas API correctly, but the output only reports the number of items on the current page. A caller with 13 projects gets page 1 (10 results) and sees `totalCount: 10` with no way to know 3 more exist.

This requests `includeCount: true` from the Atlas API and reports the real total across all pages, so callers can see `Found 10 of 13 projects.` and continue paging if needed.

- Add `includeCount: true` and surface the API's `totalCount` in text + structuredContent
- Keep the `limit`/`pageNum` args unchanged
- Update unit tests