### PR TITLE
chore: typecheck test files in library packages

### DIFF
--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -541,9 +541,13 @@ export const ConnectionConfig: z.ZodObject<{
             "SCRAM-256": "SCRAM-256";
             "SCRAM-512": "SCRAM-512";
             OAUTHBEARER: "OAUTHBEARER";
+            AWS_MSK_IAM: "AWS_MSK_IAM";
         }>>;
         username: z.ZodOptional<z.ZodString>;
         password: z.ZodOptional<z.ZodString>;
+        aws: z.ZodOptional<z.ZodObject<{
+            roleArn: z.ZodOptional<z.ZodString>;
+        }, z.core.$loose>>;
     }, z.core.$loose>>;
     security: z.ZodOptional<z.ZodObject<{
         protocol: z.ZodOptional<z.ZodEnum<{
@@ -2650,6 +2654,11 @@ export const PrivateLinkConfig: z.ZodObject<{
     region: z.ZodOptional<z.ZodString>;
     vendor: z.ZodOptional<z.ZodString>;
     arn: z.ZodOptional<z.ZodString>;
+    authenticationScheme: z.ZodOptional<z.ZodEnum<{
+        TLS: "TLS";
+        SASL_SCRAM: "SASL_SCRAM";
+        IAM: "IAM";
+    }>>;
     dnsDomain: z.ZodOptional<z.ZodString>;
     dnsSubDomain: z.ZodOptional<z.ZodArray<z.ZodString>>;
     serviceEndpointId: z.ZodOptional<z.ZodString>;
@@ -2806,9 +2815,13 @@ export class StreamsBuildTool extends StreamsToolBase {
                     "SCRAM-256": "SCRAM-256";
                     "SCRAM-512": "SCRAM-512";
                     OAUTHBEARER: "OAUTHBEARER";
+                    AWS_MSK_IAM: "AWS_MSK_IAM";
                 }>>;
                 username: z.ZodOptional<z.ZodString>;
                 password: z.ZodOptional<z.ZodString>;
+                aws: z.ZodOptional<z.ZodObject<{
+                    roleArn: z.ZodOptional<z.ZodString>;
+                }, z.core.$loose>>;
             }, z.core.$loose>>;
             security: z.ZodOptional<z.ZodObject<{
                 protocol: z.ZodOptional<z.ZodEnum<{
@@ -2865,6 +2878,11 @@ export class StreamsBuildTool extends StreamsToolBase {
             region: z.ZodOptional<z.ZodString>;
             vendor: z.ZodOptional<z.ZodString>;
             arn: z.ZodOptional<z.ZodString>;
+            authenticationScheme: z.ZodOptional<z.ZodEnum<{
+                TLS: "TLS";
+                SASL_SCRAM: "SASL_SCRAM";
+                IAM: "IAM";
+            }>>;
             dnsDomain: z.ZodOptional<z.ZodString>;
             dnsSubDomain: z.ZodOptional<z.ZodArray<z.ZodString>>;
             serviceEndpointId: z.ZodOptional<z.ZodString>;
@@ -3047,9 +3065,13 @@ export class StreamsManageTool extends StreamsToolBase {
                     "SCRAM-256": "SCRAM-256";
                     "SCRAM-512": "SCRAM-512";
                     OAUTHBEARER: "OAUTHBEARER";
+                    AWS_MSK_IAM: "AWS_MSK_IAM";
                 }>>;
                 username: z.ZodOptional<z.ZodString>;
                 password: z.ZodOptional<z.ZodString>;
+                aws: z.ZodOptional<z.ZodObject<{
+                    roleArn: z.ZodOptional<z.ZodString>;
+                }, z.core.$loose>>;
             }, z.core.$loose>>;
             security: z.ZodOptional<z.ZodObject<{
                 protocol: z.ZodOptional<z.ZodEnum<{

--- a/packages/atlas-api-client/package.json
+++ b/packages/atlas-api-client/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@mongodb-js/mcp-core": "workspace:*",

--- a/packages/atlas-telemetry/package.json
+++ b/packages/atlas-telemetry/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@mongodb-js/mcp-atlas-api-client": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@modelcontextprotocol/core": "^2.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "check:api": "api-extractor run --config api-extractor.json",
     "update:api": "api-extractor run --local --config api-extractor.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@mcp-ui/server": "^6.1.0",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@mongodb-js/devtools-proxy-support": "^0.7.19"

--- a/packages/http-runners/package.json
+++ b/packages/http-runners/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@modelcontextprotocol/node": "^2.0.0",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@mongodb-js/mcp-core": "workspace:*"

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "prom-client": "^15.1.3"

--- a/packages/mongodb-atlas-mcp-remote/package.json
+++ b/packages/mongodb-atlas-mcp-remote/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "compile": "tsc --project tsconfig.build.json",
     "build": "pnpm compile",
+    "check": "tsc --noEmit --project tsconfig.check.json",
     "pretest": "pnpm compile",
     "test": "vitest --run",
     "build:update-package-version": "node scripts/updatePackageVersion.ts"

--- a/packages/mongodb-atlas-mcp-remote/tsconfig.check.json
+++ b/packages/mongodb-atlas-mcp-remote/tsconfig.check.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  }
+}

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -15,7 +15,7 @@
     "filter:openapi": "tsx src/filter.ts",
     "apply:openapi": "tsx src/apply.ts",
     "create-dependency-sbom-lists": "tsx src/sbomReport/index.ts",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "devDependencies": {
     "@mongodb-js/mcp-ui": "workspace:*",

--- a/packages/setup/package.json
+++ b/packages/setup/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@inquirer/prompts": "^8.0.2",

--- a/packages/tools-assistant/package.json
+++ b/packages/tools-assistant/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@mongodb-js/mcp-core": "workspace:*",

--- a/packages/tools-atlas-local/package.json
+++ b/packages/tools-atlas-local/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@mongodb-js/atlas-local": "^1.3.0",

--- a/packages/tools-atlas/package.json
+++ b/packages/tools-atlas/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@mongodb-js/mcp-atlas-api-client": "workspace:*",

--- a/packages/tools-atlas/src/helpers/performanceAdvisorUtils.test.ts
+++ b/packages/tools-atlas/src/helpers/performanceAdvisorUtils.test.ts
@@ -9,7 +9,10 @@ import {
 } from "./performanceAdvisorUtils.js";
 import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 
-const context = { requestInfo: { headers: { "x-request-id": "req-pa-1" } } };
+const context = {
+    signal: new AbortController().signal,
+    requestInfo: { headers: { "x-request-id": "req-pa-1" } },
+};
 
 function makeApiClient(overrides: Partial<Record<string, ReturnType<typeof vi.fn>>>): ApiClient & {
     logger: { debug: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };

--- a/packages/tools-atlas/src/tools/create/createAccessList.test.ts
+++ b/packages/tools-atlas/src/tools/create/createAccessList.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ToolConstructorParams } from "@mongodb-js/mcp-core";
 import { CreateAccessListTool } from "./createAccessList.js";
 import { DEFAULT_ACCESS_LIST_COMMENT } from "../../helpers/accessListUtils.js";
-import type { IAtlasSession } from "../../atlasTool.js";
+import type { IAtlasConfig, IAtlasSession } from "../../atlasTool.js";
 import type { ITelemetry, IElicitation, ICompositeLogger } from "@mongodb-js/mcp-types";
 import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { MockMetrics } from "@mongodb-js/mcp-test-utils";
@@ -45,7 +45,7 @@ describe("CreateAccessListTool", () => {
                 confirmationRequiredTools: [],
                 previewFeatures: [],
                 disabledTools: [],
-            } as IAtlasSession["config"],
+            } as unknown as IAtlasConfig,
         } as unknown as IAtlasSession;
 
         const params: ToolConstructorParams<IAtlasSession> = {

--- a/packages/tools-atlas/src/tools/create/createCluster.test.ts
+++ b/packages/tools-atlas/src/tools/create/createCluster.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ToolConstructorParams } from "@mongodb-js/mcp-core";
 import { CreateClusterTool, CreateClusterArgsShape } from "./createCluster.js";
 import { z } from "zod";
-import type { IAtlasSession } from "../../atlasTool.js";
+import type { IAtlasConfig, IAtlasSession } from "../../atlasTool.js";
 import type { ITelemetry, IElicitation, ICompositeLogger } from "@mongodb-js/mcp-types";
 import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { ApiClientError } from "@mongodb-js/mcp-atlas-api-client";
@@ -54,7 +54,7 @@ describe("CreateClusterTool", () => {
                 confirmationRequiredTools: [],
                 previewFeatures: [],
                 disabledTools: [],
-            } as IAtlasSession["config"],
+            } as unknown as IAtlasConfig,
         };
 
         const mockTelemetry = {

--- a/packages/tools-atlas/src/tools/streams/build.test.ts
+++ b/packages/tools-atlas/src/tools/streams/build.test.ts
@@ -457,7 +457,7 @@ describe("StreamsBuildTool", () => {
             });
 
             expect(mockElicitation.requestInput).toHaveBeenCalledTimes(2);
-            const roleElicitationSchema = mockElicitation.requestInput.mock.calls[1][1] as {
+            const roleElicitationSchema = mockElicitation.requestInput.mock.calls[1]?.[1] as {
                 properties: Record<string, unknown>;
             };
             expect(roleElicitationSchema.properties).toEqual({ roleArn: expect.any(Object) });

--- a/packages/tools-atlas/src/tools/streams/teardown.test.ts
+++ b/packages/tools-atlas/src/tools/streams/teardown.test.ts
@@ -81,7 +81,8 @@ describe("StreamsTeardownTool", () => {
 
     describe("error classification boundary", () => {
         it("passes the raw invalid argument error to a wrapped handleError through invoke", async () => {
-            const wrappedHandleError = vi.fn(() => ({
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const wrappedHandleError = vi.fn((_: unknown, _args: Record<string, unknown>) => ({
                 content: [{ type: "text" as const, text: "classified error" }],
                 isError: true,
             }));

--- a/packages/tools-mongodb/package.json
+++ b/packages/tools-mongodb/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@mongodb-js/device-id": "^0.4.6",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@modelcontextprotocol/server": "^2.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,7 +27,7 @@
     "check:api": "api-extractor run --config api-extractor.json",
     "update:api": "api-extractor run --local --config api-extractor.json",
     "test": "vitest --run",
-    "check": "tsc --build tsconfig.build.json --noEmit"
+    "check": "tsc --noEmit --project tsconfig.check.json"
   },
   "devDependencies": {
     "@lg-mcp/embeddable-uis": "^0.1.0",

--- a/packages/ui/tsconfig.check.json
+++ b/packages/ui/tsconfig.check.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  }
+}


### PR DESCRIPTION
## What/Why

Library `check` scripts used `tsconfig.build.json`, which excludes test files, so `src/**/*.test.ts` was never type-checked in CI. Switch them to `tsc --noEmit --project tsconfig.json` (pattern already used by test-only packages) and fix the pre-existing test type errors this surfaces in tools-atlas.

Also: add `tsconfig.check.json` + a `check` script to `ui` and `mongodb-atlas-mcp-remote` (the latter had none), and regenerate the stale `tools.public.api.md` (missing MSK IAM entries from #1471, broke `check:api` on main).

## Notes

- The tools-atlas test errors are pre-existing on main; they surfaced because a full typecheck now covers test files.
