### PR TITLE
fix(atlas): stop including counts in response, pagination hint on full page

### DIFF
--- a/packages/tools-atlas/src/tools/read/listAlerts.test.ts
+++ b/packages/tools-atlas/src/tools/read/listAlerts.test.ts
@@ -200,6 +200,41 @@ describe("ListAlertsTool", () => {
         expect(text).not.toContain("false");
     });
 
+    it("should suggest pagination when a full page of alerts is returned", async () => {
+        const alerts = Array.from({ length: 10 }, (_, i) => ({
+            id: `alert-${i}`,
+            status: "OPEN",
+            created: "2025-01-01T00:00:00Z",
+            updated: "2025-01-02T00:00:00Z",
+            eventTypeName: "HOST_DOWN",
+        }));
+        mockApiClient.listAlerts!.mockResolvedValue({ results: alerts });
+
+        const result = await exec({ ...baseArgs, limit: 10 });
+
+        const text = (result.content[0] as { text: string }).text;
+        expect(text).toContain("Use pagination if more results are needed.");
+    });
+
+    it("should not suggest pagination when fewer than the limit alerts are returned", async () => {
+        mockApiClient.listAlerts!.mockResolvedValue({
+            results: [
+                {
+                    id: "alert1",
+                    status: "OPEN",
+                    created: "2025-01-01T00:00:00Z",
+                    updated: "2025-01-02T00:00:00Z",
+                    eventTypeName: "HOST_DOWN",
+                },
+            ],
+        });
+
+        const result = await exec({ ...baseArgs, limit: 10 });
+
+        const text = (result.content[0] as { text: string }).text;
+        expect(text).not.toContain("pagination");
+    });
+
     it("should format alert fields correctly", async () => {
         mockApiClient.listAlerts!.mockResolvedValue({
             results: [

--- a/packages/tools-atlas/src/tools/read/listAlerts.test.ts
+++ b/packages/tools-atlas/src/tools/read/listAlerts.test.ts
@@ -213,7 +213,7 @@ describe("ListAlertsTool", () => {
         const result = await exec({ ...baseArgs, limit: 10 });
 
         const text = (result.content[0] as { text: string }).text;
-        expect(text).toContain("Use pagination if more results are needed.");
+        expect(text).toContain("Use pagination arguments if more results are expected.");
     });
 
     it("should not suggest pagination when fewer than the limit alerts are returned", async () => {

--- a/packages/tools-atlas/src/tools/read/listAlerts.ts
+++ b/packages/tools-atlas/src/tools/read/listAlerts.ts
@@ -92,10 +92,12 @@ export class ListAlertsTool extends AtlasToolBase {
             acknowledgementComment: alert.acknowledgementComment ?? "N/A",
         }));
         const totalText = data.totalCount !== undefined ? ` (total: ${data.totalCount})` : "";
+        // A full page means more results may exist on later pages.
+        const paginationText = alerts.length === limit ? ". Use pagination if more results are needed." : "";
 
         return {
             content: formatUntrustedData(
-                `Found ${alerts.length} alerts with status "${status}" in project ${projectId}${totalText}`,
+                `Found ${alerts.length} alerts with status "${status}" in project ${projectId}${totalText}${paginationText}`,
                 JSON.stringify(alerts)
             ),
             structuredContent: {

--- a/packages/tools-atlas/src/tools/read/listAlerts.ts
+++ b/packages/tools-atlas/src/tools/read/listAlerts.ts
@@ -93,7 +93,8 @@ export class ListAlertsTool extends AtlasToolBase {
         }));
         const totalText = data.totalCount !== undefined ? ` (total: ${data.totalCount})` : "";
         // A full page means more results may exist on later pages.
-        const paginationText = alerts.length === limit ? ". Use pagination if more results are needed." : "";
+        const paginationText =
+            alerts.length === limit ? ". Use pagination arguments if more results are expected." : "";
 
         return {
             content: formatUntrustedData(

--- a/packages/tools-atlas/src/tools/read/listOrgs.test.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.test.ts
@@ -55,8 +55,13 @@ describe("ListOrganizationsTool", () => {
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-    const exec = (args: Record<string, unknown> = { limit: 10, pageNum: 1 }) =>
-        tool["execute"](args as never, { signal: new AbortController().signal });
+    const exec = (args: Record<string, unknown> = {}) =>
+        tool["execute"](
+            { limit: 10, pageNum: 1, includeCount: false, ...args },
+            {
+                signal: new AbortController().signal,
+            }
+        );
 
     it("returns organizations when they exist", async () => {
         mockApiClient.listOrgs!.mockResolvedValue({
@@ -87,10 +92,21 @@ describe("ListOrganizationsTool", () => {
         );
     });
 
-    it("calls listOrgs API with includeCount", async () => {
+    it("does not request includeCount from the API by default", async () => {
         mockApiClient.listOrgs!.mockResolvedValue({ results: [], totalCount: 0 });
 
         await exec();
+
+        expect(mockApiClient.listOrgs).toHaveBeenCalledWith(
+            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: false } } },
+            expect.anything()
+        );
+    });
+
+    it("requests includeCount from the API when the caller opts in", async () => {
+        mockApiClient.listOrgs!.mockResolvedValue({ results: [], totalCount: 0 });
+
+        await exec({ includeCount: true });
 
         expect(mockApiClient.listOrgs).toHaveBeenCalledWith(
             { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: true } } },
@@ -108,7 +124,7 @@ describe("ListOrganizationsTool", () => {
         await exec(parsedArgs);
 
         expect(mockApiClient.listOrgs).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: true } } },
+            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: false } } },
             expect.anything()
         );
     });
@@ -119,7 +135,7 @@ describe("ListOrganizationsTool", () => {
         await exec({ limit: 10, pageNum: 3 });
 
         expect(mockApiClient.listOrgs).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 10, pageNum: 3, includeCount: true } } },
+            { params: { query: { itemsPerPage: 10, pageNum: 3, includeCount: false } } },
             expect.anything()
         );
     });
@@ -221,6 +237,20 @@ describe("ListOrganizationsTool", () => {
                 ],
                 totalCount: 2,
             });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).not.toContain("pagination");
+        });
+
+        it("suggests pagination on a full page when totalCount is missing", async () => {
+            mockApiClient.listOrgs!.mockResolvedValue({
+                results: Array.from({ length: 10 }, (_, i) => ({ name: `Org ${i}`, id: `org-${i}` })),
+            });
+
+            const result = await exec({ limit: 10 });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Use pagination arguments if more results are expected.");
         });
 
         it("returns totalCount 0 when no organizations are found", async () => {

--- a/packages/tools-atlas/src/tools/read/listOrgs.test.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.test.ts
@@ -156,7 +156,7 @@ describe("ListOrganizationsTool", () => {
             });
 
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Use pagination if more results are needed.");
+            expect(text).toContain("Use pagination arguments if more results are expected.");
         });
 
         it("does not suggest pagination when all organizations are returned", async () => {
@@ -201,7 +201,7 @@ describe("ListOrganizationsTool", () => {
             const result = await exec({ limit: 10, pageNum: 2 });
 
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Use pagination if more results are needed.");
+            expect(text).toContain("Use pagination arguments if more results are expected.");
         });
 
         it("falls back to the number of organizations returned when totalCount is missing", async () => {

--- a/packages/tools-atlas/src/tools/read/listOrgs.test.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.test.ts
@@ -70,7 +70,8 @@ describe("ListOrganizationsTool", () => {
         const result = await exec();
 
         const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-        expect(text).toContain("Found 2 of 2 organizations in your MongoDB Atlas account.");
+        expect(text).toContain("Found 2 organizations in your MongoDB Atlas account.");
+        expect(text).not.toContain("of 2");
         expect(text).toContain("Org A");
         expect(text).toContain("Org B");
         expect(text).toContain("<untrusted-user-data-");
@@ -170,8 +171,9 @@ describe("ListOrganizationsTool", () => {
             const result = await exec();
 
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Found 2 of 2 organizations in your MongoDB Atlas account.");
+            expect(text).toContain("Found 2 organizations in your MongoDB Atlas account.");
             expect(text).not.toContain("pagination");
+            expect(text).not.toContain("of 2");
         });
 
         it("does not suggest pagination on the last page", async () => {
@@ -184,8 +186,9 @@ describe("ListOrganizationsTool", () => {
             const result = await exec({ limit: 10, pageNum: 2 });
 
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Found 1 of 11 organizations in your MongoDB Atlas account.");
+            expect(text).toContain("Found 1 organizations in your MongoDB Atlas account.");
             expect(text).not.toContain("pagination");
+            expect(text).not.toContain("of 11");
         });
 
         it("suggests pagination on a middle page", async () => {

--- a/packages/tools-atlas/src/tools/read/listOrgs.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.ts
@@ -63,7 +63,7 @@ export class ListOrganizationsTool extends AtlasToolBase {
 
         return {
             content: formatUntrustedData(
-                `Found ${orgs.length} of ${totalCount} organizations in your MongoDB Atlas account.${
+                `Found ${orgs.length} organizations in your MongoDB Atlas account.${
                     moreResultsAvailable ? " Use pagination if more results are needed." : ""
                 }`,
                 JSON.stringify(orgs)

--- a/packages/tools-atlas/src/tools/read/listOrgs.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.ts
@@ -6,6 +6,12 @@ import { type ToolArgs, type ToolResult, formatUntrustedData } from "@mongodb-js
 export const ListOrganizationsArgs = {
     limit: z.number().int().min(1).max(500).default(10).describe("Max number of organizations to return per page."),
     pageNum: z.number().int().min(1).default(1).describe("Page number of organizations to return."),
+    includeCount: z
+        .boolean()
+        .default(false)
+        .describe(
+            "Whether to include the total number of matching organizations. Note: enabling this makes the API request take much longer."
+        ),
 };
 
 const ListOrganizationsOutputSchema = {
@@ -28,7 +34,7 @@ export class ListOrganizationsTool extends AtlasToolBase {
     public override outputSchema = ListOrganizationsOutputSchema;
 
     protected async execute(
-        { limit, pageNum }: ToolArgs<typeof this.argsShape>,
+        { limit, pageNum, includeCount }: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
         const data = await this.apiClient.listOrgs(
@@ -37,7 +43,7 @@ export class ListOrganizationsTool extends AtlasToolBase {
                     query: {
                         itemsPerPage: limit,
                         pageNum,
-                        includeCount: true,
+                        includeCount,
                     },
                 },
             },
@@ -49,7 +55,12 @@ export class ListOrganizationsTool extends AtlasToolBase {
             id: org.id,
         }));
         const totalCount = data?.totalCount ?? orgs.length;
-        const moreResultsAvailable = (pageNum - 1) * limit + orgs.length < totalCount;
+        // Without includeCount the API omits totalCount, so a full page is the signal
+        // that more results may exist on later pages.
+        const moreResultsAvailable =
+            data?.totalCount !== undefined
+                ? (pageNum - 1) * limit + orgs.length < data.totalCount
+                : orgs.length === limit;
 
         if (!orgs.length) {
             return {

--- a/packages/tools-atlas/src/tools/read/listOrgs.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.ts
@@ -64,7 +64,7 @@ export class ListOrganizationsTool extends AtlasToolBase {
         return {
             content: formatUntrustedData(
                 `Found ${orgs.length} organizations in your MongoDB Atlas account.${
-                    moreResultsAvailable ? " Use pagination if more results are needed." : ""
+                    moreResultsAvailable ? " Use pagination arguments if more results are expected." : ""
                 }`,
                 JSON.stringify(orgs)
             ),

--- a/packages/tools-atlas/src/tools/read/listProjects.test.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.test.ts
@@ -201,7 +201,7 @@ describe("ListProjectsTool", () => {
             });
 
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Use pagination if more results are needed.");
+            expect(text).toContain("Use pagination arguments if more results are expected.");
         });
 
         it("does not suggest pagination when all projects are returned", async () => {
@@ -240,7 +240,7 @@ describe("ListProjectsTool", () => {
             const result = await exec({ orgId, limit: 10, pageNum: 2 });
 
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Use pagination if more results are needed.");
+            expect(text).toContain("Use pagination arguments if more results are expected.");
         });
 
         it("falls back to the number of projects returned when totalCount is missing", async () => {

--- a/packages/tools-atlas/src/tools/read/listProjects.test.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.test.ts
@@ -83,7 +83,8 @@ describe("ListProjectsTool", () => {
         const result = await exec({ orgId });
 
         const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-        expect(text).toContain("Found 1 of 1 projects.");
+        expect(text).toContain("Found 1 projects.");
+        expect(text).not.toContain("of 1");
         expect(text).toContain("my-project");
         expect(text).toContain("<untrusted-user-data-");
     });
@@ -94,7 +95,7 @@ describe("ListProjectsTool", () => {
         const result = await exec();
 
         const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-        expect(text).toContain("Found 1 of 1 projects.");
+        expect(text).toContain("Found 1 projects.");
         expect(mockApiClient.getOrgGroups).not.toHaveBeenCalled();
         expect(mockApiClient.listGroups).toHaveBeenCalledWith(
             { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: true } } },
@@ -209,8 +210,9 @@ describe("ListProjectsTool", () => {
             const result = await exec({ orgId });
 
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Found 1 of 1 projects.");
+            expect(text).toContain("Found 1 projects.");
             expect(text).not.toContain("pagination");
+            expect(text).not.toContain("of 1");
         });
 
         it("does not suggest pagination on the last page", async () => {
@@ -223,8 +225,9 @@ describe("ListProjectsTool", () => {
             const result = await exec({ orgId, limit: 10, pageNum: 2 });
 
             const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Found 1 of 11 projects.");
+            expect(text).toContain("Found 1 projects.");
             expect(text).not.toContain("pagination");
+            expect(text).not.toContain("of 11");
         });
 
         it("suggests pagination on a middle page", async () => {

--- a/packages/tools-atlas/src/tools/read/listProjects.test.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.test.ts
@@ -73,7 +73,7 @@ describe("ListProjectsTool", () => {
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = {}) =>
-        tool["execute"]({ limit: 10, pageNum: 1, ...args } as never, {
+        tool["execute"]({ limit: 10, pageNum: 1, includeCount: false, ...args } as never, {
             signal: new AbortController().signal,
         });
 
@@ -98,7 +98,7 @@ describe("ListProjectsTool", () => {
         expect(text).toContain("Found 1 projects.");
         expect(mockApiClient.getOrgGroups).not.toHaveBeenCalled();
         expect(mockApiClient.listGroups).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: true } } },
+            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: false } } },
             expect.anything()
         );
     });
@@ -107,6 +107,22 @@ describe("ListProjectsTool", () => {
         mockApiClient.getOrgGroups!.mockResolvedValue({ results: [], totalCount: 0 });
 
         await exec({ orgId });
+
+        expect(mockApiClient.getOrgGroups).toHaveBeenCalledWith(
+            {
+                params: {
+                    path: { orgId },
+                    query: { itemsPerPage: 10, pageNum: 1, includeCount: false },
+                },
+            },
+            expect.anything()
+        );
+    });
+
+    it("requests includeCount when the caller opts in", async () => {
+        mockApiClient.getOrgGroups!.mockResolvedValue({ results: [], totalCount: 0 });
+
+        await exec({ orgId, includeCount: true });
 
         expect(mockApiClient.getOrgGroups).toHaveBeenCalledWith(
             {
@@ -129,7 +145,7 @@ describe("ListProjectsTool", () => {
         await exec(parsedArgs);
 
         expect(mockApiClient.listGroups).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: true } } },
+            { params: { query: { itemsPerPage: 10, pageNum: 1, includeCount: false } } },
             expect.anything()
         );
     });
@@ -143,7 +159,7 @@ describe("ListProjectsTool", () => {
             {
                 params: {
                     path: { orgId },
-                    query: { itemsPerPage: 25, pageNum: 2, includeCount: true },
+                    query: { itemsPerPage: 25, pageNum: 2, includeCount: false },
                 },
             },
             expect.anything()
@@ -156,7 +172,7 @@ describe("ListProjectsTool", () => {
         await exec({ limit: 25, pageNum: 2 });
 
         expect(mockApiClient.listGroups).toHaveBeenCalledWith(
-            { params: { query: { itemsPerPage: 25, pageNum: 2, includeCount: true } } },
+            { params: { query: { itemsPerPage: 25, pageNum: 2, includeCount: false } } },
             expect.anything()
         );
     });
@@ -253,6 +269,20 @@ describe("ListProjectsTool", () => {
                 totalCount: 1,
             });
             expect(result.structuredContent).not.toHaveProperty("orgId");
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).not.toContain("pagination");
+        });
+
+        it("suggests pagination on a full page when totalCount is missing", async () => {
+            mockApiClient.getOrgGroups!.mockResolvedValue({
+                results: Array.from({ length: 10 }, (_, i) => ({ ...projectApiResponse, name: `proj-${i}` })),
+            });
+
+            const result = await exec({ orgId, limit: 10 });
+
+            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
+            expect(text).toContain("Use pagination arguments if more results are expected.");
         });
 
         it("returns empty projects when org has no projects", async () => {

--- a/packages/tools-atlas/src/tools/read/listProjects.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.ts
@@ -100,7 +100,7 @@ export class ListProjectsTool extends AtlasToolBase {
         return {
             content: formatUntrustedData(
                 `Found ${projects.length} projects.${
-                    moreResultsAvailable ? " Use pagination if more results are needed." : ""
+                    moreResultsAvailable ? " Use pagination arguments if more results are expected." : ""
                 }`,
                 JSON.stringify(projects, null, 2)
             ),

--- a/packages/tools-atlas/src/tools/read/listProjects.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.ts
@@ -99,7 +99,7 @@ export class ListProjectsTool extends AtlasToolBase {
 
         return {
             content: formatUntrustedData(
-                `Found ${projects.length} of ${totalCount} projects.${
+                `Found ${projects.length} projects.${
                     moreResultsAvailable ? " Use pagination if more results are needed." : ""
                 }`,
                 JSON.stringify(projects, null, 2)

--- a/packages/tools-atlas/src/tools/read/listProjects.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.ts
@@ -12,6 +12,12 @@ export const ListProjectsArgs = {
         .optional(),
     limit: z.number().int().min(1).max(500).default(10).describe("Max number of projects to return per page."),
     pageNum: z.number().int().min(1).default(1).describe("Page number of projects to return."),
+    includeCount: z
+        .boolean()
+        .default(false)
+        .describe(
+            "Whether to include the total number of matching projects. Note: enabling this makes the API request take much longer."
+        ),
 };
 
 const ListProjectsOutputSchema = {
@@ -37,7 +43,7 @@ export class ListProjectsTool extends AtlasToolBase {
     public override outputSchema = ListProjectsOutputSchema;
 
     protected async execute(
-        { orgId, limit, pageNum }: ToolArgs<typeof this.argsShape>,
+        { orgId, limit, pageNum, includeCount }: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<ToolResult<typeof this.outputSchema>> {
         const data = orgId
@@ -50,7 +56,7 @@ export class ListProjectsTool extends AtlasToolBase {
                           query: {
                               itemsPerPage: limit,
                               pageNum,
-                              includeCount: true,
+                              includeCount,
                           },
                       },
                   },
@@ -62,7 +68,7 @@ export class ListProjectsTool extends AtlasToolBase {
                           query: {
                               itemsPerPage: limit,
                               pageNum,
-                              includeCount: true,
+                              includeCount,
                           },
                       },
                   },
@@ -76,7 +82,12 @@ export class ListProjectsTool extends AtlasToolBase {
             created: project.created ? new Date(project.created).toLocaleString() : "N/A",
         }));
         const totalCount = data?.totalCount ?? projects.length;
-        const moreResultsAvailable = (pageNum - 1) * limit + projects.length < totalCount;
+        // Without includeCount the API omits totalCount, so a full page is the signal
+        // that more results may exist on later pages.
+        const moreResultsAvailable =
+            data?.totalCount !== undefined
+                ? (pageNum - 1) * limit + projects.length < data.totalCount
+                : projects.length === limit;
 
         if (!projects.length) {
             return {


### PR DESCRIPTION
## Summary

Follow-up to #1453 (pagination in `atlas-list-orgs`/`atlas-list-projects`) and #1447 (drop the alert count by default).

After #1453, the prose reported `Found X of Y organizations/projects.` — but the caller opted in to the count, so it already lives in `structuredContent`; echoing it in prose adds noise. This mirrors the #1447 approach: keep the value in `structuredContent`, stop printing it in prose.

- `atlas-list-orgs`: `Found 10 of 13 organizations...` → `Found 10 organizations...`
- `atlas-list-projects`: `Found 10 of 13 projects.` → `Found 10 projects.`
- `atlas-list-alerts`: append the pagination hint whenever a full page is returned (`alerts.length === limit`), so callers see `Use pagination arguments if more results are expected.` alongside the existing `(total: N)` opt-in text from #1447.

## Defaulting includeCount to false

Matching `atlas-list-alerts` (#1447), `atlas-list-orgs` and `atlas-list-projects` no longer ask the API to count every matching item by default:

- `includeCount` defaults to `false`; callers can opt in (`includeCount: true`) when they need the total across pages.
- Both args note that enabling the count makes the API request take much longer.
- When `totalCount` is omitted (the default), the pagination hint falls back to the full-page heuristic (`results.length === limit`) so callers still learn they may need to continue paging.
- `totalCount` in `structuredContent` still falls back to the page size when the API omits it (kept for schema stability and existing integration-test expectations).

## Changes

- [x] Drop `of Y` from prose in `atlas-list-orgs` / `atlas-list-projects` (count stays in `structuredContent`)
- [x] Add pagination hint to `atlas-list-alerts` on a full page
- [x] Default `includeCount` to `false` for `atlas-list-orgs` / `atlas-list-projects`, with a note that it makes the API request much longer
- [x] Update unit tests
