### PR TITLE
feat(streams): support MSK IAM authentication

### DIFF
--- a/packages/tools-atlas/src/streams/streamsArgs.ts
+++ b/packages/tools-atlas/src/streams/streamsArgs.ts
@@ -18,9 +18,19 @@ export const ConnectionConfig = z
             ),
         authentication: z
             .object({
-                mechanism: z.enum(["PLAIN", "SCRAM-256", "SCRAM-512", "OAUTHBEARER"]).optional(),
+                mechanism: z.enum(["PLAIN", "SCRAM-256", "SCRAM-512", "OAUTHBEARER", "AWS_MSK_IAM"]).optional(),
                 username: z.string().optional(),
                 password: z.string().optional(),
+                aws: z
+                    .object({
+                        roleArn: z
+                            .string()
+                            .optional()
+                            .describe("IAM role ARN registered via Atlas Cloud Provider Access."),
+                    })
+                    .passthrough()
+                    .optional()
+                    .describe("AWS configuration for AWS_MSK_IAM Kafka authentication."),
             })
             .passthrough()
             .optional()
@@ -113,6 +123,12 @@ export const PrivateLinkConfig = z
                 "PrivateLink vendor. If the user does not specify a vendor, ask them which vendor to use before proceeding. If they decline or say none, omit this field — the Atlas API will default to GENERIC. Valid values — AWS: 'CONFLUENT', 'MSK', 'KINESIS', 'S3'. Azure: 'EVENTHUB', 'CONFLUENT'. GCP: 'CONFLUENT'."
             ),
         arn: z.string().optional().describe("Amazon Resource Name (ARN). Required for AWS MSK vendor."),
+        authenticationScheme: z
+            .enum(["TLS", "SASL_SCRAM", "IAM"])
+            .optional()
+            .describe(
+                "Authentication scheme for an AWS MSK PrivateLink endpoint. Use 'IAM' for MSK IAM authentication, 'SASL_SCRAM' for SCRAM, or 'TLS' for mutual TLS."
+            ),
         dnsDomain: z
             .string()
             .optional()

--- a/packages/tools-atlas/src/tools/streams/build.test.ts
+++ b/packages/tools-atlas/src/tools/streams/build.test.ts
@@ -290,6 +290,37 @@ describe("StreamsBuildTool", () => {
             );
         });
 
+        it("should strip SASL credentials from an MSK IAM Kafka connection", async () => {
+            await exec({
+                ...baseArgs,
+                resource: "connection",
+                connectionName: "msk-iam",
+                connectionType: "Kafka",
+                connectionConfig: {
+                    bootstrapServers: "broker1:9098",
+                    authentication: {
+                        mechanism: "AWS_MSK_IAM",
+                        username: "unneeded-user",
+                        password: "unneeded-secret",
+                        aws: { roleArn: "arn:aws:iam::123456789012:role/msk-access" },
+                    },
+                    security: { protocol: "SASL_SSL" },
+                },
+            });
+
+            expect(mockApiClient.createStreamConnection).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.objectContaining({
+                        authentication: {
+                            mechanism: "AWS_MSK_IAM",
+                            aws: { roleArn: "arn:aws:iam::123456789012:role/msk-access" },
+                        },
+                    }),
+                }),
+                expect.anything()
+            );
+        });
+
         it("should create Cluster connection and set default dbRoleToExecute", async () => {
             await exec({
                 ...baseArgs,

--- a/packages/tools-atlas/src/tools/streams/build.test.ts
+++ b/packages/tools-atlas/src/tools/streams/build.test.ts
@@ -261,6 +261,35 @@ describe("StreamsBuildTool", () => {
             );
         });
 
+        it("should create an MSK IAM Kafka connection without SASL credentials", async () => {
+            await exec({
+                ...baseArgs,
+                resource: "connection",
+                connectionName: "msk-iam",
+                connectionType: "Kafka",
+                connectionConfig: {
+                    bootstrapServers: "broker1:9098",
+                    authentication: {
+                        mechanism: "AWS_MSK_IAM",
+                        aws: { roleArn: "arn:aws:iam::123456789012:role/msk-access" },
+                    },
+                    security: { protocol: "SASL_SSL" },
+                },
+            });
+
+            expect(mockApiClient.createStreamConnection).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.objectContaining({
+                        authentication: {
+                            mechanism: "AWS_MSK_IAM",
+                            aws: { roleArn: "arn:aws:iam::123456789012:role/msk-access" },
+                        },
+                    }),
+                }),
+                expect.anything()
+            );
+        });
+
         it("should create Cluster connection and set default dbRoleToExecute", async () => {
             await exec({
                 ...baseArgs,
@@ -371,6 +400,47 @@ describe("StreamsBuildTool", () => {
 
             expect(mockApiClient.createStreamConnection).toHaveBeenCalledOnce();
             expect((result.content[0] as { text: string }).text).toContain("kafka1");
+        });
+
+        it("should elicit an IAM role after AWS_MSK_IAM is selected", async () => {
+            mockElicitation.requestInput
+                .mockResolvedValueOnce({
+                    accepted: true,
+                    fields: {
+                        bootstrapServers: "broker:9098",
+                        mechanism: "AWS_MSK_IAM",
+                        protocol: "SASL_SSL",
+                    },
+                })
+                .mockResolvedValueOnce({
+                    accepted: true,
+                    fields: { roleArn: "arn:aws:iam::123456789012:role/msk-access" },
+                });
+
+            await exec({
+                ...baseArgs,
+                resource: "connection",
+                connectionName: "msk-iam",
+                connectionType: "Kafka",
+                connectionConfig: {},
+            });
+
+            expect(mockElicitation.requestInput).toHaveBeenCalledTimes(2);
+            const roleElicitationSchema = mockElicitation.requestInput.mock.calls[1][1] as {
+                properties: Record<string, unknown>;
+            };
+            expect(roleElicitationSchema.properties).toEqual({ roleArn: expect.any(Object) });
+            expect(mockApiClient.createStreamConnection).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    body: expect.objectContaining({
+                        authentication: {
+                            mechanism: "AWS_MSK_IAM",
+                            aws: { roleArn: "arn:aws:iam::123456789012:role/msk-access" },
+                        },
+                    }),
+                }),
+                expect.anything()
+            );
         });
 
         it("should throw when connectionName is missing", async () => {
@@ -939,6 +1009,32 @@ describe("StreamsBuildTool", () => {
                         provider: "AWS",
                         vendor: "MSK",
                         arn: "arn:aws:kafka:us-east-1:123456789012:cluster/my-msk/abc-123",
+                    },
+                },
+                expect.anything()
+            );
+        });
+
+        it("should create an AWS MSK PrivateLink with IAM authentication", async () => {
+            await exec({
+                ...baseArgs,
+                resource: "privatelink",
+                privateLinkConfig: {
+                    provider: "AWS",
+                    vendor: "MSK",
+                    arn: "arn:aws:kafka:us-east-1:123456789012:cluster/my-msk/abc-123",
+                    authenticationScheme: "IAM",
+                },
+            });
+
+            expect(mockApiClient.createPrivateLinkConnection).toHaveBeenCalledWith(
+                {
+                    params: { path: { groupId: "proj1" } },
+                    body: {
+                        provider: "AWS",
+                        vendor: "MSK",
+                        arn: "arn:aws:kafka:us-east-1:123456789012:cluster/my-msk/abc-123",
+                        authenticationScheme: "IAM",
                     },
                 },
                 expect.anything()

--- a/packages/tools-atlas/src/tools/streams/build.ts
+++ b/packages/tools-atlas/src/tools/streams/build.ts
@@ -428,7 +428,12 @@ export class StreamsBuildTool extends StreamsToolBase {
         }
 
         const isMskIam = auth.mechanism === "AWS_MSK_IAM";
-        const awsAuth = auth?.aws as Record<string, unknown> | undefined;
+        if (isMskIam) {
+            // SASL credentials do not apply to MSK IAM and must not be sent to Atlas.
+            delete auth.username;
+            delete auth.password;
+        }
+        const awsAuth = auth.aws as Record<string, unknown> | undefined;
         const missingFields = StreamsBuildTool.collectMissingFields([
             { key: "bootstrapServers", present: !!config.bootstrapServers, schema: KAFKA_FIELDS.bootstrapServers },
             { key: "roleArn", present: !isMskIam || !!awsAuth?.roleArn, schema: KAFKA_FIELDS.roleArn },

--- a/packages/tools-atlas/src/tools/streams/build.ts
+++ b/packages/tools-atlas/src/tools/streams/build.ts
@@ -34,7 +34,12 @@ const KAFKA_FIELDS = {
     },
     mechanism: {
         title: "Authentication Mechanism",
-        description: "SASL mechanism: 'PLAIN', 'SCRAM-256', or 'SCRAM-512'",
+        description: "SASL mechanism: 'PLAIN', 'SCRAM-256', 'SCRAM-512', 'OAUTHBEARER', or 'AWS_MSK_IAM'",
+    },
+    roleArn: {
+        title: "AWS IAM Role ARN",
+        description:
+            "IAM role ARN registered in this Atlas project via Cloud Provider Access. Required for AWS_MSK_IAM authentication.",
     },
     username: {
         title: "Username",
@@ -151,7 +156,7 @@ export class StreamsBuildTool extends StreamsToolBase {
             .describe("Connection name. Required when resource='connection'."),
         connectionType: ConnectionType.optional().describe(
             "Connection type. Required when resource='connection'. " +
-                "Kafka: needs bootstrapServers, authentication, security config. " +
+                "Kafka: needs bootstrapServers, authentication, and security config. Use authentication.mechanism='AWS_MSK_IAM' with authentication.aws.roleArn for MSK IAM authentication. " +
                 "Cluster: needs clusterName and dbRoleToExecute. " +
                 "S3: needs aws.roleArn (must be registered via Atlas Cloud Provider Access). " +
                 "Https: needs url. " +
@@ -397,11 +402,38 @@ export class StreamsBuildTool extends StreamsToolBase {
         const auth = config.authentication as Record<string, unknown> | undefined;
         const security = config.security as Record<string, unknown> | undefined;
 
+        // The required authentication fields depend on the mechanism. Ask for the
+        // mechanism first, then validate again to collect either IAM role details
+        // or SASL credentials rather than presenting incompatible fields together.
+        if (!auth?.mechanism) {
+            const mechanismFields = StreamsBuildTool.collectMissingFields([
+                { key: "bootstrapServers", present: !!config.bootstrapServers, schema: KAFKA_FIELDS.bootstrapServers },
+                { key: "mechanism", present: false, schema: KAFKA_FIELDS.mechanism },
+                { key: "protocol", present: !!security?.protocol, schema: KAFKA_FIELDS.protocol },
+            ]);
+            const result = await this.elicitOrReportMissing(
+                "Kafka",
+                config,
+                mechanismFields,
+                context,
+                (fields, cfg) => {
+                    if (fields.bootstrapServers) cfg.bootstrapServers = fields.bootstrapServers;
+                    if (!cfg.authentication) cfg.authentication = {};
+                    if (fields.mechanism) (cfg.authentication as Record<string, unknown>).mechanism = fields.mechanism;
+                    if (!cfg.security) cfg.security = {};
+                    if (fields.protocol) (cfg.security as Record<string, unknown>).protocol = fields.protocol;
+                }
+            );
+            return result ?? this.validateKafkaConfig(config, context);
+        }
+
+        const isMskIam = auth.mechanism === "AWS_MSK_IAM";
+        const awsAuth = auth?.aws as Record<string, unknown> | undefined;
         const missingFields = StreamsBuildTool.collectMissingFields([
             { key: "bootstrapServers", present: !!config.bootstrapServers, schema: KAFKA_FIELDS.bootstrapServers },
-            { key: "mechanism", present: !!auth?.mechanism, schema: KAFKA_FIELDS.mechanism },
-            { key: "username", present: !!auth?.username, schema: KAFKA_FIELDS.username },
-            { key: "password", present: !!auth?.password, schema: KAFKA_FIELDS.password },
+            { key: "roleArn", present: !isMskIam || !!awsAuth?.roleArn, schema: KAFKA_FIELDS.roleArn },
+            { key: "username", present: isMskIam || !!auth?.username, schema: KAFKA_FIELDS.username },
+            { key: "password", present: isMskIam || !!auth?.password, schema: KAFKA_FIELDS.password },
             { key: "protocol", present: !!security?.protocol, schema: KAFKA_FIELDS.protocol },
         ]);
 
@@ -416,6 +448,10 @@ export class StreamsBuildTool extends StreamsToolBase {
             if (fields.mechanism) authObj.mechanism = fields.mechanism;
             if (fields.username) authObj.username = fields.username;
             if (fields.password) authObj.password = fields.password;
+            if (fields.roleArn) {
+                if (!authObj.aws) authObj.aws = {};
+                (authObj.aws as Record<string, unknown>).roleArn = fields.roleArn;
+            }
             if (!cfg.security) cfg.security = {};
             const secObj = cfg.security as Record<string, unknown>;
             if (fields.protocol) secObj.protocol = fields.protocol;
@@ -853,7 +889,7 @@ export class StreamsBuildTool extends StreamsToolBase {
             throw new StreamsInvalidArgumentError(
                 "privateLinkConfig is required. Provide provider and vendor-specific fields:\n" +
                     "  AWS CONFLUENT: {provider, vendor:'CONFLUENT', region, serviceEndpointId, dnsDomain, dnsSubDomain: string[] of full FQDNs ([] for serverless)}\n" +
-                    "  AWS MSK: {provider, vendor:'MSK', arn}\n" +
+                    "  AWS MSK: {provider, vendor:'MSK', arn, authenticationScheme:'TLS'|'SASL_SCRAM'|'IAM'}\n" +
                     "  AWS S3: {provider, vendor:'S3', region, serviceEndpointId:'com.amazonaws.<region>.s3'}\n" +
                     "  AWS KINESIS: {provider, vendor:'KINESIS', region, serviceEndpointId}\n" +
                     "  AZURE EVENTHUB: {provider, vendor:'EVENTHUB', region, dnsDomain, serviceEndpointId (full Azure Resource ID)}\n" +


### PR DESCRIPTION
## Proposed changes

- Add `authenticationScheme` support when creating Stream Processing PrivateLink endpoints, including AWS MSK IAM endpoints.
- Add `AWS_MSK_IAM` Kafka authentication with `authentication.aws.roleArn`.
- Update Kafka configuration elicitation to request an IAM role ARN rather than SASL credentials when MSK IAM is selected.
- Add unit coverage for direct configuration, staged elicitation, and MSK IAM PrivateLink creation.

Jira: [CLOUDP-417872](https://jira.mongodb.org/browse/CLOUDP-417872)

## Validation

- `pnpm run build`
- `pnpm exec vitest --project unit packages/tools-atlas/src/tools/streams/build.test.ts --run`
- Prettier, ESLint, and `git diff --check`

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)