### PR TITLE
refactor: Phase 2 — shared AppServices over minimal per-request servers (part 2/4)

### DIFF
--- a/api-extractor/reports/core.public.api.md
+++ b/api-extractor/reports/core.public.api.md
@@ -36,7 +36,6 @@ import type { PreviewFeature } from '@mongodb-js/mcp-types';
 import type { ReactiveResourceOptions } from '@mongodb-js/mcp-types';
 import type { ResourceConfiguration } from '@mongodb-js/mcp-types';
 import type { ResourceMetadata } from '@modelcontextprotocol/server';
-import type { ResourceServices } from '@mongodb-js/mcp-types';
 import { Secret } from 'mongodb-redact';
 import { ServerContext } from '@modelcontextprotocol/server';
 import type { SupportedConnectionState } from '@mongodb-js/mcp-types';
@@ -327,31 +326,22 @@ export class NoopTelemetry implements ITelemetry {
 // @public
 export abstract class ReactiveResource<
 /** Value stored in the resource */
-Value, TServices extends ResourceServices = ResourceServices, TServer extends IResourceServer = IResourceServer> {
+Value, TServer extends IResourceServer = IResourceServer> {
     constructor(input: {
         resourceConfiguration: ResourceConfiguration;
         options: ReactiveResourceOptions<Value>;
-        services: TServices;
-        telemetry: ITelemetry;
+        server: TServer;
         current?: Value;
     });
-    protected readonly config: TServices["config"];
     // (undocumented)
     protected current: Value;
-    // (undocumented)
-    protected readonly keychain: TServices["keychain"];
-    // (undocumented)
-    protected readonly logger: TServices["logger"];
     // (undocumented)
     protected readonly name: string;
     // (undocumented)
     register(server: TServer): void;
     // (undocumented)
     protected readonly resourceConfig: ResourceMetadata;
-    // (undocumented)
-    protected server?: TServer;
-    // (undocumented)
-    protected telemetry: ITelemetry;
+    protected server: TServer;
     // (undocumented)
     abstract toOutput(): string | Promise<string>;
     // (undocumented)

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -57,7 +57,7 @@ export type AnyToolClass = Omit<ToolClass<any, any>, "new"> & {
 
 // @public (undocumented)
 export class ApiClient {
-    constructor(options: ApiClientOptions, logger: LoggerBase, authProvider?: AuthProvider);
+    constructor(input: ApiClientConstruction);
     // (undocumented)
     acceptVpcPeeringConnection(options: FetchOptions<operations["acceptGroupStreamVpcPeeringConnection"]>, context?: ApiClientRequestContext): Promise<void>;
     // (undocumented)
@@ -311,6 +311,7 @@ export class CliServer<TMetrics extends DefaultMetricDefinitions = DefaultMetric
     sendResourceUpdated(uri: string): void;
     // (undocumented)
     readonly serverMetadata: ServerMetadata;
+    readonly telemetry: AtlasTelemetry;
     // (undocumented)
     readonly tools: AnyToolBase[];
     // (undocumented)
@@ -324,6 +325,7 @@ export interface CliServerOptions<TMetrics extends DefaultMetricDefinitions = De
     // (undocumented)
     atlasLocalClient?: Client;
     config: UserConfig;
+    readonly configValidated?: boolean;
     // (undocumented)
     connectionErrorHandler: ConnectionErrorHandler;
     // (undocumented)
@@ -629,7 +631,9 @@ export type EventMap<T> = Record<keyof T, any[]>;
 
 // @public (undocumented)
 export class ExportedData {
-    constructor(services: ExportedDataServices);
+    constructor(input: {
+        server: CliServer;
+    });
     // (undocumented)
     register(server: CliServer): void;
 }

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -33,7 +33,7 @@ export type AnyToolBase = ToolBase<any>;
 
 // @public (undocumented)
 export class ApiClient {
-    constructor(options: ApiClientOptions, logger: LoggerBase, authProvider?: AuthProvider);
+    constructor(input: ApiClientConstruction);
     // (undocumented)
     acceptVpcPeeringConnection(options: FetchOptions<operations["acceptGroupStreamVpcPeeringConnection"]>, context?: ApiClientRequestContext): Promise<void>;
     // (undocumented)

--- a/packages/atlas-api-client/src/apiClient.test.ts
+++ b/packages/atlas-api-client/src/apiClient.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
+import { ApiClient, AuthProviderFactory, type AuthProvider } from "@mongodb-js/mcp-atlas-api-client";
 import type { TelemetryCommonProperties, TelemetryEvent } from "@mongodb-js/mcp-types";
 import { NoopLogger } from "@mongodb-js/mcp-core";
 
@@ -8,6 +8,18 @@ const testHttpClient = {
     fetch: globalThis.fetch.bind(globalThis),
     Request: globalThis.Request,
 };
+
+function credentialedProvider(baseUrl = "https://api.test.com", httpClient = testHttpClient): AuthProvider | undefined {
+    return AuthProviderFactory.create(
+        {
+            apiBaseUrl: baseUrl,
+            userAgent: TEST_USER_AGENT,
+            credentials: { clientId: "test-client-id", clientSecret: "test-client-secret" },
+            httpClient,
+        },
+        new NoopLogger()
+    );
+}
 
 describe("ApiClient", () => {
     let apiClient: ApiClient;
@@ -33,22 +45,17 @@ describe("ApiClient", () => {
     ];
 
     beforeEach(() => {
-        apiClient = new ApiClient(
-            {
+        apiClient = new ApiClient({
+            options: {
                 baseUrl: "https://api.test.com",
                 userAgent: TEST_USER_AGENT,
-                credentials: {
-                    clientId: "test-client-id",
-                    clientSecret: "test-client-secret",
-                },
                 httpClient: testHttpClient,
             },
-            new NoopLogger()
-        );
+            logger: new NoopLogger(),
+            authProvider: credentialedProvider(),
+        });
 
-        // @ts-expect-error accessing private property for testing
         apiClient.authProvider.validate = vi.fn().mockResolvedValue(true);
-        // @ts-expect-error accessing private property for testing
         apiClient.authProvider.getAuthHeaders = vi.fn().mockResolvedValue({
             Authorization: "Bearer mockToken",
         });
@@ -71,15 +78,15 @@ describe("ApiClient", () => {
         });
 
         it("makes getIpInfo reject without a network call when disabled", async () => {
-            const client = new ApiClient(
-                {
+            const client = new ApiClient({
+                options: {
                     baseUrl: "https://api.test.com",
                     userAgent: TEST_USER_AGENT,
                     supportsCurrentIpLookup: false,
                     httpClient: testHttpClient,
                 },
-                new NoopLogger()
-            );
+                logger: new NoopLogger(),
+            });
 
             expect(client.supportsCurrentIpLookup).toBe(false);
             await expect(client.getIpInfo()).rejects.toThrow("does not support current IP detection");
@@ -105,17 +112,18 @@ describe("ApiClient", () => {
                 .spyOn(global, "fetch")
                 .mockRejectedValue(new Error("global fetch should not be called"));
 
-            const client = new ApiClient(
-                {
+            const httpClient = {
+                fetch: injectedFetch,
+                Request: TrackedRequest,
+            };
+            const client = new ApiClient({
+                options: {
                     baseUrl: "https://api.test.com",
                     userAgent: TEST_USER_AGENT,
-                    httpClient: {
-                        fetch: injectedFetch,
-                        Request: TrackedRequest,
-                    },
+                    httpClient,
                 },
-                new NoopLogger()
-            );
+                logger: new NoopLogger(),
+            });
 
             await client.listClusterDetails();
 
@@ -127,21 +135,19 @@ describe("ApiClient", () => {
         it("passes the injected fetch to the auth provider it creates", () => {
             const injectedFetch = vi.fn();
 
-            const client = new ApiClient(
-                {
+            const httpClient = {
+                fetch: injectedFetch,
+                Request: globalThis.Request,
+            };
+            const client = new ApiClient({
+                options: {
                     baseUrl: "https://api.test.com",
                     userAgent: TEST_USER_AGENT,
-                    credentials: {
-                        clientId: "test-client-id",
-                        clientSecret: "test-client-secret",
-                    },
-                    httpClient: {
-                        fetch: injectedFetch,
-                        Request: globalThis.Request,
-                    },
+                    httpClient,
                 },
-                new NoopLogger()
-            );
+                logger: new NoopLogger(),
+                authProvider: credentialedProvider("https://api.test.com", httpClient),
+            });
 
             // @ts-expect-error accessing private property for testing
             expect(client.authProvider.customFetch).toBe(injectedFetch);
@@ -167,14 +173,14 @@ describe("ApiClient", () => {
         });
 
         it("should use the provided userAgent in unauth requests", async () => {
-            const clientWithoutCredentials = new ApiClient(
-                {
+            const clientWithoutCredentials = new ApiClient({
+                options: {
                     baseUrl: "https://api.test.com",
                     userAgent: "AtlasMCP/test-version",
                     httpClient: testHttpClient,
                 },
-                new NoopLogger()
-            );
+                logger: new NoopLogger(),
+            });
 
             const mockFetch = vi.spyOn(global, "fetch");
             mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
@@ -375,7 +381,6 @@ describe("ApiClient", () => {
             const mockFetch = vi.spyOn(global, "fetch");
             mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
 
-            // @ts-expect-error accessing private property for testing
             apiClient.authProvider.getAuthHeaders = vi.fn().mockRejectedValue(new Error("No access token available"));
 
             await apiClient.sendEvents(mockEvents);
@@ -399,7 +404,6 @@ describe("ApiClient", () => {
             const mockFetch = vi.spyOn(global, "fetch");
             mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
 
-            // @ts-expect-error accessing private property for testing
             apiClient.authProvider.getAuthHeaders = vi.fn().mockResolvedValue(undefined);
 
             await apiClient.sendEvents(mockEvents);
@@ -450,7 +454,6 @@ describe("ApiClient", () => {
                 .mockResolvedValueOnce(new Response(null, { status: 500 }));
 
             const mockToken = "test-token";
-            // @ts-expect-error accessing private property for testing
             apiClient.authProvider.getAuthHeaders = vi.fn().mockResolvedValue({
                 Authorization: `Bearer ${mockToken}`,
             });

--- a/packages/atlas-api-client/src/apiClient.ts
+++ b/packages/atlas-api-client/src/apiClient.ts
@@ -5,7 +5,6 @@ import type { components, paths, operations } from "./openapi.js";
 import type { TelemetryEvent, TelemetryCommonProperties } from "@mongodb-js/mcp-types";
 import type { LoggerBase } from "@mongodb-js/mcp-core";
 import type { Credentials, AuthProvider } from "./auth/authProvider.js";
-import { AuthProviderFactory } from "./auth/authProvider.js";
 
 const ATLAS_API_VERSION = "2025-03-12";
 const DEFAULT_SEND_TIMEOUT_MS = 5_000;
@@ -70,11 +69,30 @@ export type ApiClientRequestContext = {
  */
 const FORWARDABLE_REQUEST_HEADERS: ReadonlySet<string> = new Set(["x-request-id"]);
 
-export type ApiClientFactoryFn = (options: ApiClientOptions, logger: LoggerBase) => ApiClient;
+export type ApiClientFactoryFn = (construction: ApiClientConstruction) => ApiClient;
 
 /** @public */
-export const defaultCreateApiClient: ApiClientFactoryFn = (options, logger) => {
-    return new ApiClient(options, logger);
+export const defaultCreateApiClient: ApiClientFactoryFn = (construction) => {
+    return new ApiClient(construction);
+};
+
+/**
+ * The construction input for {@link ApiClient}: field-specific options plus
+ * the injected logger and an optionally-supplied auth provider. `authProvider`
+ * is omitted when the client is unauthenticated (e.g. anonymous telemetry) —
+ * the client no longer derives one from `options.credentials`; call sites that
+ * need auth build the provider explicitly (e.g. via {@link AuthProviderFactory}).
+ */
+export type ApiClientConstruction = {
+    /** Field-specific client options (base URL, user agent, http client, ...). */
+    options: ApiClientOptions;
+    /** Logger used by the client and its auth provider. */
+    logger: LoggerBase;
+    /**
+     * The auth strategy for Atlas API requests. Omit when the client is not
+     * authenticated (no auth headers, `isAuthConfigured()` returns `false`).
+     */
+    authProvider?: AuthProvider;
 };
 
 export class ApiClient {
@@ -93,25 +111,14 @@ export class ApiClient {
         return !!this.authProvider;
     }
 
-    constructor(options: ApiClientOptions, logger: LoggerBase, authProvider?: AuthProvider) {
+    constructor({ options, logger, authProvider }: ApiClientConstruction) {
         this.logger = logger;
+        this.authProvider = authProvider;
         this.options = {
             baseUrl: options.baseUrl,
             userAgent: options.userAgent,
             supportsCurrentIpLookup: options.supportsCurrentIpLookup ?? true,
         };
-
-        this.authProvider =
-            authProvider ??
-            AuthProviderFactory.create(
-                {
-                    apiBaseUrl: this.options.baseUrl,
-                    userAgent: this.options.userAgent,
-                    credentials: options.credentials ?? {},
-                    httpClient: options.httpClient,
-                },
-                logger
-            );
 
         this.client = createClient<paths>({
             baseUrl: this.options.baseUrl,
@@ -123,7 +130,7 @@ export class ApiClient {
             Request: options.httpClient.Request,
         });
 
-        if (this.authProvider) {
+        if (this.isAuthConfigured()) {
             this.client.use(this.createAuthMiddleware());
         }
     }
@@ -226,7 +233,7 @@ export class ApiClient {
         events: TelemetryEvent<TelemetryCommonProperties>[],
         { signal = AbortSignal.timeout(DEFAULT_SEND_TIMEOUT_MS) }: { signal?: AbortSignal } = {}
     ): Promise<void> {
-        if (!this.authProvider) {
+        if (!this.isAuthConfigured()) {
             await this.sendUnauthEvents(events, signal);
             return;
         }

--- a/packages/atlas-api-client/src/index.ts
+++ b/packages/atlas-api-client/src/index.ts
@@ -1,7 +1,14 @@
 export { userAgentFromServerMetadata } from "./userAgentFromServerMetadata.js";
-export { ApiClient, type ApiClientOptions, type ApiClientRequestContext, type HttpClient } from "./apiClient.js";
+export {
+    ApiClient,
+    type ApiClientConstruction,
+    type ApiClientOptions,
+    type ApiClientRequestContext,
+    type HttpClient,
+} from "./apiClient.js";
 export { ApiClientError } from "./apiClientError.js";
-export type { AuthProvider, AccessToken, Credentials } from "./auth/authProvider.js";
+export { AuthProviderFactory } from "./auth/authProvider.js";
+export type { AuthProvider, AccessToken, Credentials, AuthProviderOptions } from "./auth/authProvider.js";
 export type { ClientCredentialsAuthOptions } from "./auth/clientCredentials.js";
 export { ClientCredentialsAuthProvider } from "./auth/clientCredentials.js";
 export type { paths, operations, ApiError } from "./openapi.js";

--- a/packages/atlas-telemetry/src/atlasTelemetry.test.ts
+++ b/packages/atlas-telemetry/src/atlasTelemetry.test.ts
@@ -1,4 +1,9 @@
-import { ApiClient, ApiClientError, userAgentFromServerMetadata } from "@mongodb-js/mcp-atlas-api-client";
+import {
+    ApiClient,
+    ApiClientError,
+    AuthProviderFactory,
+    userAgentFromServerMetadata,
+} from "@mongodb-js/mcp-atlas-api-client";
 import {
     AtlasTelemetry,
     nextBackoffMs,
@@ -682,21 +687,29 @@ describe("AtlasTelemetry credentials handling", () => {
         },
     ])("sends telemetry events $label", async ({ clientId, clientSecret, expectedPath, expectAuthHeader }) => {
         const logger = new NoopLogger();
-        const apiClient = new ApiClient(
+        const httpClient = {
+            fetch: globalThis.fetch.bind(globalThis),
+            Request: globalThis.Request,
+        };
+        const userAgent = userAgentFromServerMetadata(TEST_SERVER_METADATA);
+        const authProvider = AuthProviderFactory.create(
             {
-                baseUrl: API_BASE,
-                userAgent: userAgentFromServerMetadata(TEST_SERVER_METADATA),
-                credentials: {
-                    clientId,
-                    clientSecret,
-                },
-                httpClient: {
-                    fetch: globalThis.fetch.bind(globalThis),
-                    Request: globalThis.Request,
-                },
+                apiBaseUrl: API_BASE,
+                userAgent,
+                credentials: { clientId, clientSecret },
+                httpClient,
             },
             logger
         );
+        const apiClient = new ApiClient({
+            options: {
+                baseUrl: API_BASE,
+                userAgent,
+                httpClient,
+            },
+            logger,
+            authProvider,
+        });
 
         // When credentials are present, short-circuit the OAuth token fetch
         // so the test stays focused on the telemetry dispatch rather than the

--- a/packages/browser-tests/src/telemetry.test.ts
+++ b/packages/browser-tests/src/telemetry.test.ts
@@ -53,8 +53,8 @@ describe("Telemetry in browser environment", () => {
     it("can construct an ApiClient with an injected browser httpClient", () => {
         expect(
             () =>
-                new ApiClient(
-                    {
+                new ApiClient({
+                    options: {
                         baseUrl: API_BASE,
                         userAgent: "browser-test-agent/1.0.0",
                         httpClient: {
@@ -62,14 +62,14 @@ describe("Telemetry in browser environment", () => {
                             Request: globalThis.Request,
                         },
                     },
-                    new CompositeLogger()
-                )
+                    logger: new CompositeLogger(),
+                })
         ).not.toThrow();
     });
 
     it("initializes Telemetry and sends events via the browser fetch without throwing", async () => {
-        const apiClient = new ApiClient(
-            {
+        const apiClient = new ApiClient({
+            options: {
                 baseUrl: API_BASE,
                 userAgent: "browser-test-agent/1.0.0",
                 httpClient: {
@@ -77,8 +77,8 @@ describe("Telemetry in browser environment", () => {
                     Request: globalThis.Request,
                 },
             },
-            new CompositeLogger()
-        );
+            logger: new CompositeLogger(),
+        });
         expect(apiClient.isAuthConfigured()).toBe(false);
 
         const session = createMockSession(apiClient);

--- a/packages/cli/src/cliServer.ts
+++ b/packages/cli/src/cliServer.ts
@@ -95,7 +95,8 @@ export class CliServer<TMetrics extends DefaultMetricDefinitions = DefaultMetric
     public readonly apiClient: ApiClient;
     public readonly atlasLocalClient?: AtlasLocalClient;
     public readonly mcpServer: McpServer;
-    private readonly telemetry: AtlasTelemetry;
+    /** Telemetry for tracking tool/resource usage; read by resources off the server. */
+    public readonly telemetry: AtlasTelemetry;
     public readonly elicitation: Elicitation;
     private readonly toolConstructors: ToolRegistry;
     private readonly resourceConstructors: ResourceRegistry;
@@ -370,18 +371,7 @@ export class CliServer<TMetrics extends DefaultMetricDefinitions = DefaultMetric
 
     public registerResources(): void {
         for (const resourceConstructor of this.resourceConstructors) {
-            const resource = new resourceConstructor(
-                {
-                    config: this.config,
-                    logger: this.logger,
-                    keychain: this.keychain,
-                    connectionRegistry: this.connectionRegistry,
-                    exportsManager: this.exportsManager,
-                    apiClient: this.apiClient,
-                    atlasLocalClient: this.atlasLocalClient,
-                },
-                this.telemetry
-            );
+            const resource = new resourceConstructor({ server: this });
             resource.register(this);
         }
     }

--- a/packages/cli/src/cliServer.ts
+++ b/packages/cli/src/cliServer.ts
@@ -26,6 +26,15 @@ export type ResourceRegistry = readonly AnyResourceClass[];
 export interface CliServerOptions<TMetrics extends DefaultMetricDefinitions = DefaultMetricDefinitions> {
     /** The individually-injected services for this request-scoped server. There is no server-scoped "session" (or services) object: every service is constructed once per process (see `createAppServicesFromConfig`) and handed to the request-scoped server instance directly. MongoDB connection state lives in the app-level `connectionRegistry` and is addressed per request by `connectionId`; per-client identity travels on the tool request (`ToolExecutionContext.request.clientInfo`). */
     config: UserConfig;
+    /**
+     * Set when the app-fixed config has already been validated once at startup
+     * (see `validateAppConfig` in createServerServices). When true, `register()`
+     * skips re-validating the connection string / Atlas credentials — these
+     * fields cannot be overridden per request, so the result is identical and
+     * the (network) revalidation per request would be pure waste. Direct
+     * constructions default to `false` so validation still runs.
+     */
+    readonly configValidated?: boolean;
     logger: CompositeLogger;
     keychain: Keychain;
     connectionRegistry: ConnectionRegistry;
@@ -117,6 +126,9 @@ export class CliServer<TMetrics extends DefaultMetricDefinitions = DefaultMetric
     private readonly startTime: number;
     private readonly subscriptions = new Set<string>();
 
+    /** Whether the app-fixed config was already validated at startup. */
+    private readonly configValidated: boolean;
+
     /** Whether {@link register} has run (guards against repeated registration). */
     private registered = false;
 
@@ -144,8 +156,10 @@ export class CliServer<TMetrics extends DefaultMetricDefinitions = DefaultMetric
         uiRegistry,
         metrics,
         serverMetadata,
+        configValidated = false,
     }: CliServerOptions<TMetrics>) {
         this.startTime = Date.now();
+        this.configValidated = configValidated;
         this.config = config;
         this.logger = logger;
         this.keychain = keychain;
@@ -201,7 +215,14 @@ export class CliServer<TMetrics extends DefaultMetricDefinitions = DefaultMetric
     }
 
     private async doRegister(): Promise<void> {
-        await this.validateConfig();
+        // App-fixed config (connection string, Atlas credentials) is validated
+        // once at startup by `validateAppConfig` (createServerServices); these
+        // fields cannot be overridden per request, so per-request instances built
+        // from app services skip the (network) revalidation. Directly-constructed
+        // servers still validate here.
+        if (!this.configValidated) {
+            await this.validateConfig();
+        }
         this.registerResources();
         this.mcpServer.server.registerCapabilities({
             logging: {},

--- a/packages/cli/src/createApiClientFromConfig.test.ts
+++ b/packages/cli/src/createApiClientFromConfig.test.ts
@@ -53,7 +53,11 @@ describe("createApiClientFromConfig", () => {
         });
 
         expect(capturedApiClientArgs).toHaveLength(1);
-        const { options, logger: passedLogger, authProvider } = capturedApiClientArgs[0] as {
+        const {
+            options,
+            logger: passedLogger,
+            authProvider,
+        } = capturedApiClientArgs[0] as {
             options: {
                 baseUrl: string;
                 userAgent: string;

--- a/packages/cli/src/createApiClientFromConfig.test.ts
+++ b/packages/cli/src/createApiClientFromConfig.test.ts
@@ -2,15 +2,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CompositeLogger } from "@mongodb-js/mcp-core";
 import { UserConfigSchema } from "./config/userConfig.js";
 
-const { capturedApiClientArgs } = vi.hoisted(() => ({
-    capturedApiClientArgs: [] as unknown[],
-}));
+const { capturedApiClientArgs, mockAuthProviderFactoryCreate } = vi.hoisted(() => {
+    const mockAuthProviderFactoryCreate = vi.fn(
+        (options: { credentials?: { clientId?: string; clientSecret?: string } }) =>
+            options.credentials?.clientId && options.credentials.clientSecret
+                ? { credentials: options.credentials }
+                : undefined
+    );
+    return {
+        capturedApiClientArgs: [] as unknown[],
+        mockAuthProviderFactoryCreate,
+    };
+});
 
 vi.mock("@mongodb-js/mcp-atlas-api-client", () => ({
     ApiClient: class MockApiClient {
-        constructor(options: unknown) {
-            capturedApiClientArgs.push(options);
+        constructor(construction: unknown) {
+            capturedApiClientArgs.push(construction);
         }
+    },
+    AuthProviderFactory: {
+        create: mockAuthProviderFactoryCreate,
     },
     userAgentFromServerMetadata: (): string => "MongoDB MCP Server/1.2.3-test",
 }));
@@ -41,17 +53,22 @@ describe("createApiClientFromConfig", () => {
         });
 
         expect(capturedApiClientArgs).toHaveLength(1);
-        const options = capturedApiClientArgs[0] as {
-            baseUrl: string;
-            userAgent: string;
-            credentials: { clientId?: string; clientSecret?: string };
-            httpClient: { fetch: unknown; Request: unknown };
+        const { options, logger: passedLogger, authProvider } = capturedApiClientArgs[0] as {
+            options: {
+                baseUrl: string;
+                userAgent: string;
+                httpClient: { fetch: unknown; Request: unknown };
+            };
+            logger: unknown;
+            authProvider: unknown;
         };
         expect(options.baseUrl).toBe(config.apiBaseUrl);
         expect(options.userAgent).toBe("MongoDB MCP Server/1.2.3-test");
-        expect(options.credentials).toEqual({ clientId: undefined, clientSecret: undefined });
         expect(typeof options.httpClient.fetch).toBe("function");
         expect(options.httpClient.Request).toBeDefined();
+        expect(passedLogger).toBe(logger);
+        // No credentials configured → the client is unauthenticated.
+        expect(authProvider).toBeUndefined();
     });
 
     it("should pass configured credentials to ApiClient when they are set", () => {
@@ -69,14 +86,17 @@ describe("createApiClientFromConfig", () => {
         });
 
         expect(capturedApiClientArgs).toHaveLength(1);
-        const options = capturedApiClientArgs[0] as {
-            userAgent: string;
-            credentials: { clientId?: string; clientSecret?: string };
+        const { options, authProvider } = capturedApiClientArgs[0] as {
+            options: { userAgent: string };
+            authProvider: { credentials: { clientId?: string; clientSecret?: string } } | string;
         };
         expect(options.userAgent).toBe("MongoDB MCP Server/1.2.3-test");
-        expect(options.credentials).toEqual({
-            clientId: "test-client-id",
-            clientSecret: "test-client-secret",
+        // Credentials configured → a provider is built from them (not the sentinel).
+        expect(authProvider).toEqual({
+            credentials: {
+                clientId: "test-client-id",
+                clientSecret: "test-client-secret",
+            },
         });
     });
 });

--- a/packages/cli/src/createApiClientFromConfig.ts
+++ b/packages/cli/src/createApiClientFromConfig.ts
@@ -1,4 +1,9 @@
-import { ApiClient, type HttpClient, userAgentFromServerMetadata } from "@mongodb-js/mcp-atlas-api-client";
+import {
+    ApiClient,
+    AuthProviderFactory,
+    type HttpClient,
+    userAgentFromServerMetadata,
+} from "@mongodb-js/mcp-atlas-api-client";
 import { getDefaultHttpClient } from "@mongodb-js/mcp-fetch";
 import type { CompositeLogger } from "@mongodb-js/mcp-core";
 import type { ServerMetadata } from "@mongodb-js/mcp-types";
@@ -18,10 +23,11 @@ export function createApiClientFromConfig({
     // Shared, memoized proxy-aware fetch (see @mongodb-js/mcp-fetch).
     const httpClient: HttpClient = getDefaultHttpClient();
 
-    return new ApiClient(
+    const userAgent = userAgentFromServerMetadata(serverMetadata);
+    const authProvider = AuthProviderFactory.create(
         {
-            baseUrl: config.apiBaseUrl,
-            userAgent: userAgentFromServerMetadata(serverMetadata),
+            apiBaseUrl: config.apiBaseUrl,
+            userAgent,
             credentials: {
                 clientId: config.apiClientId,
                 clientSecret: config.apiClientSecret,
@@ -30,4 +36,14 @@ export function createApiClientFromConfig({
         },
         logger
     );
+
+    return new ApiClient({
+        options: {
+            baseUrl: config.apiBaseUrl,
+            userAgent,
+            httpClient,
+        },
+        logger,
+        authProvider,
+    });
 }

--- a/packages/cli/src/createServerServices.ts
+++ b/packages/cli/src/createServerServices.ts
@@ -1,5 +1,6 @@
 import { PrometheusMetrics, createDefaultMetrics } from "@mongodb-js/mcp-metrics";
-import { CompositeLogger, Elicitation, Keychain, McpServer, LogId } from "@mongodb-js/mcp-core";
+import type { CompositeLogger } from "@mongodb-js/mcp-core";
+import { Elicitation, Keychain, McpServer, LogId } from "@mongodb-js/mcp-core";
 import type { IMetrics, IDeviceId, ServerMetadata } from "@mongodb-js/mcp-types";
 import type { Client as AtlasLocalClient } from "@mongodb-js/atlas-local";
 import type { ResourceRegistry, ToolRegistry } from "./cliServer.js";

--- a/packages/cli/src/createServerServices.ts
+++ b/packages/cli/src/createServerServices.ts
@@ -1,6 +1,5 @@
 import { PrometheusMetrics, createDefaultMetrics } from "@mongodb-js/mcp-metrics";
-import type { CompositeLogger } from "@mongodb-js/mcp-core";
-import { Elicitation, Keychain, McpServer } from "@mongodb-js/mcp-core";
+import { CompositeLogger, Elicitation, Keychain, McpServer, LogId } from "@mongodb-js/mcp-core";
 import type { IMetrics, IDeviceId, ServerMetadata } from "@mongodb-js/mcp-types";
 import type { Client as AtlasLocalClient } from "@mongodb-js/atlas-local";
 import type { ResourceRegistry, ToolRegistry } from "./cliServer.js";
@@ -9,6 +8,7 @@ import {
     connectionErrorHandler,
     DeviceId,
     MCPConnectionStore,
+    validateConnectionString,
     type ConnectionRegistry,
 } from "@mongodb-js/mcp-tools-mongodb";
 import { createAtlasLocalClient } from "@mongodb-js/mcp-tools-atlas-local";
@@ -55,6 +55,72 @@ export type AppServices = {
     monitoringServer: ReturnType<typeof createMonitoringServerFromConfig>;
 };
 
+/**
+ * Validates the app-fixed config once at startup: the connection string and
+ * Atlas API credentials. These fields are `overrideBehavior: "not-allowed"`,
+ * so request-level overrides cannot change them — the validation result is the
+ * same for every request, which is why it runs here rather than per request.
+ */
+export async function validateAppConfig({
+    config,
+    logger,
+    apiClient,
+}: {
+    config: UserConfig;
+    logger: CompositeLogger;
+    apiClient: ApiClient;
+}): Promise<void> {
+    // Validate connection string
+    if (config.connectionString) {
+        try {
+            validateConnectionString(config.connectionString, false);
+        } catch (error) {
+            throw new Error(
+                "Connection string validation failed with error: " +
+                    (error instanceof Error ? error.message : String(error)),
+                { cause: error }
+            );
+        }
+    }
+
+    // Validate API client credentials
+    if (config.apiClientId && config.apiClientSecret) {
+        try {
+            try {
+                const apiBaseUrl = new URL(config.apiBaseUrl);
+                if (apiBaseUrl.protocol !== "https:") {
+                    // Log a warning, but don't error out. This is to allow for testing against local or non-HTTPS endpoints.
+                    const message = `apiBaseUrl is configured to use ${apiBaseUrl.protocol}, which is not secure. It is strongly recommended to use HTTPS for secure communication.`;
+                    logger.warning({
+                        id: LogId.atlasApiBaseUrlInsecure,
+                        context: "server",
+                        message,
+                    });
+                }
+            } catch (error) {
+                throw new Error(`Invalid apiBaseUrl: ${error instanceof Error ? error.message : String(error)}`, {
+                    cause: error,
+                });
+            }
+
+            await apiClient.validateAuthConfig();
+        } catch (error) {
+            if (config.connectionString === undefined) {
+                throw new Error(
+                    `Failed to connect to MongoDB Atlas instance using the credentials from the config: ${error instanceof Error ? error.message : String(error)}`,
+                    { cause: error }
+                );
+            }
+
+            logger.warning({
+                id: LogId.atlasCheckCredentials,
+                context: "server",
+                message: `Failed to validate MongoDB Atlas API client credentials from the config: ${error instanceof Error ? error.message : String(error)}. Continuing since a connection string is also provided.`,
+            });
+        }
+    }
+}
+
 /** Builds every app-level service once: metrics, monitoring, keychain, device id, connection store, API client, exports, telemetry, Atlas Local client. */
 export async function createAppServicesFromConfig(options: CreateServerServicesOptions): Promise<AppServices> {
     const { config, serverMetadata, logger } = options;
@@ -71,6 +137,10 @@ export async function createAppServicesFromConfig(options: CreateServerServicesO
 
     const exportsManager = createExportsManagerFromConfig({ config, logger });
     const apiClient = createApiClientFromConfig({ config, serverMetadata, logger });
+
+    // Validate app-fixed config once at startup (see {@link validateAppConfig}).
+    await validateAppConfig({ config, logger, apiClient });
+
     const telemetry = createTelemetryFromConfig({
         config,
         logger,
@@ -157,6 +227,9 @@ export function createServerFromConfig({
         tools,
         resources,
         serverMetadata,
+        // Validated once at startup by `validateAppConfig`; the per-request
+        // server must not re-run the (network) credential validation.
+        configValidated: true,
     });
 }
 

--- a/packages/cli/src/resources/common/config.test.ts
+++ b/packages/cli/src/resources/common/config.test.ts
@@ -25,8 +25,8 @@ describe("config resource", () => {
     function createResource(config: UserConfig): ConfigResource {
         const connectionRegistry = new MCPConnectionStore({ options: config, logger, deviceId }).view();
         const keychain = new Keychain();
-        const apiClient = new ApiClient(
-            {
+        const apiClient = new ApiClient({
+            options: {
                 baseUrl: config.apiBaseUrl,
                 userAgent: userAgentFromServerMetadata(testServerMetadata),
                 httpClient: {
@@ -34,8 +34,8 @@ describe("config resource", () => {
                     Request: globalThis.Request,
                 },
             },
-            logger
-        );
+            logger,
+        });
         const telemetry = AtlasTelemetry.create({
             logger,
             deviceId,

--- a/packages/cli/src/resources/common/config.test.ts
+++ b/packages/cli/src/resources/common/config.test.ts
@@ -3,7 +3,7 @@ import { ConfigResource } from "./config.js";
 import { CompositeLogger, Keychain } from "@mongodb-js/mcp-core";
 import { AtlasTelemetry } from "@mongodb-js/mcp-atlas-telemetry";
 import { ApiClient, userAgentFromServerMetadata } from "@mongodb-js/mcp-atlas-api-client";
-import { UserConfigSchema, type UserConfig } from "@mongodb-js/mcp-cli";
+import { UserConfigSchema, type UserConfig, type CliServer } from "@mongodb-js/mcp-cli";
 import { DeviceId, MCPConnectionStore } from "@mongodb-js/mcp-tools-mongodb";
 
 const defaultTestConfig: UserConfig = {
@@ -44,15 +44,15 @@ describe("config resource", () => {
             enabled: false,
             serverMetadata: testServerMetadata,
         });
-        return new ConfigResource(
-            {
+        return new ConfigResource({
+            server: {
                 config,
                 logger,
                 keychain,
+                telemetry,
                 connectionRegistry,
-            },
-            telemetry
-        );
+            } as unknown as CliServer,
+        });
     }
 
     it("should not leak AWS KMS credentials in connectOptions", () => {
@@ -94,7 +94,7 @@ describe("config resource", () => {
 
         const resource = createResource(config);
         // Register a secret that would otherwise appear in the output (logPath).
-        resource["keychain"].register(config.logPath, "url");
+        (resource as unknown as { server: { keychain: Keychain } }).server.keychain.register(config.logPath, "url");
 
         const output = resource.toOutput();
         expect(output).not.toContain(config.logPath);

--- a/packages/cli/src/resources/common/config.ts
+++ b/packages/cli/src/resources/common/config.ts
@@ -1,7 +1,5 @@
 import { ReactiveResource, Keychain, redactValues } from "@mongodb-js/mcp-core";
-import type { ITelemetry } from "@mongodb-js/mcp-types";
-import type { UserConfig, CliServer, ResourceServices } from "@mongodb-js/mcp-cli";
-import type { ConnectionRegistry } from "@mongodb-js/mcp-tools-mongodb";
+import type { UserConfig, CliServer } from "@mongodb-js/mcp-cli";
 import { generateConnectionInfoFromCliArgs } from "@mongosh/arg-parser";
 import { connectCapableTools } from "@mongodb-js/mcp-tools-mongodb";
 
@@ -18,13 +16,8 @@ function redactDriverOptions(driverOptions: Record<string, unknown>): Record<str
     return { ...rest, autoEncryption: "set; client-side field level encryption is configured" };
 }
 
-export type ConfigResourceServices = Omit<ResourceServices, "config"> & {
-    config: UserConfig;
-    connectionRegistry: ConnectionRegistry;
-};
-
-export class ConfigResource extends ReactiveResource<UserConfig, ConfigResourceServices, CliServer> {
-    constructor(services: ConfigResourceServices, telemetry: ITelemetry) {
+export class ConfigResource extends ReactiveResource<UserConfig, CliServer> {
+    constructor({ server }: { server: CliServer }) {
         super({
             resourceConfiguration: {
                 name: "config",
@@ -35,10 +28,9 @@ export class ConfigResource extends ReactiveResource<UserConfig, ConfigResourceS
                 },
             },
             options: {
-                initial: { ...services.config },
+                initial: { ...server.config },
             },
-            services,
-            telemetry,
+            server,
         });
     }
 
@@ -59,18 +51,17 @@ export class ConfigResource extends ReactiveResource<UserConfig, ConfigResourceS
 
         // Backstop: redact any remaining registered secrets (keychain) before egress, matching
         // the redaction applied on every logging path. Redact per-value so JSON stays valid.
-        const secrets = [...this.keychain.allSecrets, ...Keychain.root.allSecrets];
+        const secrets = [...this.server.keychain.allSecrets, ...Keychain.root.allSecrets];
         return JSON.stringify(redactValues(result, secrets));
     }
 
     /**
-     * The host server surface the resource can read tool state from. At runtime
-     * resources are registered by {@link CliServer} (see `registerResources`),
-     * which carries the registered tools alongside the `IResourceServer`
-     * contract (mcpServer + change notifications).
+     * The host server surface the resource can read tool state from. The server
+     * carries the registered tools alongside the `IResourceServer` contract
+     * (mcpServer + change notifications).
      */
     private connectToolsGuidance(): string {
-        const connectToolNames = connectCapableTools(this.server?.tools ?? [])
+        const connectToolNames = connectCapableTools(this.server.tools)
             .map((tool) => `"${tool.name}"`)
             .join(", ");
         return connectToolNames

--- a/packages/cli/src/resources/common/debug.test.ts
+++ b/packages/cli/src/resources/common/debug.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DebugResource, type DebugResourceServices } from "./debug.js";
+import { DebugResource } from "./debug.js";
 import { CompositeLogger, Keychain } from "@mongodb-js/mcp-core";
 import { AtlasTelemetry } from "@mongodb-js/mcp-atlas-telemetry";
 import { ApiClient, userAgentFromServerMetadata } from "@mongodb-js/mcp-atlas-api-client";
-import { UserConfigSchema, type UserConfig } from "@mongodb-js/mcp-cli";
+import { UserConfigSchema, type UserConfig, type CliServer } from "@mongodb-js/mcp-cli";
 import {
     PRECONFIGURED_CONNECTION_ID,
     DeviceId,
@@ -30,7 +30,6 @@ describe("debug resource", () => {
     const deviceId = DeviceId.create(logger);
 
     let managers: FakeConnectionManager[];
-    let services: DebugResourceServices;
     let registry: ConnectionRegistry;
     let debugResource: DebugResource;
 
@@ -71,13 +70,16 @@ describe("debug resource", () => {
             serverMetadata: testServerMetadata,
         });
 
-        services = {
-            config,
-            logger,
-            keychain,
-            connectionRegistry: registry,
-        };
-        debugResource = new DebugResource(services, telemetry);
+        debugResource = new DebugResource({
+            server: {
+                config,
+                logger,
+                keychain,
+                telemetry,
+                connectionRegistry: registry,
+                tools: [],
+            } as unknown as CliServer,
+        });
     }
 
     beforeEach(() => {
@@ -97,7 +99,10 @@ describe("debug resource", () => {
             },
             { name: "find", category: "mongodb", operationType: "read", isEnabled: (): boolean => true },
         ];
-        (debugResource as unknown as { server: { tools: typeof fakeTools } }).server = { tools: fakeTools };
+        (debugResource as unknown as { server: { tools: typeof fakeTools; connectionRegistry: ConnectionRegistry } }).server = {
+            tools: fakeTools,
+            connectionRegistry: registry,
+        };
 
         const output = await debugResource.toOutput();
 

--- a/packages/cli/src/resources/common/debug.test.ts
+++ b/packages/cli/src/resources/common/debug.test.ts
@@ -50,8 +50,8 @@ describe("debug resource", () => {
         }).view();
 
         const keychain = new Keychain();
-        const apiClient = new ApiClient(
-            {
+        const apiClient = new ApiClient({
+            options: {
                 baseUrl: config.apiBaseUrl,
                 userAgent: userAgentFromServerMetadata(testServerMetadata),
                 httpClient: {
@@ -59,8 +59,8 @@ describe("debug resource", () => {
                     Request: globalThis.Request,
                 },
             },
-            logger
-        );
+            logger,
+        });
 
         const telemetry = AtlasTelemetry.create({
             logger,

--- a/packages/cli/src/resources/common/debug.ts
+++ b/packages/cli/src/resources/common/debug.ts
@@ -37,7 +37,7 @@ export class DebugResource extends ReactiveResource<undefined, CliServer> {
             const summary = summarizeConnection(entry);
             let line = `- "${summary.connectionId}" (${summary.state}): ${summary.description}`;
             if (summary.state === "connected") {
-                const searchIndexesSupported = await entry.isSearchSupported(this.server.logger as never);
+                const searchIndexesSupported = await entry.isSearchSupported(this.server.logger);
                 line += searchIndexesSupported
                     ? " Search indexes are supported."
                     : " Search indexes are not supported.";

--- a/packages/cli/src/resources/common/debug.ts
+++ b/packages/cli/src/resources/common/debug.ts
@@ -1,17 +1,9 @@
 import { ReactiveResource, formatUntrustedData } from "@mongodb-js/mcp-core";
-import type { ITelemetry } from "@mongodb-js/mcp-types";
 import { connectCapableTools, summarizeConnection } from "@mongodb-js/mcp-tools-mongodb";
-import type { CliServer, ResourceServices } from "@mongodb-js/mcp-cli";
-import type { ConnectionRegistry } from "@mongodb-js/mcp-tools-mongodb";
+import type { CliServer } from "@mongodb-js/mcp-cli";
 
-export type DebugResourceServices = ResourceServices & {
-    connectionRegistry: ConnectionRegistry;
-};
-
-export class DebugResource extends ReactiveResource<undefined, DebugResourceServices, CliServer> {
-    protected readonly connectionRegistry: ConnectionRegistry;
-
-    constructor(services: DebugResourceServices, telemetry: ITelemetry) {
+export class DebugResource extends ReactiveResource<undefined, CliServer> {
+    constructor({ server }: { server: CliServer }) {
         super({
             resourceConfiguration: {
                 name: "debug-mongodb",
@@ -24,16 +16,14 @@ export class DebugResource extends ReactiveResource<undefined, DebugResourceServ
             options: {
                 initial: undefined,
             },
-            services,
-            telemetry,
+            server,
         });
-        this.connectionRegistry = services.connectionRegistry;
     }
 
     async toOutput(): Promise<string> {
-        const entries = await this.connectionRegistry.find(() => true);
+        const entries = await this.server.connectionRegistry.find(() => true);
         if (entries.length === 0) {
-            const connectToolNames = connectCapableTools(this.server?.tools ?? [])
+            const connectToolNames = connectCapableTools(this.server.tools)
                 .map((tool) => `"${tool.name}"`)
                 .join(", ");
             if (!connectToolNames) {
@@ -47,7 +37,7 @@ export class DebugResource extends ReactiveResource<undefined, DebugResourceServ
             const summary = summarizeConnection(entry);
             let line = `- "${summary.connectionId}" (${summary.state}): ${summary.description}`;
             if (summary.state === "connected") {
-                const searchIndexesSupported = await entry.isSearchSupported(this.logger as never);
+                const searchIndexesSupported = await entry.isSearchSupported(this.server.logger as never);
                 line += searchIndexesSupported
                     ? " Search indexes are supported."
                     : " Search indexes are not supported.";

--- a/packages/cli/src/resources/common/exportedData.ts
+++ b/packages/cli/src/resources/common/exportedData.ts
@@ -1,28 +1,17 @@
 import { ResourceTemplate } from "@modelcontextprotocol/server";
 import type { CompleteResourceTemplateCallback, ListResourcesCallback, ReadResourceTemplateCallback } from "@modelcontextprotocol/server";
 import { LogId } from "@mongodb-js/mcp-core";
-import type { CliServer, ResourceServices } from "@mongodb-js/mcp-cli";
-import type { ICompositeLogger } from "@mongodb-js/mcp-types";
-import type { ExportsManager } from "@mongodb-js/mcp-tools-mongodb";
+import type { CliServer } from "@mongodb-js/mcp-cli";
 import { formatUntrustedData } from "@mongodb-js/mcp-core";
-
-export type ExportedDataServices = ResourceServices & {
-    exportsManager: ExportsManager;
-};
 
 export class ExportedData {
     private readonly name = "exported-data";
     private readonly description = "Data files exported through the export tool.";
     private readonly uri = "exported-data://{exportName}";
-    private server?: CliServer;
-    private readonly logger: ICompositeLogger;
-    private readonly exportsManager: ExportsManager;
-    private readonly keychain: ResourceServices["keychain"];
+    private server: CliServer;
 
-    constructor(services: ExportedDataServices) {
-        this.logger = services.logger;
-        this.exportsManager = services.exportsManager;
-        this.keychain = services.keychain;
+    constructor({ server }: { server: CliServer }) {
+        this.server = server;
     }
 
     public register(server: CliServer): void {
@@ -45,19 +34,19 @@ export class ExportedData {
             { description: this.description },
             this.readResourceCallback
         );
-        this.exportsManager.on("export-available", (uri: string): void => {
-            server.sendResourceListChanged();
-            server.sendResourceUpdated(uri);
+        this.server.exportsManager.on("export-available", (uri: string): void => {
+            this.server.sendResourceListChanged();
+            this.server.sendResourceUpdated(uri);
         });
-        this.exportsManager.on("export-expired", (): void => {
-            server.sendResourceListChanged();
+        this.server.exportsManager.on("export-expired", (): void => {
+            this.server.sendResourceListChanged();
         });
     }
 
     private listResourcesCallback: ListResourcesCallback = () => {
         try {
             return {
-                resources: this.exportsManager.availableExports.map(
+                resources: this.server.exportsManager.availableExports.map(
                     ({ exportName, exportTitle, exportURI }) => ({
                         name: exportName,
                         description: exportTitle,
@@ -67,7 +56,7 @@ export class ExportedData {
                 ),
             };
         } catch (error) {
-            this.logger.error({
+            this.server.logger.error({
                 id: LogId.exportedDataListError,
                 context: "Error when listing exported data resources",
                 message: error instanceof Error ? error.message : String(error),
@@ -80,7 +69,7 @@ export class ExportedData {
 
     private autoCompleteExportName: CompleteResourceTemplateCallback = (value) => {
         try {
-            return this.exportsManager.availableExports
+            return this.server.exportsManager.availableExports
                 .filter(({ exportName, exportTitle }) => {
                     const lcExportName = exportName.toLowerCase();
                     const lcExportTitle = exportTitle.toLowerCase();
@@ -89,7 +78,7 @@ export class ExportedData {
                 })
                 .map(({ exportName }) => exportName);
         } catch (error) {
-            this.logger.error({
+            this.server.logger.error({
                 id: LogId.exportedDataAutoCompleteError,
                 context: "Error when autocompleting exported data",
                 message: error instanceof Error ? error.message : String(error),
@@ -104,7 +93,7 @@ export class ExportedData {
                 throw new Error("Cannot retrieve exported data, exportName not provided.");
             }
 
-            const { content, docsTransformed } = await this.exportsManager.readExport(exportName);
+            const { content, docsTransformed } = await this.server.exportsManager.readExport(exportName);
 
             const text = formatUntrustedData(`The exported data contains ${docsTransformed} documents.`, content)
                 .map((t) => t.text)

--- a/packages/core/src/reactiveResource.ts
+++ b/packages/core/src/reactiveResource.ts
@@ -1,8 +1,4 @@
-import type {
-    ReactiveResourceOptions,
-    ResourceConfiguration,
-    IResourceServer,
-} from "@mongodb-js/mcp-types";
+import type { ReactiveResourceOptions, ResourceConfiguration, IResourceServer } from "@mongodb-js/mcp-types";
 import type { ReadResourceCallback, ResourceMetadata } from "@modelcontextprotocol/server";
 
 /**

--- a/packages/core/src/reactiveResource.ts
+++ b/packages/core/src/reactiveResource.ts
@@ -1,25 +1,23 @@
 import type {
-    ResourceServices,
-    ITelemetry,
     ReactiveResourceOptions,
     ResourceConfiguration,
     IResourceServer,
 } from "@mongodb-js/mcp-types";
 import type { ReadResourceCallback, ResourceMetadata } from "@modelcontextprotocol/server";
-import {} from "./logId.js";
 
 /**
  * Abstract base class for implementing MCP resources.
  *
- * Resources are constructed by the host server with `(services, telemetry)`
- * (see the CLI's `registerResources`), which the base class receives as
- * constructor options. The resolved user configuration is read from
- * `services.config`.
+ * Resources are constructed by the host server with `({ server })`
+ * (see the CLI's `registerResources`). The server is the composition: resources
+ * read whatever they need (config, logger, keychain, telemetry, and any
+ * host-specific extras such as the connection registry) off the server itself,
+ * rather than copy services into discrete fields at construction.
  *
  * @example Basic Custom Resource
  * ```typescript
  * class MyResource extends ReactiveResource<string> {
- *   constructor(services: ResourceServices, telemetry: ITelemetry) {
+ *   constructor({ server }: { server: MyServer }) {
  *     super({
  *       resourceConfiguration: {
  *         name: "my-resource",
@@ -29,13 +27,12 @@ import {} from "./logId.js";
  *       options: {
  *         initial: "disconnected",
  *       },
- *       services,
- *       telemetry,
+ *       server,
  *     });
  *   }
  *
  *   toOutput(): string {
- *     return this.current;
+ *     return this.server.config.logLevel;
  *   }
  * }
  * ```
@@ -43,15 +40,10 @@ import {} from "./logId.js";
 export abstract class ReactiveResource<
     /** Value stored in the resource */
     Value,
-    TServices extends ResourceServices = ResourceServices,
     TServer extends IResourceServer = IResourceServer,
 > {
-    protected server?: TServer;
-    /** The individually-injected services, stored as discrete fields (no server-scoped session object). */
-    protected readonly config: TServices["config"];
-    protected readonly logger: TServices["logger"];
-    protected readonly keychain: TServices["keychain"];
-    protected telemetry: ITelemetry;
+    /** The host server this resource registers against and reads services from. */
+    protected server: TServer;
 
     protected current: Value;
     protected readonly name: string;
@@ -61,20 +53,15 @@ export abstract class ReactiveResource<
     constructor({
         resourceConfiguration,
         options,
-        services,
-        telemetry,
+        server,
         current,
     }: {
         resourceConfiguration: ResourceConfiguration;
         options: ReactiveResourceOptions<Value>;
-        services: TServices;
-        telemetry: ITelemetry;
+        server: TServer;
         current?: Value;
     }) {
-        this.config = services.config;
-        this.logger = services.logger;
-        this.keychain = services.keychain;
-        this.telemetry = telemetry;
+        this.server = server;
 
         this.name = resourceConfiguration.name;
         this.uri = resourceConfiguration.uri;

--- a/packages/integration-tests/src/integrationHelpers.ts
+++ b/packages/integration-tests/src/integrationHelpers.ts
@@ -17,7 +17,12 @@ import type { MockClientCapabilities, createMockElicitInput } from "@mongodb-js/
 import { createAtlasLocalClient } from "mongodb-mcp-server";
 import type { AnyToolClass } from "@mongodb-js/mcp-core";
 import type { AnyResourceClass, OperationType, ServerMetadata } from "@mongodb-js/mcp-types";
-import { ApiClient, type HttpClient, userAgentFromServerMetadata } from "@mongodb-js/mcp-atlas-api-client";
+import {
+    ApiClient,
+    AuthProviderFactory,
+    type HttpClient,
+    userAgentFromServerMetadata,
+} from "@mongodb-js/mcp-atlas-api-client";
 import { MockMetrics, sleep } from "@mongodb-js/mcp-test-utils";
 export { sleep };
 import { AtlasTelemetry } from "@mongodb-js/mcp-atlas-telemetry";
@@ -43,18 +48,26 @@ export function createTestApiClient(options: CreateTestApiClientOptions): ApiCli
         Request: globalThis.Request,
     };
 
-    return new ApiClient(
+    const userAgent = userAgentFromServerMetadata(serverMetadata);
+    const authProvider = AuthProviderFactory.create(
         {
-            baseUrl,
-            userAgent: userAgentFromServerMetadata(serverMetadata),
-            credentials: {
-                clientId,
-                clientSecret,
-            },
+            apiBaseUrl: baseUrl,
+            userAgent,
+            credentials: { clientId, clientSecret },
             httpClient,
         },
         logger
     );
+
+    return new ApiClient({
+        options: {
+            baseUrl,
+            userAgent,
+            httpClient,
+        },
+        logger,
+        authProvider,
+    });
 }
 
 /** Driver product labels for tests; mirrors root `serverMetadata`. */

--- a/packages/scripts/src/cleanupAtlasTestLeftovers.test.ts
+++ b/packages/scripts/src/cleanupAtlasTestLeftovers.test.ts
@@ -1,8 +1,9 @@
 import {
     ApiClient,
-    userAgentFromServerMetadata,
+    AuthProviderFactory,
     type Group,
     type AtlasOrganization,
+    userAgentFromServerMetadata,
 } from "@mongodb-js/mcp-atlas-api-client";
 import { ConsoleLogger } from "@mongodb-js/mcp-logging";
 import { Keychain } from "@mongodb-js/mcp-core";
@@ -147,21 +148,29 @@ async function main(): Promise<void> {
     const logger = new ConsoleLogger({ keychain: Keychain.root });
     const clientId = process.env.MDB_MCP_API_CLIENT_ID || "";
     const clientSecret = process.env.MDB_MCP_API_CLIENT_SECRET || "";
-    const apiClient = new ApiClient(
+    const httpClient = {
+        fetch: globalThis.fetch.bind(globalThis),
+        Request: globalThis.Request,
+    };
+    const userAgent = userAgentFromServerMetadata(testServerMetadata);
+    const authProvider = AuthProviderFactory.create(
         {
-            baseUrl,
-            userAgent: userAgentFromServerMetadata(testServerMetadata),
-            credentials: {
-                clientId,
-                clientSecret,
-            },
-            httpClient: {
-                fetch: globalThis.fetch.bind(globalThis),
-                Request: globalThis.Request,
-            },
+            apiBaseUrl: baseUrl,
+            userAgent,
+            credentials: { clientId, clientSecret },
+            httpClient,
         },
         logger
     );
+    const apiClient = new ApiClient({
+        options: {
+            baseUrl,
+            userAgent,
+            httpClient,
+        },
+        logger,
+        authProvider,
+    });
 
     const testOrg = await findTestOrganization(apiClient);
     if (!testOrg.id) {

--- a/packages/setup/src/setupTelemetry.ts
+++ b/packages/setup/src/setupTelemetry.ts
@@ -68,14 +68,16 @@ export class SetupTelemetry {
         const deviceId = DeviceId.create(logger);
         // Shared, memoized proxy-aware fetch (see @mongodb-js/mcp-fetch).
         const httpClient: HttpClient = getDefaultHttpClient();
-        const apiClient = new ApiClient(
-            {
+        // Anonymous telemetry setup: no Atlas API credentials, so the client is
+        // unauthenticated (telemetry is sent over the unauth endpoint).
+        const apiClient = new ApiClient({
+            options: {
                 baseUrl: config.apiBaseUrl,
                 userAgent: userAgentFromServerMetadata(serverMetadata),
                 httpClient,
             },
-            logger
-        );
+            logger,
+        });
         const telemetry = AtlasTelemetry.create({
             logger,
             deviceId,

--- a/packages/types/src/resources.ts
+++ b/packages/types/src/resources.ts
@@ -5,11 +5,12 @@ import type { ICompositeLogger } from "./logging.js";
 import type { IKeychain } from "./keychain.js";
 
 /**
- * The minimal services resources receive at construction, injected
- * individually (no server-scoped \"session\" object exists). The server is
- * deliberately stateless (connection state lives in the app-level registry),
- * so resources receive only the specific services they need; host-specific
- * extras (e.g. the connection registry) are added by the resource type.
+ * The minimal services resources read off the host server at construction,
+ * injected individually (no server-scoped "session" object exists). The server
+ * is deliberately stateless (connection state lives in the app-level registry),
+ * so resources read only the specific services they need from the server;
+ * host-specific extras (e.g. the connection registry) are read directly off
+ * the concrete server type by the resource implementation.
  */
 export type ResourceServices = {
     readonly config: IToolConfig;
@@ -34,8 +35,16 @@ export type ReactiveResourceOptions<Value> = {
     initial: Value;
 };
 
-/** The host server surface resources register against. */
+/**
+ * The host server surface resources register against and read services from.
+ * Resources are constructed with the server itself (`{ server }`) and derive
+ * the minimal services (config/logger/keychain) plus telemetry from it.
+ */
 export interface IResourceServer {
+    readonly config: ResourceServices["config"];
+    readonly logger: ResourceServices["logger"];
+    readonly keychain: ResourceServices["keychain"];
+    readonly telemetry: ITelemetry;
     mcpServer: {
         registerResource: (name: string, uri: string, config: ResourceMetadata, callback: ReadResourceCallback) => void;
     };
@@ -43,19 +52,24 @@ export interface IResourceServer {
     sendResourceUpdated(uri: string): void;
 }
 
+/** The construction argument every resource class receives: the host server. */
+export type ResourceServerArg<TServer extends IResourceServer = IResourceServer> = {
+    server: TServer;
+};
+
 /**
  * The type that all resource classes must conform to when implementing custom resources
  * for the MongoDB MCP Server.
  *
  * This type enforces that resource classes have a constructor accepting
- * `(services, telemetry)`, matching the construction pattern used by
+ * `({ server })`, matching the construction pattern used by
  * {@link CliServer} (see `registerResources`). The resolved user
- * configuration is read from `services.config`.
+ * configuration is read from `server.config`.
  */
-export type ResourceClass<TServices extends ResourceServices = ResourceServices> = {
-    new (services: TServices, telemetry: ITelemetry): { register(server: IResourceServer): void };
+export type ResourceClass<TServer extends IResourceServer = IResourceServer> = {
+    new (arg: ResourceServerArg<TServer>): { register(server: IResourceServer): void };
 };
 
-/** Resource constructor type for registries that may include resource-specific services. */
+/** Resource constructor type for registries that may include resource-specific servers. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyResourceClass = ResourceClass<any>;


### PR DESCRIPTION
Second slice: single-arg `ApiClient` constructor, resources constructed with (`{ server }`) reading services off the server, and startup-only app-config validation — the app-level shared services that per-request servers reference but never own.

Part 2 of the session-removal stack (#1474); builds on part 1 (#1477), continues in part 3.