### PR TITLE
fix(atlas): classify invalid Streams arguments MCP-628

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -591,6 +591,7 @@ export const ErrorCodes: {
     readonly ForbiddenServerSideJS: 1000009;
     readonly UnknownConnectionId: 1000010;
     readonly ConfirmationDeclined: 1000011;
+    readonly InvalidArgument: 1000012;
 };
 
 // @public

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -1513,6 +1513,7 @@ export const ErrorCodes: {
     readonly ForbiddenServerSideJS: 1000009;
     readonly UnknownConnectionId: 1000010;
     readonly ConfirmationDeclined: 1000011;
+    readonly InvalidArgument: 1000012;
 };
 
 // @public (undocumented)

--- a/packages/tools-atlas/src/streams/errors.test.ts
+++ b/packages/tools-atlas/src/streams/errors.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { ErrorCodes, MongoDBError } from "@mongodb-js/mcp-tools-mongodb";
+import { streamsInvalidArgument } from "./errors.js";
+
+describe("streamsInvalidArgument", () => {
+    it("creates a caller-addressable MongoDBError", () => {
+        const error = streamsInvalidArgument("workspaceName is required");
+
+        expect(error).toBeInstanceOf(MongoDBError);
+        expect(error.code).toBe(ErrorCodes.InvalidArgument);
+        expect(error.message).toBe("workspaceName is required");
+    });
+});

--- a/packages/tools-atlas/src/streams/errors.test.ts
+++ b/packages/tools-atlas/src/streams/errors.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { ErrorCodes, MongoDBError } from "@mongodb-js/mcp-tools-mongodb";
-import { streamsInvalidArgument } from "./errors.js";
+import { StreamsInvalidArgumentError } from "./errors.js";
 
-describe("streamsInvalidArgument", () => {
+describe("StreamsInvalidArgumentError", () => {
     it("creates a caller-addressable MongoDBError", () => {
-        const error = streamsInvalidArgument("workspaceName is required");
+        const error = new StreamsInvalidArgumentError("workspaceName is required");
 
         expect(error).toBeInstanceOf(MongoDBError);
         expect(error.code).toBe(ErrorCodes.InvalidArgument);

--- a/packages/tools-atlas/src/streams/errors.ts
+++ b/packages/tools-atlas/src/streams/errors.ts
@@ -1,0 +1,11 @@
+import { ErrorCodes, MongoDBError } from "@mongodb-js/mcp-tools-mongodb";
+
+/**
+ * Creates a caller-addressable error for invalid or incomplete Streams tool arguments.
+ *
+ * Using MongoDBError rather than a plain Error allows Remote MCP to classify the
+ * failure as expected without relying on the caller-facing message.
+ */
+export function streamsInvalidArgument(message: string): MongoDBError<typeof ErrorCodes.InvalidArgument> {
+    return new MongoDBError(ErrorCodes.InvalidArgument, message);
+}

--- a/packages/tools-atlas/src/streams/errors.ts
+++ b/packages/tools-atlas/src/streams/errors.ts
@@ -1,11 +1,9 @@
 import { ErrorCodes, MongoDBError } from "@mongodb-js/mcp-tools-mongodb";
 
-/**
- * Creates a caller-addressable error for invalid or incomplete Streams tool arguments.
- *
- * Using MongoDBError rather than a plain Error allows Remote MCP to classify the
- * failure as expected without relying on the caller-facing message.
- */
-export function streamsInvalidArgument(message: string): MongoDBError<typeof ErrorCodes.InvalidArgument> {
-    return new MongoDBError(ErrorCodes.InvalidArgument, message);
+/** A caller-addressable error for invalid or incomplete Streams tool arguments. */
+export class StreamsInvalidArgumentError extends MongoDBError<typeof ErrorCodes.InvalidArgument> {
+    constructor(message: string) {
+        super(ErrorCodes.InvalidArgument, message);
+        this.name = "StreamsInvalidArgumentError";
+    }
 }

--- a/packages/tools-atlas/src/tools/streams/build.ts
+++ b/packages/tools-atlas/src/tools/streams/build.ts
@@ -5,6 +5,7 @@ import type { ElicitRequestFormParams } from "@modelcontextprotocol/server";
 import type { ToolArgs } from "@mongodb-js/mcp-core";
 import { AtlasArgs } from "../../args.js";
 import { ConnectionConfig, PrivateLinkConfig, StreamsArgs } from "../../streams/streamsArgs.js";
+import { streamsInvalidArgument } from "../../streams/errors.js";
 
 const BuildResource = z.enum(["workspace", "connection", "processor", "privatelink"]);
 
@@ -237,7 +238,7 @@ export class StreamsBuildTool extends StreamsToolBase {
 
     private requireWorkspaceName(args: ToolArgs<typeof this.argsShape>): string {
         if (!args.workspaceName) {
-            throw new Error("workspaceName is required for this resource type.");
+            throw streamsInvalidArgument("workspaceName is required for this resource type.");
         }
         return args.workspaceName;
     }
@@ -248,10 +249,12 @@ export class StreamsBuildTool extends StreamsToolBase {
     ): Promise<CallToolResult> {
         const workspaceName = this.requireWorkspaceName(args);
         if (!args.cloudProvider) {
-            throw new Error("cloudProvider is required when creating a workspace. Choose from: AWS, AZURE, GCP.");
+            throw streamsInvalidArgument(
+                "cloudProvider is required when creating a workspace. Choose from: AWS, AZURE, GCP."
+            );
         }
         if (!args.region) {
-            throw new Error(
+            throw streamsInvalidArgument(
                 "region is required when creating a workspace (e.g. 'VIRGINIA_USA', 'eastus2', 'US_CENTRAL1')."
             );
         }
@@ -308,10 +311,10 @@ export class StreamsBuildTool extends StreamsToolBase {
     ): Promise<CallToolResult> {
         const workspaceName = this.requireWorkspaceName(args);
         if (!args.connectionName) {
-            throw new Error("connectionName is required when adding a connection.");
+            throw streamsInvalidArgument("connectionName is required when adding a connection.");
         }
         if (!args.connectionType) {
-            throw new Error(
+            throw streamsInvalidArgument(
                 "connectionType is required. Choose from: Kafka, Cluster, S3, Https, AWSKinesisDataStreams, AWSLambda, SchemaRegistry, Sample."
             );
         }
@@ -766,10 +769,10 @@ export class StreamsBuildTool extends StreamsToolBase {
     ): Promise<CallToolResult> {
         const workspaceName = this.requireWorkspaceName(args);
         if (!args.processorName) {
-            throw new Error("processorName is required when deploying a processor.");
+            throw streamsInvalidArgument("processorName is required when deploying a processor.");
         }
         if (!args.pipeline || args.pipeline.length === 0) {
-            throw new Error(
+            throw streamsInvalidArgument(
                 "pipeline is required. Provide an array of aggregation stages starting with $source and ending with a terminal stage ($merge, $emit, $https, or $externalFunction)."
             );
         }
@@ -847,7 +850,7 @@ export class StreamsBuildTool extends StreamsToolBase {
         context: ToolExecutionContext
     ): Promise<CallToolResult> {
         if (!args.privateLinkConfig) {
-            throw new Error(
+            throw streamsInvalidArgument(
                 "privateLinkConfig is required. Provide provider and vendor-specific fields:\n" +
                     "  AWS CONFLUENT: {provider, vendor:'CONFLUENT', region, serviceEndpointId, dnsDomain, dnsSubDomain: string[] of full FQDNs ([] for serverless)}\n" +
                     "  AWS MSK: {provider, vendor:'MSK', arn}\n" +
@@ -859,7 +862,7 @@ export class StreamsBuildTool extends StreamsToolBase {
             );
         }
         if (!args.privateLinkConfig.provider) {
-            throw new Error("privateLinkConfig.provider is required. Choose from: AWS, AZURE, GCP.");
+            throw streamsInvalidArgument("privateLinkConfig.provider is required. Choose from: AWS, AZURE, GCP.");
         }
 
         const body: Record<string, unknown> = {

--- a/packages/tools-atlas/src/tools/streams/build.ts
+++ b/packages/tools-atlas/src/tools/streams/build.ts
@@ -5,7 +5,7 @@ import type { ElicitRequestFormParams } from "@modelcontextprotocol/server";
 import type { ToolArgs } from "@mongodb-js/mcp-core";
 import { AtlasArgs } from "../../args.js";
 import { ConnectionConfig, PrivateLinkConfig, StreamsArgs } from "../../streams/streamsArgs.js";
-import { streamsInvalidArgument } from "../../streams/errors.js";
+import { StreamsInvalidArgumentError } from "../../streams/errors.js";
 
 const BuildResource = z.enum(["workspace", "connection", "processor", "privatelink"]);
 
@@ -238,7 +238,7 @@ export class StreamsBuildTool extends StreamsToolBase {
 
     private requireWorkspaceName(args: ToolArgs<typeof this.argsShape>): string {
         if (!args.workspaceName) {
-            throw streamsInvalidArgument("workspaceName is required for this resource type.");
+            throw new StreamsInvalidArgumentError("workspaceName is required for this resource type.");
         }
         return args.workspaceName;
     }
@@ -249,12 +249,12 @@ export class StreamsBuildTool extends StreamsToolBase {
     ): Promise<CallToolResult> {
         const workspaceName = this.requireWorkspaceName(args);
         if (!args.cloudProvider) {
-            throw streamsInvalidArgument(
+            throw new StreamsInvalidArgumentError(
                 "cloudProvider is required when creating a workspace. Choose from: AWS, AZURE, GCP."
             );
         }
         if (!args.region) {
-            throw streamsInvalidArgument(
+            throw new StreamsInvalidArgumentError(
                 "region is required when creating a workspace (e.g. 'VIRGINIA_USA', 'eastus2', 'US_CENTRAL1')."
             );
         }
@@ -311,10 +311,10 @@ export class StreamsBuildTool extends StreamsToolBase {
     ): Promise<CallToolResult> {
         const workspaceName = this.requireWorkspaceName(args);
         if (!args.connectionName) {
-            throw streamsInvalidArgument("connectionName is required when adding a connection.");
+            throw new StreamsInvalidArgumentError("connectionName is required when adding a connection.");
         }
         if (!args.connectionType) {
-            throw streamsInvalidArgument(
+            throw new StreamsInvalidArgumentError(
                 "connectionType is required. Choose from: Kafka, Cluster, S3, Https, AWSKinesisDataStreams, AWSLambda, SchemaRegistry, Sample."
             );
         }
@@ -769,10 +769,10 @@ export class StreamsBuildTool extends StreamsToolBase {
     ): Promise<CallToolResult> {
         const workspaceName = this.requireWorkspaceName(args);
         if (!args.processorName) {
-            throw streamsInvalidArgument("processorName is required when deploying a processor.");
+            throw new StreamsInvalidArgumentError("processorName is required when deploying a processor.");
         }
         if (!args.pipeline || args.pipeline.length === 0) {
-            throw streamsInvalidArgument(
+            throw new StreamsInvalidArgumentError(
                 "pipeline is required. Provide an array of aggregation stages starting with $source and ending with a terminal stage ($merge, $emit, $https, or $externalFunction)."
             );
         }
@@ -850,7 +850,7 @@ export class StreamsBuildTool extends StreamsToolBase {
         context: ToolExecutionContext
     ): Promise<CallToolResult> {
         if (!args.privateLinkConfig) {
-            throw streamsInvalidArgument(
+            throw new StreamsInvalidArgumentError(
                 "privateLinkConfig is required. Provide provider and vendor-specific fields:\n" +
                     "  AWS CONFLUENT: {provider, vendor:'CONFLUENT', region, serviceEndpointId, dnsDomain, dnsSubDomain: string[] of full FQDNs ([] for serverless)}\n" +
                     "  AWS MSK: {provider, vendor:'MSK', arn}\n" +
@@ -862,7 +862,9 @@ export class StreamsBuildTool extends StreamsToolBase {
             );
         }
         if (!args.privateLinkConfig.provider) {
-            throw streamsInvalidArgument("privateLinkConfig.provider is required. Choose from: AWS, AZURE, GCP.");
+            throw new StreamsInvalidArgumentError(
+                "privateLinkConfig.provider is required. Choose from: AWS, AZURE, GCP."
+            );
         }
 
         const body: Record<string, unknown> = {

--- a/packages/tools-atlas/src/tools/streams/discover.ts
+++ b/packages/tools-atlas/src/tools/streams/discover.ts
@@ -4,7 +4,7 @@ import type { CallToolResult, OperationType, ToolExecutionContext } from "@mongo
 import { formatUntrustedData, type ToolArgs } from "@mongodb-js/mcp-core";
 import { AtlasArgs } from "../../args.js";
 import { StreamsArgs } from "../../streams/streamsArgs.js";
-import { streamsInvalidArgument } from "../../streams/errors.js";
+import { StreamsInvalidArgumentError } from "../../streams/errors.js";
 
 type StreamsProcessorWithStats = {
     name?: string;
@@ -329,7 +329,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
 
     private requireWorkspaceName(workspaceName: string | undefined): string {
         if (!workspaceName) {
-            throw streamsInvalidArgument(
+            throw new StreamsInvalidArgumentError(
                 "workspaceName is required for this action. Use action 'list-workspaces' to see available workspaces."
             );
         }
@@ -338,7 +338,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
 
     private requireResourceName(resourceName: string | undefined, resourceType: string): string {
         if (!resourceName) {
-            throw streamsInvalidArgument(
+            throw new StreamsInvalidArgumentError(
                 `resourceName is required to inspect a ${resourceType}. ` +
                     `Use 'list-${resourceType}s' action to see available ${resourceType}s.`
             );
@@ -408,7 +408,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
             context
         );
         if (!data) {
-            throw streamsInvalidArgument(`Workspace '${workspaceName}' not found.`);
+            throw new StreamsInvalidArgumentError(`Workspace '${workspaceName}' not found.`);
         }
 
         const format = responseFormat ?? "detailed";

--- a/packages/tools-atlas/src/tools/streams/discover.ts
+++ b/packages/tools-atlas/src/tools/streams/discover.ts
@@ -4,6 +4,7 @@ import type { CallToolResult, OperationType, ToolExecutionContext } from "@mongo
 import { formatUntrustedData, type ToolArgs } from "@mongodb-js/mcp-core";
 import { AtlasArgs } from "../../args.js";
 import { StreamsArgs } from "../../streams/streamsArgs.js";
+import { streamsInvalidArgument } from "../../streams/errors.js";
 
 type StreamsProcessorWithStats = {
     name?: string;
@@ -328,7 +329,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
 
     private requireWorkspaceName(workspaceName: string | undefined): string {
         if (!workspaceName) {
-            throw new Error(
+            throw streamsInvalidArgument(
                 "workspaceName is required for this action. Use action 'list-workspaces' to see available workspaces."
             );
         }
@@ -337,7 +338,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
 
     private requireResourceName(resourceName: string | undefined, resourceType: string): string {
         if (!resourceName) {
-            throw new Error(
+            throw streamsInvalidArgument(
                 `resourceName is required to inspect a ${resourceType}. ` +
                     `Use 'list-${resourceType}s' action to see available ${resourceType}s.`
             );
@@ -407,7 +408,7 @@ export class StreamsDiscoverTool extends StreamsToolBase {
             context
         );
         if (!data) {
-            throw new Error(`Workspace '${workspaceName}' not found.`);
+            throw streamsInvalidArgument(`Workspace '${workspaceName}' not found.`);
         }
 
         const format = responseFormat ?? "detailed";

--- a/packages/tools-atlas/src/tools/streams/manage.ts
+++ b/packages/tools-atlas/src/tools/streams/manage.ts
@@ -4,6 +4,7 @@ import type { CallToolResult, OperationType, ToolExecutionContext } from "@mongo
 import { LogId, requestIdAttr, type ToolArgs } from "@mongodb-js/mcp-core";
 import { AtlasArgs } from "../../args.js";
 import { ConnectionConfig, StreamsArgs } from "../../streams/streamsArgs.js";
+import { streamsInvalidArgument } from "../../streams/errors.js";
 
 const ManageAction = z.enum([
     "start-processor",
@@ -191,11 +192,11 @@ export class StreamsManageTool extends StreamsToolBase {
                 return `You are about to update connection '${name}' in workspace '${args.workspaceName}'. Proceed?`;
             }
             case "accept-peering": {
-                if (!args.peeringId) throw new Error("peeringId is required for 'accept-peering'.");
+                if (!args.peeringId) throw streamsInvalidArgument("peeringId is required for 'accept-peering'.");
                 return `You are about to accept VPC peering connection '${args.peeringId}'. Proceed?`;
             }
             case "reject-peering": {
-                if (!args.peeringId) throw new Error("peeringId is required for 'reject-peering'.");
+                if (!args.peeringId) throw streamsInvalidArgument("peeringId is required for 'reject-peering'.");
                 return `You are about to reject VPC peering connection '${args.peeringId}'. This cannot be undone. Proceed?`;
             }
         }
@@ -203,7 +204,7 @@ export class StreamsManageTool extends StreamsToolBase {
 
     private requireResourceName(resourceName: string | undefined, context: string): string {
         if (!resourceName) {
-            throw new Error(`resourceName is required for '${context}'.`);
+            throw streamsInvalidArgument(`resourceName is required for '${context}'.`);
         }
         return resourceName;
     }
@@ -543,7 +544,7 @@ export class StreamsManageTool extends StreamsToolBase {
         const name = this.requireResourceName(args.resourceName, "update-connection");
 
         if (!args.connectionConfig) {
-            throw new Error("connectionConfig is required to update a connection.");
+            throw streamsInvalidArgument("connectionConfig is required to update a connection.");
         }
 
         const connection = (await this.apiClient.getStreamConnection(
@@ -587,9 +588,10 @@ export class StreamsManageTool extends StreamsToolBase {
         args: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<CallToolResult> {
-        if (!args.peeringId) throw new Error("peeringId is required to accept a VPC peering connection.");
-        if (!args.requesterAccountId) throw new Error("requesterAccountId is required to accept VPC peering.");
-        if (!args.requesterVpcId) throw new Error("requesterVpcId is required to accept VPC peering.");
+        if (!args.peeringId) throw streamsInvalidArgument("peeringId is required to accept a VPC peering connection.");
+        if (!args.requesterAccountId)
+            throw streamsInvalidArgument("requesterAccountId is required to accept VPC peering.");
+        if (!args.requesterVpcId) throw streamsInvalidArgument("requesterVpcId is required to accept VPC peering.");
 
         const peeringId = args.peeringId;
         const requesterAccountId = args.requesterAccountId;
@@ -621,7 +623,7 @@ export class StreamsManageTool extends StreamsToolBase {
         args: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<CallToolResult> {
-        if (!args.peeringId) throw new Error("peeringId is required to reject a VPC peering connection.");
+        if (!args.peeringId) throw streamsInvalidArgument("peeringId is required to reject a VPC peering connection.");
 
         await this.apiClient.rejectVpcPeeringConnection(
             {

--- a/packages/tools-atlas/src/tools/streams/manage.ts
+++ b/packages/tools-atlas/src/tools/streams/manage.ts
@@ -4,7 +4,7 @@ import type { CallToolResult, OperationType, ToolExecutionContext } from "@mongo
 import { LogId, requestIdAttr, type ToolArgs } from "@mongodb-js/mcp-core";
 import { AtlasArgs } from "../../args.js";
 import { ConnectionConfig, StreamsArgs } from "../../streams/streamsArgs.js";
-import { streamsInvalidArgument } from "../../streams/errors.js";
+import { StreamsInvalidArgumentError } from "../../streams/errors.js";
 
 const ManageAction = z.enum([
     "start-processor",
@@ -192,11 +192,13 @@ export class StreamsManageTool extends StreamsToolBase {
                 return `You are about to update connection '${name}' in workspace '${args.workspaceName}'. Proceed?`;
             }
             case "accept-peering": {
-                if (!args.peeringId) throw streamsInvalidArgument("peeringId is required for 'accept-peering'.");
+                if (!args.peeringId)
+                    throw new StreamsInvalidArgumentError("peeringId is required for 'accept-peering'.");
                 return `You are about to accept VPC peering connection '${args.peeringId}'. Proceed?`;
             }
             case "reject-peering": {
-                if (!args.peeringId) throw streamsInvalidArgument("peeringId is required for 'reject-peering'.");
+                if (!args.peeringId)
+                    throw new StreamsInvalidArgumentError("peeringId is required for 'reject-peering'.");
                 return `You are about to reject VPC peering connection '${args.peeringId}'. This cannot be undone. Proceed?`;
             }
         }
@@ -204,7 +206,7 @@ export class StreamsManageTool extends StreamsToolBase {
 
     private requireResourceName(resourceName: string | undefined, context: string): string {
         if (!resourceName) {
-            throw streamsInvalidArgument(`resourceName is required for '${context}'.`);
+            throw new StreamsInvalidArgumentError(`resourceName is required for '${context}'.`);
         }
         return resourceName;
     }
@@ -544,7 +546,7 @@ export class StreamsManageTool extends StreamsToolBase {
         const name = this.requireResourceName(args.resourceName, "update-connection");
 
         if (!args.connectionConfig) {
-            throw streamsInvalidArgument("connectionConfig is required to update a connection.");
+            throw new StreamsInvalidArgumentError("connectionConfig is required to update a connection.");
         }
 
         const connection = (await this.apiClient.getStreamConnection(
@@ -588,10 +590,12 @@ export class StreamsManageTool extends StreamsToolBase {
         args: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<CallToolResult> {
-        if (!args.peeringId) throw streamsInvalidArgument("peeringId is required to accept a VPC peering connection.");
+        if (!args.peeringId)
+            throw new StreamsInvalidArgumentError("peeringId is required to accept a VPC peering connection.");
         if (!args.requesterAccountId)
-            throw streamsInvalidArgument("requesterAccountId is required to accept VPC peering.");
-        if (!args.requesterVpcId) throw streamsInvalidArgument("requesterVpcId is required to accept VPC peering.");
+            throw new StreamsInvalidArgumentError("requesterAccountId is required to accept VPC peering.");
+        if (!args.requesterVpcId)
+            throw new StreamsInvalidArgumentError("requesterVpcId is required to accept VPC peering.");
 
         const peeringId = args.peeringId;
         const requesterAccountId = args.requesterAccountId;
@@ -623,7 +627,8 @@ export class StreamsManageTool extends StreamsToolBase {
         args: ToolArgs<typeof this.argsShape>,
         context: ToolExecutionContext
     ): Promise<CallToolResult> {
-        if (!args.peeringId) throw streamsInvalidArgument("peeringId is required to reject a VPC peering connection.");
+        if (!args.peeringId)
+            throw new StreamsInvalidArgumentError("peeringId is required to reject a VPC peering connection.");
 
         await this.apiClient.rejectVpcPeeringConnection(
             {

--- a/packages/tools-atlas/src/tools/streams/teardown.test.ts
+++ b/packages/tools-atlas/src/tools/streams/teardown.test.ts
@@ -79,6 +79,34 @@ describe("StreamsTeardownTool", () => {
         tool["execute"](args as never, { signal: new AbortController().signal });
     const confirmMsg = (args: Record<string, unknown>): string => tool["getConfirmationMessage"](args as never);
 
+    describe("error classification boundary", () => {
+        it("passes the raw invalid argument error to a wrapped handleError through invoke", async () => {
+            const wrappedHandleError = vi.fn(() => ({
+                content: [{ type: "text" as const, text: "classified error" }],
+                isError: true,
+            }));
+            Object.assign(tool, { handleError: wrappedHandleError });
+
+            const result = await tool.invoke(
+                {
+                    ...baseArgs,
+                    resource: "processor",
+                    resourceName: "proc1",
+                },
+                { signal: new AbortController().signal }
+            );
+
+            expect(wrappedHandleError).toHaveBeenCalledOnce();
+            const error = wrappedHandleError.mock.calls[0]?.[0];
+            expect(error).toBeInstanceOf(MongoDBError);
+            expect(error).toMatchObject({
+                code: ErrorCodes.InvalidArgument,
+                message: expect.stringContaining("workspaceName is required") as string,
+            });
+            expect(result.isError).toBe(true);
+        });
+    });
+
     describe("deleteProcessor", () => {
         it("should stop then delete a STARTED processor", async () => {
             mockApiClient.getStreamProcessor!.mockResolvedValue({ state: "STARTED", name: "proc1" });

--- a/packages/tools-atlas/src/tools/streams/teardown.test.ts
+++ b/packages/tools-atlas/src/tools/streams/teardown.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ToolConstructorParams } from "@mongodb-js/mcp-core";
 import type { IAtlasConfig, IAtlasSession } from "@mongodb-js/mcp-tools-atlas";
 import { StreamsTeardownTool } from "@mongodb-js/mcp-tools-atlas";
+import { ErrorCodes, MongoDBError } from "@mongodb-js/mcp-tools-mongodb";
 import type { AtlasTelemetry } from "@mongodb-js/mcp-atlas-telemetry";
 import type { Elicitation } from "@mongodb-js/mcp-core";
 import type { CompositeLogger } from "@mongodb-js/mcp-core";
@@ -155,24 +156,32 @@ describe("StreamsTeardownTool", () => {
             expect(result.structuredContent).toEqual({ resource: "processor" });
         });
 
-        it("should throw when workspaceName is missing", async () => {
-            await expect(
-                exec({
-                    ...baseArgs,
-                    resource: "processor",
-                    resourceName: "proc1",
-                })
-            ).rejects.toThrow("workspaceName is required");
+        it("should throw a caller-addressable error when workspaceName is missing", async () => {
+            const error = await exec({
+                ...baseArgs,
+                resource: "processor",
+                resourceName: "proc1",
+            }).catch((error: unknown) => error);
+
+            expect(error).toBeInstanceOf(MongoDBError);
+            expect(error).toMatchObject({
+                code: ErrorCodes.InvalidArgument,
+                message: expect.stringContaining("workspaceName is required") as string,
+            });
         });
 
-        it("should throw when resourceName is missing", async () => {
-            await expect(
-                exec({
-                    ...baseArgs,
-                    resource: "processor",
-                    workspaceName: "ws1",
-                })
-            ).rejects.toThrow("resourceName is required");
+        it("should throw a caller-addressable error when resourceName is missing", async () => {
+            const error = await exec({
+                ...baseArgs,
+                resource: "processor",
+                workspaceName: "ws1",
+            }).catch((error: unknown) => error);
+
+            expect(error).toBeInstanceOf(MongoDBError);
+            expect(error).toMatchObject({
+                code: ErrorCodes.InvalidArgument,
+                message: expect.stringContaining("resourceName is required") as string,
+            });
         });
     });
 

--- a/packages/tools-atlas/src/tools/streams/teardown.ts
+++ b/packages/tools-atlas/src/tools/streams/teardown.ts
@@ -4,6 +4,7 @@ import type { CallToolResult, OperationType, ToolExecutionContext } from "@mongo
 import { LogId, requestIdAttr, type ToolArgs } from "@mongodb-js/mcp-core";
 import { AtlasArgs } from "../../args.js";
 import { StreamsArgs } from "../../streams/streamsArgs.js";
+import { streamsInvalidArgument } from "../../streams/errors.js";
 
 const TeardownResource = z.enum(["processor", "connection", "workspace", "privatelink", "peering"]);
 
@@ -115,14 +116,14 @@ export class StreamsTeardownTool extends StreamsToolBase {
 
     private requireWorkspaceName(args: ToolArgs<typeof this.argsShape>): string {
         if (!args.workspaceName) {
-            throw new Error("workspaceName is required for this deletion.");
+            throw streamsInvalidArgument("workspaceName is required for this deletion.");
         }
         return args.workspaceName;
     }
 
     private requireResourceName(args: ToolArgs<typeof this.argsShape>): string {
         if (!args.resourceName) {
-            throw new Error("resourceName is required for this deletion.");
+            throw streamsInvalidArgument("resourceName is required for this deletion.");
         }
         return args.resourceName;
     }

--- a/packages/tools-atlas/src/tools/streams/teardown.ts
+++ b/packages/tools-atlas/src/tools/streams/teardown.ts
@@ -4,7 +4,7 @@ import type { CallToolResult, OperationType, ToolExecutionContext } from "@mongo
 import { LogId, requestIdAttr, type ToolArgs } from "@mongodb-js/mcp-core";
 import { AtlasArgs } from "../../args.js";
 import { StreamsArgs } from "../../streams/streamsArgs.js";
-import { streamsInvalidArgument } from "../../streams/errors.js";
+import { StreamsInvalidArgumentError } from "../../streams/errors.js";
 
 const TeardownResource = z.enum(["processor", "connection", "workspace", "privatelink", "peering"]);
 
@@ -116,14 +116,14 @@ export class StreamsTeardownTool extends StreamsToolBase {
 
     private requireWorkspaceName(args: ToolArgs<typeof this.argsShape>): string {
         if (!args.workspaceName) {
-            throw streamsInvalidArgument("workspaceName is required for this deletion.");
+            throw new StreamsInvalidArgumentError("workspaceName is required for this deletion.");
         }
         return args.workspaceName;
     }
 
     private requireResourceName(args: ToolArgs<typeof this.argsShape>): string {
         if (!args.resourceName) {
-            throw streamsInvalidArgument("resourceName is required for this deletion.");
+            throw new StreamsInvalidArgumentError("resourceName is required for this deletion.");
         }
         return args.resourceName;
     }

--- a/packages/tools-mongodb/src/common/errors.ts
+++ b/packages/tools-mongodb/src/common/errors.ts
@@ -10,6 +10,7 @@ export const ErrorCodes = {
     ForbiddenServerSideJS: 1_000_009,
     UnknownConnectionId: 1_000_010,
     ConfirmationDeclined: 1_000_011,
+    InvalidArgument: 1_000_012,
 } as const;
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];


### PR DESCRIPTION
## Proposed changes

Streams tools threw plain `Error` objects for caller-correctable validation failures such as a missing `workspaceName`. Remote MCP could not distinguish those failures from programming or infrastructure errors, so they were classified as unexpected and contributed to alerting totals.

Add a stable `InvalidArgument` error code and use `MongoDBError` for caller-addressable validation failures across the Streams build, discover, manage, and teardown tools. This lets the existing Remote MCP error classifier mark them as expected without matching user-facing message text. Infrastructure and programming errors retain their existing unexpected classification.

Includes regression coverage for the Streams error helper and missing teardown arguments.

Validation:
- Built `@mongodb-js/mcp-tools-atlas` and its workspace dependencies
- Passed `@mongodb-js/mcp-tools-atlas` typecheck
- Passed ESLint for changed TypeScript files
- Passed Streams error helper test (1 test)
- Passed Streams teardown tests (26 tests)

Jira: https://jira.mongodb.org/browse/MCP-628

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
