### PR TITLE
refactor: read effective config off request.server + lint/api sweep (part 4/4)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 dist
 node_modules
+.pi/
 *.lock
 resources/
 packages/ui/src/lib/tools/*

--- a/api-extractor/reports/core.public.api.md
+++ b/api-extractor/reports/core.public.api.md
@@ -44,6 +44,7 @@ import { ToolAnnotations } from '@modelcontextprotocol/server';
 import type { ToolCategory } from '@mongodb-js/mcp-types';
 import type { ToolExecutionContext } from '@mongodb-js/mcp-types';
 import type { ToolServer } from '@mongodb-js/mcp-types';
+import type { ToolServices } from '@mongodb-js/mcp-types';
 import type { Transport } from '@modelcontextprotocol/server';
 import type { TransportType } from '@mongodb-js/mcp-types';
 import { z } from 'zod';
@@ -448,7 +449,7 @@ export type ToolResult<OutputSchema extends ZodRawShape | undefined = undefined>
 export type ToolServerParam<TServer extends ToolServer = ToolServer> = TServer;
 
 // @public
-export function toToolExecutionContext<TConfig extends IToolConfig = IToolConfig>(ctx: ServerContext, config: TConfig, clientInfoProvider?: () => Implementation | undefined): ToolExecutionContext<TConfig>;
+export function toToolExecutionContext<TConfig extends IToolConfig = IToolConfig>(ctx: ServerContext, server: ToolServer<ToolServices<TConfig>>, clientInfoProvider?: () => Implementation | undefined): ToolExecutionContext<TConfig>;
 
 // @public
 export const TRANSPORT_PAYLOAD_LIMITS: Record<TransportType, number>;

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -606,6 +606,7 @@ export const ErrorCodes: {
     readonly ForbiddenServerSideJS: 1000009;
     readonly UnknownConnectionId: 1000010;
     readonly ConfirmationDeclined: 1000011;
+    readonly InvalidArgument: 1000012;
 };
 
 // @public

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -606,7 +606,6 @@ export const ErrorCodes: {
     readonly ForbiddenServerSideJS: 1000009;
     readonly UnknownConnectionId: 1000010;
     readonly ConfirmationDeclined: 1000011;
-    readonly InvalidArgument: 1000012;
 };
 
 // @public
@@ -1045,7 +1044,7 @@ export type ToolExecutionContext<TConfig extends IToolConfig = IToolConfig> = {
 
 // @public
 export type ToolRequest<TConfig extends IToolConfig = IToolConfig> = {
-    readonly config: TConfig;
+    readonly server: ToolServer<ToolServices<TConfig>>;
     readonly raw?: ServerContext["mcpReq"];
     signal: AbortSignal;
     headers?: Record<string, unknown>;

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -1071,9 +1071,9 @@ export const CreateDBUserArgs: {
     password: z.ZodOptional<z.ZodString>;
     roles: z.ZodArray<z.ZodObject<{
         roleName: z.ZodUnion<readonly [z.ZodEnum<{
+            backup: "backup";
             read: "read";
             atlasAdmin: "atlasAdmin";
-            backup: "backup";
             clusterMonitor: "clusterMonitor";
             dbAdmin: "dbAdmin";
             dbAdminAnyDatabase: "dbAdminAnyDatabase";
@@ -1097,9 +1097,9 @@ export class CreateDBUserTool extends AtlasToolBase {
         password: z.ZodOptional<z.ZodString>;
         roles: z.ZodArray<z.ZodObject<{
             roleName: z.ZodUnion<readonly [z.ZodEnum<{
+                backup: "backup";
                 read: "read";
                 atlasAdmin: "atlasAdmin";
-                backup: "backup";
                 clusterMonitor: "clusterMonitor";
                 dbAdmin: "dbAdmin";
                 dbAdminAnyDatabase: "dbAdminAnyDatabase";
@@ -1535,7 +1535,6 @@ export const ErrorCodes: {
     readonly ForbiddenServerSideJS: 1000009;
     readonly UnknownConnectionId: 1000010;
     readonly ConfirmationDeclined: 1000011;
-    readonly InvalidArgument: 1000012;
 };
 
 // @public (undocumented)
@@ -2953,8 +2952,8 @@ export class StreamsDiscoverTool extends StreamsToolBase {
             state: z.ZodOptional<z.ZodString>;
         }, z.core.$strip>>>;
         connection: z.ZodOptional<z.ZodObject<{
-            state: z.ZodOptional<z.ZodString>;
             type: z.ZodOptional<z.ZodString>;
+            state: z.ZodOptional<z.ZodString>;
             region: z.ZodOptional<z.ZodString>;
             clusterName: z.ZodOptional<z.ZodString>;
             bootstrapServers: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>]>>;
@@ -3227,7 +3226,7 @@ export type ToolExecutionContext<TConfig extends IToolConfig = IToolConfig> = {
 
 // @public
 export type ToolRequest<TConfig extends IToolConfig = IToolConfig> = {
-    readonly config: TConfig;
+    readonly server: ToolServer<ToolServices<TConfig>>;
     readonly raw?: ServerContext["mcpReq"];
     signal: AbortSignal;
     headers?: Record<string, unknown>;
@@ -3292,7 +3291,6 @@ export class UpgradeClusterTool extends AtlasToolBase {
         projectId: z.ZodString;
         clusterName: z.ZodString;
         targetTier: z.ZodOptional<z.ZodEnum<{
-            FLEX: "FLEX";
             M10: "M10";
             M20: "M20";
             M30: "M30";
@@ -3300,6 +3298,7 @@ export class UpgradeClusterTool extends AtlasToolBase {
             M50: "M50";
             M60: "M60";
             M80: "M80";
+            FLEX: "FLEX";
         }>>;
         computeAutoScaling: z.ZodOptional<z.ZodBoolean>;
         minInstanceSize: z.ZodOptional<z.ZodEnum<{
@@ -3336,18 +3335,17 @@ export class UpgradeClusterTool extends AtlasToolBase {
     // (undocumented)
     outputSchema: {
         originalTier: z.ZodEnum<{
+            M10: "M10";
+            M20: "M20";
+            M30: "M30";
+            M40: "M40";
+            M50: "M50";
+            M60: "M60";
+            M80: "M80";
             FREE: "FREE";
             FLEX: "FLEX";
-            M10: "M10";
-            M20: "M20";
-            M30: "M30";
-            M40: "M40";
-            M50: "M50";
-            M60: "M60";
-            M80: "M80";
         }>;
         targetTier: z.ZodEnum<{
-            FLEX: "FLEX";
             M10: "M10";
             M20: "M20";
             M30: "M30";
@@ -3355,6 +3353,7 @@ export class UpgradeClusterTool extends AtlasToolBase {
             M50: "M50";
             M60: "M60";
             M80: "M80";
+            FLEX: "FLEX";
         }>;
         computeAutoScaling: z.ZodOptional<z.ZodBoolean>;
         minInstanceSize: z.ZodOptional<z.ZodString>;

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -1071,9 +1071,9 @@ export const CreateDBUserArgs: {
     password: z.ZodOptional<z.ZodString>;
     roles: z.ZodArray<z.ZodObject<{
         roleName: z.ZodUnion<readonly [z.ZodEnum<{
-            backup: "backup";
             read: "read";
             atlasAdmin: "atlasAdmin";
+            backup: "backup";
             clusterMonitor: "clusterMonitor";
             dbAdmin: "dbAdmin";
             dbAdminAnyDatabase: "dbAdminAnyDatabase";
@@ -1097,9 +1097,9 @@ export class CreateDBUserTool extends AtlasToolBase {
         password: z.ZodOptional<z.ZodString>;
         roles: z.ZodArray<z.ZodObject<{
             roleName: z.ZodUnion<readonly [z.ZodEnum<{
-                backup: "backup";
                 read: "read";
                 atlasAdmin: "atlasAdmin";
+                backup: "backup";
                 clusterMonitor: "clusterMonitor";
                 dbAdmin: "dbAdmin";
                 dbAdminAnyDatabase: "dbAdminAnyDatabase";
@@ -1206,8 +1206,8 @@ export class CreateIndexTool extends MongoDBToolBase {
                     dotProduct: "dotProduct";
                 }>>;
                 quantization: z.ZodDefault<z.ZodEnum<{
-                    none: "none";
                     binary: "binary";
+                    none: "none";
                     scalar: "scalar";
                 }>>;
             }, z.core.$strict>, z.ZodObject<{
@@ -1535,6 +1535,7 @@ export const ErrorCodes: {
     readonly ForbiddenServerSideJS: 1000009;
     readonly UnknownConnectionId: 1000010;
     readonly ConfirmationDeclined: 1000011;
+    readonly InvalidArgument: 1000012;
 };
 
 // @public (undocumented)
@@ -1612,8 +1613,8 @@ export class ExplainTool extends MongoDBToolBase {
         explainResult: z.ZodRecord<z.ZodString, z.ZodUnknown>;
         method: z.ZodEnum<{
             find: "find";
-            count: "count";
             aggregate: "aggregate";
+            count: "count";
         }>;
         verbosity: z.ZodEnum<{
             queryPlanner: "queryPlanner";
@@ -2952,8 +2953,8 @@ export class StreamsDiscoverTool extends StreamsToolBase {
             state: z.ZodOptional<z.ZodString>;
         }, z.core.$strip>>>;
         connection: z.ZodOptional<z.ZodObject<{
-            type: z.ZodOptional<z.ZodString>;
             state: z.ZodOptional<z.ZodString>;
+            type: z.ZodOptional<z.ZodString>;
             region: z.ZodOptional<z.ZodString>;
             clusterName: z.ZodOptional<z.ZodString>;
             bootstrapServers: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>]>>;
@@ -3291,6 +3292,7 @@ export class UpgradeClusterTool extends AtlasToolBase {
         projectId: z.ZodString;
         clusterName: z.ZodString;
         targetTier: z.ZodOptional<z.ZodEnum<{
+            FLEX: "FLEX";
             M10: "M10";
             M20: "M20";
             M30: "M30";
@@ -3298,7 +3300,6 @@ export class UpgradeClusterTool extends AtlasToolBase {
             M50: "M50";
             M60: "M60";
             M80: "M80";
-            FLEX: "FLEX";
         }>>;
         computeAutoScaling: z.ZodOptional<z.ZodBoolean>;
         minInstanceSize: z.ZodOptional<z.ZodEnum<{
@@ -3335,17 +3336,8 @@ export class UpgradeClusterTool extends AtlasToolBase {
     // (undocumented)
     outputSchema: {
         originalTier: z.ZodEnum<{
-            M10: "M10";
-            M20: "M20";
-            M30: "M30";
-            M40: "M40";
-            M50: "M50";
-            M60: "M60";
-            M80: "M80";
             FREE: "FREE";
             FLEX: "FLEX";
-        }>;
-        targetTier: z.ZodEnum<{
             M10: "M10";
             M20: "M20";
             M30: "M30";
@@ -3353,7 +3345,16 @@ export class UpgradeClusterTool extends AtlasToolBase {
             M50: "M50";
             M60: "M60";
             M80: "M80";
+        }>;
+        targetTier: z.ZodEnum<{
             FLEX: "FLEX";
+            M10: "M10";
+            M20: "M20";
+            M30: "M30";
+            M40: "M40";
+            M50: "M50";
+            M60: "M60";
+            M80: "M80";
         }>;
         computeAutoScaling: z.ZodOptional<z.ZodBoolean>;
         minInstanceSize: z.ZodOptional<z.ZodString>;

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -820,7 +820,7 @@ export type ToolExecutionContext<TConfig extends IToolConfig = IToolConfig> = {
 
 // @public
 export type ToolRequest<TConfig extends IToolConfig = IToolConfig> = {
-    readonly config: TConfig;
+    readonly server: ToolServer<ToolServices<TConfig>>;
     readonly raw?: ServerContext["mcpReq"];
     signal: AbortSignal;
     headers?: Record<string, unknown>;

--- a/docs/plans/remove-session-concept.md
+++ b/docs/plans/remove-session-concept.md
@@ -175,7 +175,7 @@ Concretely:
   never owns, them.
 - **Done — startup-only config validation**: `validateAppConfig` runs once at
   startup (connection string + Atlas credentials are `overrideBehavior:
-  "not-allowed"`, so the result is identical for every request); per-request
+"not-allowed"`, so the result is identical for every request); per-request
   servers are built with `configValidated: true` and skip the network
   revalidation.
 - **Done — amortized schema building**: `ToolBase` caches input/output schemas

--- a/docs/plans/remove-session-concept.md
+++ b/docs/plans/remove-session-concept.md
@@ -1,7 +1,11 @@
 # Plan: Remove "Session" as a Concept from the MCP Server
 
 > Branch: `refactor/remove-session-concept` (based on `chore/protocol-revision-2026-07-28`)
-> Status: **Plan only — no implementation yet.**
+> Status: **In progress.** Phases 0–1 (session removal, request-centric tool context) and
+> Phase 3A (client-identity connection scoping, including authenticated multi-tenant mode)
+> have landed. Phase 2 has partially landed: `AppServices` (shared once per process) and
+> startup-only config validation are in; the per-request target is now a **minimal** server
+> because the SDK's HTTP entry mandates a fresh `McpServer` per request (see Phase 2).
 
 ## 1. Goal
 
@@ -55,9 +59,13 @@ These are what "removing sessions" actually has to solve:
    `CliServer` → fresh registry view scoped to a random UUID (when
    `connectionScope: "session"`, the default). A `connect` in request N is invisible to
    request N+1. Only `connectionScope: "global"` works today.
-2. **Per-request server construction is expensive and wasteful**: fresh `McpServer`,
-   fresh `CompositeLogger`, fresh `AtlasTelemetry`, fresh exports directory (each request
-   mints a new `ObjectId` exports dir), fresh `Elicitation`.
+2. **Per-request server construction is redundant (now mostly shared)**: the SDK's HTTP
+   entry forces a fresh `McpServer` per request (see Phase 2), but the rest of what a
+   request used to build fresh — `CompositeLogger`, `AtlasTelemetry`, exports directory
+   (each request minted a new `ObjectId` dir), `Elicitation` onboarding — is now shared
+   via `AppServices`. What remains per request: `McpServer` + `Elicitation` (bound to the
+   instance) + `CliServer` + tool instantiation/registration, which Phase 2 trims and
+   amortizes.
 3. **Exports directory lifecycle is tied to `Session.close()`**; with a per-request
    server this either leaks per-request dirs or deletes exports the client might still
    be downloading on a subsequent request.
@@ -74,15 +82,20 @@ These are what "removing sessions" actually has to solve:
 App-level (built once at startup, shared, immutable config):
   UserConfig, Metrics, CompositeLogger (root), Keychain (root),
   MCPConnectionStore, ApiClient, ExportsManager (app-rooted),
-  AtlasLocalClient, DeviceId, MonitoringServer, Elicitation factory,
-  a single McpServer (+ CliServer facade) with tools registered once.
+  AtlasLocalClient, DeviceId, MonitoringServer, AtlasTelemetry.
+  (No McpServer — the SDK's HTTP entry requires a fresh instance per request,
+  so the app level holds only heavy services; see Phase 2.)
 
 Request-scoped (derived per request, never stored):
+  the minimal per-request server: fresh McpServer + Elicitation + CliServer,
+  tool instantiation/registration, and a client-scoped ConnectionRegistry view
+  (keyed by client identity).
   ToolRequest (carried as ToolExecutionContext.request):
-    { config (effective, request-overridden), raw (SDK mcpReq), signal, id,
-      headers, _meta, sendNotification, inputResponses, clientInfo,
-      elicitationDurationMs }                                   (landed)
-  + client-scoped ConnectionRegistry view (keyed by client identity)
+    { server (the request-scoped CliServer: config/logger/keychain/...),
+      raw (SDK mcpReq), signal, id, headers, _meta, sendNotification,
+      inputResponses, clientInfo, elicitationDurationMs }         (landed)
+    `config` is removed from the envelope — the effective, request-overridden
+    config is read as `server.config`.                              (landed)
 ```
 
 Concretely:
@@ -128,31 +141,66 @@ Concretely:
   (flattened from the old `requestInfo.headers`), `_meta`, `inputResponses`,
   `sendNotification`, `clientInfo`, `elicitationDurationMs`. `ApiClientRequestContext`
   mirrors the flattening (`headers` at top level) so a `ToolRequest` is passed
-  straight to Atlas API calls. Tools read `request.config` instead of
-  `this.server.config` at execute time; registration-time config reads
+  straight to Atlas API calls. **Done — config lives on the request-scoped server:**
+  since every server is request-scoped, the effective config belongs on the
+  per-request server: `ToolRequest` now carries `server`, execute-time reads use
+  `request.server.config`, and `request.config` is removed from the envelope (no
+  alias, no getter). `toToolExecutionContext` receives the server (not the config);
+  tools read config off `request.server`. Registration-time config reads
   (`verifyAllowed`, `toolMeta`, description, `schemaVariantKey`, argShape) stay on
-  `server.config`.
+  `this.server.config` — the same instance, so they are request-correct too. Tool
+  bodies that access the server heavily can keep using `this.server` as a shortcut:
+  it is the same object as `request.server`.
 - Update the 3 tools that read `session.mcpClient` to read from the context.
 - Update `IToolSession` doc/types accordingly (it already only requires
   `config`/`logger`/`keychain`).
 
-### Phase 2 — App-level services construction
+### Phase 2 — Minimal per-request server over shared app services
 
-- Collapse `createSharedServicesFromConfig` + `createServerFromConfig`
-  (`packages/cli/src/createServerServices.ts`) into a single `createAppServices(config)`
-  built once at startup.
-- Build `McpServer`, `CompositeLogger`, `AtlasTelemetry`, `Elicitation`, `ExportsManager`
-  **once**; register tools once.
-- Stdio runner: already one server per process — minimal change.
-- HTTP: `createServerForRequest` stops building servers per request; instead it only
-  applies config overrides (headers/query) into a **request-scoped effective config**
-  and resolves the client-scoped registry view.
+> **SDK constraint (why the original "one shared McpServer" Phase 2 is impossible):**
+> the 2026-07-28 serving entry `createMcpHandler` calls the server factory **once per
+> HTTP request** (and per stdio connection, plus a discarded probe instance for
+> `server/discover`), and the `McpServer` it returns is connection-scoped:
+> `connect()` owns exactly one transport, and `oninitialized`, capability negotiation,
+> `getClientVersion()`, the request-handler map and the subscription set are all
+> per-instance state. A shared, pre-registered `McpServer` therefore cannot serve
+> requests. Phase 2 is about making the mandatory per-request instance **minimal**,
+> not eliminating it.
 
-> Note: per-request config overrides currently produce a _new server_ because tools bake
-> `config` at construction. Decide: either (a) make tool config access request-aware
-> (read effective config from the execution context), or (b) restrict HTTP overrides to
-> only affect request-safe fields. This is the trickiest structural change in Phase 2 —
-> see Limitations.
+- **Done — `AppServices`**: `createAppServicesFromConfig` (collapsed from
+  `createSharedServicesFromConfig` + `createServerFromConfig`) builds every heavy
+  dependency once per process — root logger, metrics, monitoring, `Keychain`,
+  device id, `MCPConnectionStore`, `ApiClient`, `ExportsManager`,
+  `AtlasTelemetry`, Atlas Local client — and each request's server references,
+  never owns, them.
+- **Done — startup-only config validation**: `validateAppConfig` runs once at
+  startup (connection string + Atlas credentials are `overrideBehavior:
+  "not-allowed"`, so the result is identical for every request); per-request
+  servers are built with `configValidated: true` and skip the network
+  revalidation.
+- **Done — amortized schema building**: `ToolBase` caches input/output schemas
+  in static `WeakMap`s keyed by tool class and config `schemaVariantKey`, so
+  per-request `registerTool` calls reuse the same zod schema objects.
+- Remaining per-request cost (the "minimal server"): fresh `McpServer` +
+  `Elicitation` (binds to the instance's `Server`) + `CliServer` + tool
+  instantiation/registration. Trim further by precomputing per-tool JSON schemas
+  once — the SDK re-converts zod → JSON Schema on every instance — and by keeping
+  tool construction dependency-light.
+- HTTP: `createServerForRequest` keeps building the minimal instance per request
+  from `applyConfigOverrides` + a client-scoped registry view.
+- Stdio runner: already one server per connection — no change.
+
+> **Config access (landed design)**: because every server is request-scoped by SDK
+> mandate, the effective config (base + header/query overrides) lives on the
+> per-request server, not on a base-config-bound shared instance. The single read
+> path is `request.server.config` — the request envelope carries the request-scoped
+> server (`request.server`), and there is **no `request.config` alias or getter**.
+> In tool bodies that access the server heavily, `this.server` (the
+> construction-time instance) is a valid shortcut: it is the same object as
+> `request.server` in the per-request world. Registration-time reads
+> (`verifyAllowed`, `toolMeta`, description, `schemaVariantKey`, argShape) stay on
+> `this.server.config` — same instance, same effective config, so they are
+> request-correct too.
 
 ### Phase 3 — Connection ownership without sessions (decision required)
 
@@ -247,13 +295,14 @@ Options (pick one — recommend **A**):
    itself a lightweight form of state (a lookup key, though not a server-side session
    object). If no identity is available, the fallback is global/shared connections
    (security posture change, §5 Phase 3B).
-3. **Per-request config overrides vs. shared server instance**: execute-time config
-   reads now travel on the request (`request.config`), so a shared server no longer
-   needs rebuilding per request for those. Registration-time reads (`verifyAllowed`,
-   `toolMeta`, tool `description`, `schemaVariantKey`) still consume `server.config`
-   and remain base-config-bound until the request-aware registration is designed
-   (tool enablement flags like `disabledTools`/read-only would have to be enforced at
-   invoke time on a shared instance).
+3. **No shared-server config problem (superseded)**: the original concern — execute-time
+   config reads must travel on the request so a shared server needn't be rebuilt — is
+   moot because the SDK mandates a fresh server per HTTP request anyway. The effective
+   config travels on the per-request server, read as `request.server.config`, and
+   registration-time reads are request-correct too (same instance). The residual
+   trade-off is purely cost: each request re-instantiates tools and re-registers them
+   on the fresh `McpServer`; Phase 2 amortizes it (static schema caches, shared
+   `AppServices`, no re-validation).
 4. **Performance reality check**: the current modern path is _worse_ than stateless —
    it rebuilds the entire server per request (telemetry clients, exports dirs, logger).
    The plan fixes this, but until Phase 2 lands, HTTP-per-request is expensive.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "@modelcontextprotocol/core": "^2.0.0",
-    "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
     "@mongodb-js/mcp-fetch": "workspace:*",
     "@mongodb-js/mcp-core": "workspace:*",

--- a/packages/core/src/toolBase.ts
+++ b/packages/core/src/toolBase.ts
@@ -40,11 +40,10 @@ import { redact } from "mongodb-redact";
  * and the HTTP request under `ctx.http` (see the SDK's v1 → v2 migration
  * guide).
  *
- * @param config The effective configuration for this request. Passed through
- * to the execution context as `request.config` — the server holds no
- * per-request state, so the effective (possibly request-overridden) config
- * travels with the call instead of being baked onto any server-scoped
- * object.
+ * @param server The request-scoped server this request was built around.
+ * Carried on the execution context as `request.server` — the server is
+ * constructed fresh per request, so it already holds the effective
+ * (possibly request-overridden) config, read as `request.server.config`.
  * @param clientInfoProvider Optional source of the client identity negotiated
  * (or envelope-declared) for the request's server instance. The server holds
  * no per-client state, so the identity is carried on the execution context
@@ -52,7 +51,7 @@ import { redact } from "mongodb-redact";
  */
 export function toToolExecutionContext<TConfig extends IToolConfig = IToolConfig>(
     ctx: ServerContext,
-    config: TConfig,
+    server: ToolServer<ToolServices<TConfig>>,
     clientInfoProvider?: () => Implementation | undefined
 ): ToolExecutionContext<TConfig> {
     const headers: Record<string, unknown> = Object.fromEntries(ctx.http?.req?.headers ?? []);
@@ -61,7 +60,7 @@ export function toToolExecutionContext<TConfig extends IToolConfig = IToolConfig
     const mcpReq = (ctx as Partial<ServerContext>).mcpReq;
     return {
         request: {
-            config,
+            server,
             // raw is the original per-request `mcpReq` (id, method, _meta,
             // envelope, signal, ...) this request was built around.
             raw: mcpReq,
@@ -254,10 +253,10 @@ export type AnyToolClass = Omit<ToolClass<any, any>, "new"> & {
  * ## Protected Members Available to Subclasses
  *
  * - `server` - The server this tool reads its app-level services from
- *   (logger, keychain, telemetry, metrics, ...)
- * - `server.config` - The base server configuration (`IToolConfig`); the
- *   effective per-request config travels on the request object
- *   (`request.config`) instead
+ *   (logger, keychain, telemetry, metrics, ...). Every server is
+ *   request-scoped (the SDK constructs a fresh one per HTTP request), so
+ *   `server.config` already holds the effective per-request config — read it
+ *   directly, or via `request.server.config` on the execution context.
  * - `server.telemetry` - Telemetry service for tracking usage
  * - `server.elicitation` - Service for requesting user confirmations
  *
@@ -774,15 +773,16 @@ export abstract class ToolBase<
                     annotations: this.annotations,
                     _meta: this.toolMeta,
                 },
-                // The effective config and client identity are carried on the
-                // request rather than baked onto any server-scoped object: the
-                // config is the effective (possibly request-overridden) config
-                // for this request, and the identity is merged in here. Both
-                // travel to the tool on the execution context.
+                // The request-scoped server and client identity are carried on
+                // the request rather than baked onto any server-scoped object:
+                // the server is the effective (possibly request-overridden)
+                // per-request server for this call (config read as
+                // `request.server.config`), and the identity is merged in here.
+                // Both travel to the tool on the execution context.
                 (args, ctx) =>
                     this.invoke(
                         args,
-                        toToolExecutionContext(ctx, this.server.config, () =>
+                        toToolExecutionContext(ctx, this.server, () =>
                             server.mcpServer?.server?.getClientVersion()
                         )
                     )

--- a/packages/core/src/toolBase.ts
+++ b/packages/core/src/toolBase.ts
@@ -618,7 +618,7 @@ export abstract class ToolBase<
      * Multi-round-trip elicitation (protocol revision 2026-07-28): on the
      * first entry this reads `context.request.inputResponses` and, when this
      * round carries no answer yet, returns `undefined` — the caller must
-     * return {@link IElicitation.confirmationRequired} from its handler
+     * return `IElicitation.confirmationRequired` from its handler
      * instead of proceeding. On re-entry it resolves to `true` when the user
      * accepted and `false` when they declined.
      *
@@ -634,7 +634,7 @@ export abstract class ToolBase<
      * object under `request`).
      * @returns `true` when confirmed, `false` when declined, `undefined` when
      * this round carries no answer yet (return
-     * {@link IElicitation.confirmationRequired} instead).
+     * `IElicitation.confirmationRequired` instead).
      */
     protected requestConfirmation(message: string, context: ToolExecutionContext): boolean | undefined {
         const confirmed = this.server.elicitation.readConfirmation(context.request.inputResponses);
@@ -782,9 +782,7 @@ export abstract class ToolBase<
                 (args, ctx) =>
                     this.invoke(
                         args,
-                        toToolExecutionContext(ctx, this.server, () =>
-                            server.mcpServer?.server?.getClientVersion()
-                        )
+                        toToolExecutionContext(ctx, this.server, () => server.mcpServer?.server?.getClientVersion())
                     )
             );
 

--- a/packages/core/src/toolBase.ts
+++ b/packages/core/src/toolBase.ts
@@ -15,6 +15,7 @@ import type {
     ConnectionMetadata,
     TelemetryToolMetadata,
     ToolEvent,
+    ToolServices,
     ToolServer,
     PreviewFeature,
     DefaultMetricDefinitions,

--- a/packages/core/src/toolExecutionContext.test.ts
+++ b/packages/core/src/toolExecutionContext.test.ts
@@ -14,8 +14,20 @@ const config: IToolConfig = {
 
 const server: ToolServer = { config, logger: loggerStub(), keychain: { allSecrets: [] } } as ToolServer;
 
-function loggerStub() {
-    return { debug: () => {}, info: () => {}, warning: () => {}, error: () => {}, log: () => {} };
+function loggerStub(): {
+    debug: () => void;
+    info: () => void;
+    warning: () => void;
+    error: () => void;
+    log: () => void;
+} {
+    return {
+        debug: (): void => {},
+        info: (): void => {},
+        warning: (): void => {},
+        error: (): void => {},
+        log: (): void => {},
+    };
 }
 
 function makeCtx(overrides: Partial<ServerContext> = {}): ServerContext {

--- a/packages/core/src/toolExecutionContext.test.ts
+++ b/packages/core/src/toolExecutionContext.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { toToolExecutionContext } from "./toolBase.js";
 import type { ServerContext } from "@modelcontextprotocol/server";
-import type { IToolConfig } from "@mongodb-js/mcp-types";
+import type { IToolConfig, ToolServer } from "@mongodb-js/mcp-types";
 
 const config: IToolConfig = {
     transport: "stdio",
@@ -11,6 +11,12 @@ const config: IToolConfig = {
     confirmationRequiredTools: [],
     previewFeatures: [],
 };
+
+const server: ToolServer = { config, logger: loggerStub(), keychain: { allSecrets: [] } } as ToolServer;
+
+function loggerStub() {
+    return { debug: () => {}, info: () => {}, warning: () => {}, error: () => {}, log: () => {} };
+}
 
 function makeCtx(overrides: Partial<ServerContext> = {}): ServerContext {
     return {
@@ -22,16 +28,17 @@ function makeCtx(overrides: Partial<ServerContext> = {}): ServerContext {
 }
 
 describe("toToolExecutionContext", () => {
-    it("carries the effective config on the request object", () => {
+    it("carries the request-scoped server on the request object (config = server.config)", () => {
         const ctx = makeCtx({ mcpReq: {} as never });
-        const result = toToolExecutionContext(ctx, config);
-        expect(result.request.config).toBe(config);
+        const result = toToolExecutionContext(ctx, server);
+        expect(result.request.server).toBe(server);
+        expect(result.request.server.config).toBe(config);
     });
 
     it("exposes the raw mcpReq the request was built around", () => {
         const mcpReq = { id: 7, method: "tools/call" } as never;
         const ctx = makeCtx({ mcpReq });
-        const result = toToolExecutionContext(ctx, config);
+        const result = toToolExecutionContext(ctx, server);
         expect(result.request.raw).toBe(mcpReq);
         expect(result.request.id).toBe(7);
     });
@@ -47,7 +54,7 @@ describe("toToolExecutionContext", () => {
                 notify,
             } as never,
         });
-        const result = toToolExecutionContext(ctx, config);
+        const result = toToolExecutionContext(ctx, server);
         expect(result.request.signal).toBe(signal);
         expect(result.request._meta).toEqual({ progressToken: 1 });
         expect(result.request.inputResponses).toEqual({ confirm: { value: true } });
@@ -60,18 +67,18 @@ describe("toToolExecutionContext", () => {
             http: { req: { headers } } as never,
             mcpReq: {} as never,
         });
-        const result = toToolExecutionContext(ctx, config);
+        const result = toToolExecutionContext(ctx, server);
         expect(result.request.headers?.["x-request-id"]).toBe("req-1");
     });
 
     it("has no headers when not served over HTTP", () => {
         const ctx = makeCtx({ mcpReq: {} as never });
-        const result = toToolExecutionContext(ctx, config);
+        const result = toToolExecutionContext(ctx, server);
         expect(result.request.headers).toBeUndefined();
     });
 
     it("falls back to a fresh signal and no id for partial contexts (direct invocation)", () => {
-        const result = toToolExecutionContext({} as ServerContext, config);
+        const result = toToolExecutionContext({} as ServerContext, server);
         expect(result.request.id).toBeUndefined();
         expect(result.request.signal).toBeInstanceOf(AbortSignal);
         expect(result.request.raw).toBeUndefined();
@@ -79,7 +86,7 @@ describe("toToolExecutionContext", () => {
 
     it("normalizes client info from the provider", () => {
         const ctx = makeCtx({ mcpReq: {} as never });
-        const result = toToolExecutionContext(ctx, config, () => ({ name: "my-client", version: "1.0.0" }));
+        const result = toToolExecutionContext(ctx, server, () => ({ name: "my-client", version: "1.0.0" }));
         expect(result.request.clientInfo).toEqual({ name: "my-client", version: "1.0.0", title: "unknown" });
     });
 });

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -35,7 +35,6 @@
     "@mongodb-js/mcp-cli": "workspace:*",
     "@mongodb-js/mcp-ui": "workspace:*",
     "@modelcontextprotocol/client": "^2.0.0",
-    "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
     "@mongosh/service-provider-node-driver": "^5.0.2",
     "mongodb": "^7.1.1",

--- a/packages/integration-tests/src/integrationHelpers.ts
+++ b/packages/integration-tests/src/integrationHelpers.ts
@@ -109,11 +109,12 @@ const RESOURCE_CHANGED_NOTIFICATION_TIMEOUT_MS = 30_000;
 /**
  * No-op kept for call-site compatibility.
  *
- * The request-centric design delivers config to tools through
- * `ToolExecutionContext.request.config`, which is built from the server's
- * effective config for every call. Tests that mutate `mcpServer().config`
- * (e.g. readOnly / disabledTools) see those mutations on the next tool call
- * automatically, so no per-tool config syncing is needed.
+ * The request-centric design delivers config to tools through the
+ * request-scoped server (`ToolExecutionContext.request.server.config`), which
+ * is constructed from the server's effective config for every call. Tests
+ * that mutate `mcpServer().config` (e.g. readOnly / disabledTools) see those
+ * mutations on the next tool call automatically, so no per-tool config
+ * syncing is needed.
  */
 export function syncMongoToolsConfigFromUserConfig(_mcpServer: CliServer): void {
     void _mcpServer;

--- a/packages/integration-tests/src/toolBase.test.ts
+++ b/packages/integration-tests/src/toolBase.test.ts
@@ -13,7 +13,7 @@ import type { CallToolResult, ToolAnnotations } from "@modelcontextprotocol/serv
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MockToolCallback = (args: any, ctx: never) => Promise<CallToolResult>;
 import type { CliServer, UserConfig } from "@mongodb-js/mcp-cli";
-import type {} from "@mongodb-js/mcp-types";
+import type { IToolConfig, ToolServices } from "@mongodb-js/mcp-types";
 import type { AtlasTelemetry } from "@mongodb-js/mcp-atlas-telemetry";
 import type { ToolBase } from "@mongodb-js/mcp-core";
 import type { Elicitation } from "@mongodb-js/mcp-core";
@@ -83,7 +83,7 @@ describe("ToolBase", () => {
             elicitation: mockElicitation,
             metrics: mockMetrics,
             uiRegistry: new UIRegistry(),
-        };
+        } as unknown as TestServer;
 
         testTool = new TestTool(mockServer);
     });
@@ -92,10 +92,7 @@ describe("ToolBase", () => {
         it("does not ask when the tool is not in the confirmationRequiredTools list", async () => {
             mockConfig.confirmationRequiredTools = ["other-tool", "another-tool"];
 
-            const result = await testTool["invoke"](
-                { param1: "test" },
-                { request: { config: mockConfig, signal: new AbortController().signal } }
-            );
+            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
 
             expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
             expect(mockReadConfirmation).not.toHaveBeenCalled();
@@ -104,10 +101,7 @@ describe("ToolBase", () => {
         it("does not ask when the confirmationRequiredTools list is empty", async () => {
             mockConfig.confirmationRequiredTools = [];
 
-            const result = await testTool["invoke"](
-                { param1: "test" },
-                { request: { config: mockConfig, signal: new AbortController().signal } }
-            );
+            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
 
             expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
             expect(mockReadConfirmation).not.toHaveBeenCalled();
@@ -119,10 +113,7 @@ describe("ToolBase", () => {
             const expected = { resultType: "input_required", inputRequests: {} };
             mockConfirmationRequired.mockReturnValue(expected as never);
 
-            const result = await testTool["invoke"](
-                { param1: "test", param2: 42 },
-                { request: { config: mockConfig, signal: new AbortController().signal } }
-            );
+            const result = await testTool["invoke"]({ param1: "test", param2: 42 }, { request: { server: mockServer, signal: new AbortController().signal } });
 
             expect(result).toEqual(expected);
             expect(mockReadConfirmation).toHaveBeenCalledTimes(1);
@@ -138,13 +129,7 @@ describe("ToolBase", () => {
 
             const result = await testTool["invoke"](
                 { param1: "test", param2: 42 },
-                {
-                    request: {
-                        config: mockConfig,
-                        signal: new AbortController().signal,
-                        inputResponses: { confirmation: {} },
-                    },
-                }
+                { request: { server: mockServer, signal: new AbortController().signal, inputResponses: { confirmation: {} } } }
             );
 
             expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
@@ -155,10 +140,7 @@ describe("ToolBase", () => {
             mockConfig.confirmationRequiredTools = ["test-tool"];
             mockReadConfirmation.mockReturnValue(false);
 
-            const result = await testTool["invoke"](
-                { param1: "test" },
-                { request: { config: mockConfig, signal: new AbortController().signal } }
-            );
+            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
 
             expect(result.isError).toBe(true);
 
@@ -180,10 +162,7 @@ describe("ToolBase", () => {
             mockConfig.confirmationRequiredTools = ["test-tool"];
             mockReadConfirmation.mockReturnValue(false);
 
-            const result = await testTool["invoke"](
-                { param1: "test" },
-                { request: { config: mockConfig, signal: new AbortController().signal } }
-            );
+            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
 
             expect(result.isError).toBe(true);
             expect(result.content).toEqual([
@@ -201,7 +180,7 @@ describe("ToolBase", () => {
             mockReadConfirmation.mockReturnValue(true);
 
             const context: ToolExecutionContext = {
-                request: { config: mockConfig, signal: new AbortController().signal, id: 7 },
+                request: { server: mockServer, signal: new AbortController().signal, id: 7 },
             };
             const result = testTool["requestConfirmation"]("Custom message", context);
 
@@ -213,7 +192,7 @@ describe("ToolBase", () => {
             mockReadConfirmation.mockReturnValue(undefined);
             const context: ToolExecutionContext = {
                 request: {
-                    config: mockConfig,
+                    server: mockServer,
                     signal: new AbortController().signal,
                     id: 42,
                     inputResponses: { confirmation: { action: "accept", content: { confirmation: "Yes" } } },
@@ -234,10 +213,7 @@ describe("ToolBase", () => {
         it("runs the operation when the user confirms", async () => {
             mockReadConfirmation.mockReturnValue(true);
 
-            const result = await createConfirmingTool()["invoke"](
-                {},
-                { request: { config: mockConfig, signal: new AbortController().signal } }
-            );
+            const result = await createConfirmingTool()["invoke"]({}, { request: { server: mockServer, signal: new AbortController().signal } });
 
             expect(result.isError).toBeUndefined();
             expect(result.content).toEqual([{ type: "text", text: "executed" }]);
@@ -246,10 +222,7 @@ describe("ToolBase", () => {
         it("aborts the operation when the user declines", async () => {
             mockReadConfirmation.mockReturnValue(false);
 
-            const result = await createConfirmingTool()["invoke"](
-                {},
-                { request: { config: mockConfig, signal: new AbortController().signal } }
-            );
+            const result = await createConfirmingTool()["invoke"]({}, { request: { server: mockServer, signal: new AbortController().signal } });
 
             expect(result.isError).toBe(true);
             expect(result.content).toEqual([{ type: "text", text: "The operation was not performed." }]);
@@ -260,10 +233,7 @@ describe("ToolBase", () => {
             try {
                 mockReadConfirmation.mockReturnValue(true);
 
-                const result = await createConfirmingTool()["invoke"](
-                    {},
-                    { request: { config: mockConfig, signal: new AbortController().signal } }
-                );
+                const result = await createConfirmingTool()["invoke"]({}, { request: { server: mockServer, signal: new AbortController().signal } });
                 expect(result.content).toEqual([{ type: "text", text: "executed" }]);
             } finally {
                 vi.useRealTimers();
@@ -538,7 +508,8 @@ describe("ToolBase", () => {
                 mockConfig,
                 mockAtlasTelemetry,
                 mockElicitation,
-                mockUIRegistry
+                mockUIRegistry,
+                mockMetrics
             );
             (mockUIRegistry.get as Mock).mockReturnValue("<html>test UI</html>");
 
@@ -684,14 +655,10 @@ describe("ToolBase", () => {
 
     describe("invoke logging", () => {
         const contextWithRequestId: ToolExecutionContext = {
-            request: {
-                config: mockConfig,
-                signal: new AbortController().signal,
-                headers: { "x-request-id": "req-test-123" },
-            },
+            request: { server: mockServer, signal: new AbortController().signal, headers: { "x-request-id": "req-test-123" } },
         };
         const contextWithoutRequestId: ToolExecutionContext = {
-            request: { config: mockConfig, signal: new AbortController().signal },
+            request: { server: mockServer, signal: new AbortController().signal },
         };
 
         it("includes x-request-id in debug logs when context carries it", async () => {
@@ -720,7 +687,7 @@ describe("ToolBase", () => {
             );
         });
 
-        it("omits x-request-id from log attributes when context has no requestInfo", async () => {
+        it("omits x-request-id from log attributes when context carries no headers", async () => {
             await testTool["invoke"]({ param1: "test" }, contextWithoutRequestId);
 
             for (const [payload] of (mockLogger.debug as Mock).mock.calls) {
@@ -847,7 +814,8 @@ function createToolWithoutStructuredContent(
     mockConfig: UserConfig,
     mockAtlasTelemetry: AtlasTelemetry,
     mockElicitation: Elicitation,
-    mockUIRegistry: UIRegistry
+    mockUIRegistry: UIRegistry,
+    mockMetrics: MockMetrics
 ): TestToolWithoutStructuredContent {
     mockConfig.previewFeatures = previewFeatures;
     return new TestToolWithoutStructuredContent({

--- a/packages/integration-tests/src/toolBase.test.ts
+++ b/packages/integration-tests/src/toolBase.test.ts
@@ -13,7 +13,6 @@ import type { CallToolResult, ToolAnnotations } from "@modelcontextprotocol/serv
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MockToolCallback = (args: any, ctx: never) => Promise<CallToolResult>;
 import type { CliServer, UserConfig } from "@mongodb-js/mcp-cli";
-import type { IToolConfig, ToolServices } from "@mongodb-js/mcp-types";
 import type { AtlasTelemetry } from "@mongodb-js/mcp-atlas-telemetry";
 import type { ToolBase } from "@mongodb-js/mcp-core";
 import type { Elicitation } from "@mongodb-js/mcp-core";
@@ -83,7 +82,7 @@ describe("ToolBase", () => {
             elicitation: mockElicitation,
             metrics: mockMetrics,
             uiRegistry: new UIRegistry(),
-        } as unknown as TestServer;
+        };
 
         testTool = new TestTool(mockServer);
     });
@@ -92,7 +91,10 @@ describe("ToolBase", () => {
         it("does not ask when the tool is not in the confirmationRequiredTools list", async () => {
             mockConfig.confirmationRequiredTools = ["other-tool", "another-tool"];
 
-            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await testTool["invoke"](
+                { param1: "test" },
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
             expect(mockReadConfirmation).not.toHaveBeenCalled();
@@ -101,7 +103,10 @@ describe("ToolBase", () => {
         it("does not ask when the confirmationRequiredTools list is empty", async () => {
             mockConfig.confirmationRequiredTools = [];
 
-            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await testTool["invoke"](
+                { param1: "test" },
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
             expect(mockReadConfirmation).not.toHaveBeenCalled();
@@ -113,7 +118,10 @@ describe("ToolBase", () => {
             const expected = { resultType: "input_required", inputRequests: {} };
             mockConfirmationRequired.mockReturnValue(expected as never);
 
-            const result = await testTool["invoke"]({ param1: "test", param2: 42 }, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await testTool["invoke"](
+                { param1: "test", param2: 42 },
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result).toEqual(expected);
             expect(mockReadConfirmation).toHaveBeenCalledTimes(1);
@@ -129,7 +137,13 @@ describe("ToolBase", () => {
 
             const result = await testTool["invoke"](
                 { param1: "test", param2: 42 },
-                { request: { server: mockServer, signal: new AbortController().signal, inputResponses: { confirmation: {} } } }
+                {
+                    request: {
+                        server: mockServer,
+                        signal: new AbortController().signal,
+                        inputResponses: { confirmation: {} },
+                    },
+                }
             );
 
             expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
@@ -140,7 +154,10 @@ describe("ToolBase", () => {
             mockConfig.confirmationRequiredTools = ["test-tool"];
             mockReadConfirmation.mockReturnValue(false);
 
-            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await testTool["invoke"](
+                { param1: "test" },
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.isError).toBe(true);
 
@@ -162,7 +179,10 @@ describe("ToolBase", () => {
             mockConfig.confirmationRequiredTools = ["test-tool"];
             mockReadConfirmation.mockReturnValue(false);
 
-            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await testTool["invoke"](
+                { param1: "test" },
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.isError).toBe(true);
             expect(result.content).toEqual([
@@ -213,7 +233,10 @@ describe("ToolBase", () => {
         it("runs the operation when the user confirms", async () => {
             mockReadConfirmation.mockReturnValue(true);
 
-            const result = await createConfirmingTool()["invoke"]({}, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await createConfirmingTool()["invoke"](
+                {},
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.isError).toBeUndefined();
             expect(result.content).toEqual([{ type: "text", text: "executed" }]);
@@ -222,7 +245,10 @@ describe("ToolBase", () => {
         it("aborts the operation when the user declines", async () => {
             mockReadConfirmation.mockReturnValue(false);
 
-            const result = await createConfirmingTool()["invoke"]({}, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await createConfirmingTool()["invoke"](
+                {},
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.isError).toBe(true);
             expect(result.content).toEqual([{ type: "text", text: "The operation was not performed." }]);
@@ -233,7 +259,10 @@ describe("ToolBase", () => {
             try {
                 mockReadConfirmation.mockReturnValue(true);
 
-                const result = await createConfirmingTool()["invoke"]({}, { request: { server: mockServer, signal: new AbortController().signal } });
+                const result = await createConfirmingTool()["invoke"](
+                    {},
+                    { request: { server: mockServer, signal: new AbortController().signal } }
+                );
                 expect(result.content).toEqual([{ type: "text", text: "executed" }]);
             } finally {
                 vi.useRealTimers();
@@ -508,8 +537,7 @@ describe("ToolBase", () => {
                 mockConfig,
                 mockAtlasTelemetry,
                 mockElicitation,
-                mockUIRegistry,
-                mockMetrics
+                mockUIRegistry
             );
             (mockUIRegistry.get as Mock).mockReturnValue("<html>test UI</html>");
 
@@ -655,7 +683,11 @@ describe("ToolBase", () => {
 
     describe("invoke logging", () => {
         const contextWithRequestId: ToolExecutionContext = {
-            request: { server: mockServer, signal: new AbortController().signal, headers: { "x-request-id": "req-test-123" } },
+            request: {
+                server: mockServer,
+                signal: new AbortController().signal,
+                headers: { "x-request-id": "req-test-123" },
+            },
         };
         const contextWithoutRequestId: ToolExecutionContext = {
             request: { server: mockServer, signal: new AbortController().signal },
@@ -814,8 +846,7 @@ function createToolWithoutStructuredContent(
     mockConfig: UserConfig,
     mockAtlasTelemetry: AtlasTelemetry,
     mockElicitation: Elicitation,
-    mockUIRegistry: UIRegistry,
-    mockMetrics: MockMetrics
+    mockUIRegistry: UIRegistry
 ): TestToolWithoutStructuredContent {
     mockConfig.previewFeatures = previewFeatures;
     return new TestToolWithoutStructuredContent({

--- a/packages/integration-tests/src/tools/mongodb/mongodbTool.test.ts
+++ b/packages/integration-tests/src/tools/mongodb/mongodbTool.test.ts
@@ -15,7 +15,7 @@ import {
     type IMongoDBConfig,
 } from "@mongodb-js/mcp-tools-mongodb";
 import * as MongoDbTools from "@mongodb-js/mcp-tools-mongodb";
-import type { OperationType, ToolRequest } from "@mongodb-js/mcp-types";
+import type { OperationType, ToolRequest, ToolServer } from "@mongodb-js/mcp-types";
 import type { ToolArgs } from "@mongodb-js/mcp-core";
 import { type UserConfig } from "mongodb-mcp-server";
 import { CliServer } from "@mongodb-js/mcp-cli";
@@ -515,7 +515,7 @@ describe("MongoDBTool implementations", () => {
 
             const signal = AbortSignal.timeout(5000);
             const options = randomTool["getOperationOptions"]({
-                config: { maxTimeMS: mcpServer?.config.maxTimeMS },
+                server: mcpServer as unknown as ToolServer,
                 signal,
             } as ToolRequest<IMongoDBConfig>);
 
@@ -531,7 +531,7 @@ describe("MongoDBTool implementations", () => {
 
             const signal = AbortSignal.timeout(5000);
             const options = randomTool["getOperationOptions"]({
-                config: { maxTimeMS: mcpServer?.config.maxTimeMS },
+                server: mcpServer as unknown as ToolServer,
                 signal,
             } as ToolRequest<IMongoDBConfig>);
 
@@ -545,7 +545,7 @@ describe("MongoDBTool implementations", () => {
             const randomTool = tool as RandomTool;
 
             const options = randomTool["getOperationOptions"]({
-                config: { maxTimeMS: mcpServer?.config.maxTimeMS },
+                server: mcpServer as unknown as ToolServer,
                 signal: undefined as AbortSignal | undefined,
             } as ToolRequest<IMongoDBConfig>);
 
@@ -559,7 +559,7 @@ describe("MongoDBTool implementations", () => {
             const randomTool = tool as RandomTool;
 
             const options = randomTool["getOperationOptions"]({
-                config: { maxTimeMS: mcpServer?.config.maxTimeMS },
+                server: mcpServer as unknown as ToolServer,
                 signal: undefined as AbortSignal | undefined,
             } as ToolRequest<IMongoDBConfig>);
 
@@ -574,7 +574,7 @@ describe("MongoDBTool implementations", () => {
 
             const signal = AbortSignal.timeout(5000);
             const options = randomTool["getOperationOptions"]({
-                config: { maxTimeMS: mcpServer?.config.maxTimeMS },
+                server: mcpServer as unknown as ToolServer,
                 signal,
             } as ToolRequest<IMongoDBConfig>);
 
@@ -588,7 +588,7 @@ describe("MongoDBTool implementations", () => {
             const randomTool = tool as RandomTool;
 
             const options = randomTool["getOperationOptions"]({
-                config: { maxTimeMS: mcpServer?.config.maxTimeMS },
+                server: mcpServer as unknown as ToolServer,
                 signal: undefined as AbortSignal | undefined,
             } as ToolRequest<IMongoDBConfig>);
 

--- a/packages/tools-atlas-local/src/tools/create/createDeployment.ts
+++ b/packages/tools-atlas-local/src/tools/create/createDeployment.ts
@@ -44,7 +44,9 @@ export class CreateDeploymentTool extends AtlasLocalToolBase {
             },
             loadSampleData,
             imageTag,
-            ...(context.request.config.voyageApiKey ? { voyageApiKey: context.request.config.voyageApiKey } : {}),
+            ...(context.request.server.config.voyageApiKey
+                ? { voyageApiKey: context.request.server.config.voyageApiKey }
+                : {}),
             doNotTrack: !this.server.telemetry.isTelemetryEnabled(),
         };
         // Create the deployment

--- a/packages/tools-atlas/src/helpers/cluster.test.ts
+++ b/packages/tools-atlas/src/helpers/cluster.test.ts
@@ -16,9 +16,9 @@ describe("inspectCluster", () => {
         const context = {
             signal: new AbortController().signal,
             headers: { "x-request-id": "req-cluster-1" },
-        };
+        } as { signal: AbortSignal; headers: Record<string, unknown> };
 
-        await expect(inspectCluster(apiClient, "proj1", "cluster1", context)).rejects.toThrow();
+        await expect(inspectCluster(apiClient, "proj1", "cluster1", context as never)).rejects.toThrow();
 
         expect(error).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/packages/tools-atlas/src/streams/streamsToolBase.test.ts
+++ b/packages/tools-atlas/src/streams/streamsToolBase.test.ts
@@ -10,7 +10,6 @@ import type { CompositeLogger } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
-import type {} from "@mongodb-js/mcp-metrics";
 import type { IAtlasConfig } from "@mongodb-js/mcp-tools-atlas";
 import type { AtlasToolServer } from "../atlasTool.js";
 

--- a/packages/tools-atlas/src/tools/connect/connectCluster.test.ts
+++ b/packages/tools-atlas/src/tools/connect/connectCluster.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 import { ConnectClusterTool } from "./connectCluster.js";
 import type { IAtlasConfig } from "../../atlasTool.js";
-import type { ITelemetry, ICompositeLogger } from "@mongodb-js/mcp-types";
+import type { ITelemetry, ICompositeLogger, ToolExecutionContext } from "@mongodb-js/mcp-types";
 import { CompositeLogger } from "@mongodb-js/mcp-core";
 import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import type { AtlasClusterConnectionInfo } from "@mongodb-js/mcp-types";
@@ -116,7 +115,12 @@ describe("ConnectClusterTool", () => {
         const args = { projectId: "proj1", clusterName: "cluster1", connectionType: "standard" as const };
 
         it("names the entry combining the project and cluster names", async () => {
-            const result = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+            const result = await tool["execute"](args, {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            });
 
             expect(mockApiClient.getGroup).toHaveBeenCalledWith(
                 { params: { path: { groupId: "proj1" } } },
@@ -131,7 +135,12 @@ describe("ConnectClusterTool", () => {
         it("falls back to the cluster name alone when the project lookup fails", async () => {
             mockApiClient.getGroup?.mockRejectedValue(new Error("forbidden"));
 
-            const result = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+            const result = await tool["execute"](args, {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            });
 
             expect(result.structuredContent?.state).toBe("connected");
             const connectionId = result.structuredContent?.connectionId;
@@ -140,8 +149,18 @@ describe("ConnectClusterTool", () => {
         });
 
         it("reuses the existing entry when called again for the same cluster", async () => {
-            const first = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
-            const second = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+            const first = await tool["execute"](args, {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            });
+            const second = await tool["execute"](args, {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            });
 
             expect(second.structuredContent?.connectionId).toBe(first.structuredContent?.connectionId);
             expect(first.structuredContent?.createdTemporaryUser).toBe(true);
@@ -152,11 +171,21 @@ describe("ConnectClusterTool", () => {
         });
 
         it("creates a separate entry for a different cluster", async () => {
-            const first = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+            const first = await tool["execute"](args, {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            });
             mockApiClient.getCluster?.mockResolvedValue({ ...CLUSTER_DESCRIPTION, name: "cluster2" });
             const second = await tool["execute"](
                 { ...args, clusterName: "cluster2" },
-                { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext
+                {
+                    request: {
+                        server: (tool as unknown as { server: AtlasToolServer }).server,
+                        signal: new AbortController().signal,
+                    },
+                }
             );
 
             expect(second.structuredContent?.connectionId).not.toBe(first.structuredContent?.connectionId);
@@ -166,13 +195,13 @@ describe("ConnectClusterTool", () => {
 
     describe("connectToCluster request ID logging", () => {
         it("includes x-request-id in attempt and success debug logs", async () => {
-            const context: ToolExecutionContext = {
+            const context: ToolExecutionContext<IAtlasConfig> = {
                 request: {
                     server: (tool as unknown as { server: AtlasToolServer }).server,
                     signal: new AbortController().signal,
                     headers: { "x-request-id": "req-connect-abc" },
                 },
-            } as unknown as ToolExecutionContext;
+            };
 
             const entry = await connectionRegistry.createEntry({ name: ATLAS_INFO.clusterName });
             await tool["connectToCluster"](entry, "mongodb://localhost", ATLAS_INFO, context.request);
@@ -196,12 +225,12 @@ describe("ConnectClusterTool", () => {
         });
 
         it("omits x-request-id from log attributes when context carries no headers", async () => {
-            const context: ToolExecutionContext = {
+            const context: ToolExecutionContext<IAtlasConfig> = {
                 request: {
                     server: (tool as unknown as { server: AtlasToolServer }).server,
                     signal: new AbortController().signal,
                 },
-            } as unknown as ToolExecutionContext;
+            };
 
             const entry = await connectionRegistry.createEntry({ name: ATLAS_INFO.clusterName });
             await tool["connectToCluster"](entry, "mongodb://localhost", ATLAS_INFO, context.request);

--- a/packages/tools-atlas/src/tools/connect/connectCluster.test.ts
+++ b/packages/tools-atlas/src/tools/connect/connectCluster.test.ts
@@ -116,12 +116,7 @@ describe("ConnectClusterTool", () => {
         const args = { projectId: "proj1", clusterName: "cluster1", connectionType: "standard" as const };
 
         it("names the entry combining the project and cluster names", async () => {
-            const result = await tool["execute"](args, {
-                request: {
-                    config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                    signal: new AbortController().signal,
-                },
-            });
+            const result = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
             expect(mockApiClient.getGroup).toHaveBeenCalledWith(
                 { params: { path: { groupId: "proj1" } } },
@@ -136,12 +131,7 @@ describe("ConnectClusterTool", () => {
         it("falls back to the cluster name alone when the project lookup fails", async () => {
             mockApiClient.getGroup?.mockRejectedValue(new Error("forbidden"));
 
-            const result = await tool["execute"](args, {
-                request: {
-                    config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                    signal: new AbortController().signal,
-                },
-            });
+            const result = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
             expect(result.structuredContent?.state).toBe("connected");
             const connectionId = result.structuredContent?.connectionId;
@@ -150,18 +140,8 @@ describe("ConnectClusterTool", () => {
         });
 
         it("reuses the existing entry when called again for the same cluster", async () => {
-            const first = await tool["execute"](args, {
-                request: {
-                    config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                    signal: new AbortController().signal,
-                },
-            });
-            const second = await tool["execute"](args, {
-                request: {
-                    config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                    signal: new AbortController().signal,
-                },
-            });
+            const first = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+            const second = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
             expect(second.structuredContent?.connectionId).toBe(first.structuredContent?.connectionId);
             expect(first.structuredContent?.createdTemporaryUser).toBe(true);
@@ -172,21 +152,11 @@ describe("ConnectClusterTool", () => {
         });
 
         it("creates a separate entry for a different cluster", async () => {
-            const first = await tool["execute"](args, {
-                request: {
-                    config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                    signal: new AbortController().signal,
-                },
-            });
+            const first = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
             mockApiClient.getCluster?.mockResolvedValue({ ...CLUSTER_DESCRIPTION, name: "cluster2" });
             const second = await tool["execute"](
                 { ...args, clusterName: "cluster2" },
-                {
-                    request: {
-                        config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                        signal: new AbortController().signal,
-                    },
-                }
+                { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext
             );
 
             expect(second.structuredContent?.connectionId).not.toBe(first.structuredContent?.connectionId);
@@ -198,11 +168,11 @@ describe("ConnectClusterTool", () => {
         it("includes x-request-id in attempt and success debug logs", async () => {
             const context: ToolExecutionContext = {
                 request: {
-                    config: (tool as unknown as { server: AtlasToolServer }).server.config,
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
                     signal: new AbortController().signal,
                     headers: { "x-request-id": "req-connect-abc" },
                 },
-            };
+            } as unknown as ToolExecutionContext;
 
             const entry = await connectionRegistry.createEntry({ name: ATLAS_INFO.clusterName });
             await tool["connectToCluster"](entry, "mongodb://localhost", ATLAS_INFO, context.request);
@@ -225,13 +195,13 @@ describe("ConnectClusterTool", () => {
             );
         });
 
-        it("omits x-request-id from log attributes when context has no headers", async () => {
+        it("omits x-request-id from log attributes when context carries no headers", async () => {
             const context: ToolExecutionContext = {
                 request: {
-                    config: (tool as unknown as { server: AtlasToolServer }).server.config,
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
                     signal: new AbortController().signal,
                 },
-            };
+            } as unknown as ToolExecutionContext;
 
             const entry = await connectionRegistry.createEntry({ name: ATLAS_INFO.clusterName });
             await tool["connectToCluster"](entry, "mongodb://localhost", ATLAS_INFO, context.request);

--- a/packages/tools-atlas/src/tools/create/createAccessList.test.ts
+++ b/packages/tools-atlas/src/tools/create/createAccessList.test.ts
@@ -8,7 +8,6 @@ import { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { RegisteredTool } from "@modelcontextprotocol/server";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const projectId = "507f1f77bcf86cd799439011";
 const currentIpAddress = "203.0.113.10";
@@ -54,14 +53,19 @@ describe("CreateAccessListTool", () => {
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         return new CreateAccessListTool(server);
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("creates access list entries for IPs and CIDR blocks", async () => {
         const result = await exec({

--- a/packages/tools-atlas/src/tools/create/createAccessList.test.ts
+++ b/packages/tools-atlas/src/tools/create/createAccessList.test.ts
@@ -8,7 +8,7 @@ import { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { RegisteredTool } from "@modelcontextprotocol/server";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const projectId = "507f1f77bcf86cd799439011";
 const currentIpAddress = "203.0.113.10";
@@ -54,19 +54,14 @@ describe("CreateAccessListTool", () => {
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        };
+        } as unknown as AtlasToolServer;
 
         return new CreateAccessListTool(server);
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     it("creates access list entries for IPs and CIDR blocks", async () => {
         const result = await exec({

--- a/packages/tools-atlas/src/tools/create/createCluster.test.ts
+++ b/packages/tools-atlas/src/tools/create/createCluster.test.ts
@@ -8,7 +8,6 @@ import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const BASE_ARGS_WITHOUT_REGIONS = {
     projectId: "507f1f77bcf86cd799439011",
@@ -78,15 +77,12 @@ describe("CreateClusterTool", () => {
     // The invoke() result is narrowed to CallToolResult in these tests: the
     // tools under test never return input_required.
     const exec = async (args: Record<string, unknown>): Promise<CallToolResult> =>
-        (await tool["invoke"](
-            z.object(CreateClusterArgsShape).strict().parse(tool.normalizeRawArgs(args)),
-            {
-                request: {
-                    server: (tool as unknown as { server: AtlasToolServer }).server,
-                    signal: new AbortController().signal,
-                },
-            } as unknown as ToolExecutionContext
-        )) as CallToolResult;
+        (await tool["invoke"](z.object(CreateClusterArgsShape).strict().parse(tool.normalizeRawArgs(args)), {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        })) as CallToolResult;
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-atlas/src/tools/create/createCluster.test.ts
+++ b/packages/tools-atlas/src/tools/create/createCluster.test.ts
@@ -8,6 +8,7 @@ import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { AtlasToolServer } from "../../atlasTool.js";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const BASE_ARGS_WITHOUT_REGIONS = {
     projectId: "507f1f77bcf86cd799439011",
@@ -77,12 +78,15 @@ describe("CreateClusterTool", () => {
     // The invoke() result is narrowed to CallToolResult in these tests: the
     // tools under test never return input_required.
     const exec = async (args: Record<string, unknown>): Promise<CallToolResult> =>
-        (await tool["invoke"](z.object(CreateClusterArgsShape).strict().parse(tool.normalizeRawArgs(args)), {
-            request: {
-                server: (tool as unknown as { server: AtlasToolServer }).server,
-                signal: new AbortController().signal,
-            },
-        })) as CallToolResult;
+        (await tool["invoke"](
+            z.object(CreateClusterArgsShape).strict().parse(tool.normalizeRawArgs(args)),
+            {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            } as unknown as ToolExecutionContext
+        )) as CallToolResult;
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-atlas/src/tools/create/createDBUser.test.ts
+++ b/packages/tools-atlas/src/tools/create/createDBUser.test.ts
@@ -10,7 +10,7 @@ import { Keychain } from "@mongodb-js/mcp-core";
 import { ensureCurrentIpInAccessList } from "../../helpers/accessListUtils.js";
 import type * as AccessListUtils from "../../helpers/accessListUtils.js";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 vi.mock("../../helpers/accessListUtils.js", async (importOriginal) => {
     const actual = await importOriginal<typeof AccessListUtils>();
@@ -67,19 +67,14 @@ describe("CreateDBUserTool", () => {
             telemetry: { isTelemetryEnabled: () => false, emitEvents: vi.fn() } as unknown as ITelemetry,
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
-        };
+        } as unknown as AtlasToolServer;
 
         tool = new CreateDBUserTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = baseArgs) =>
-        tool["execute"](args as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     it("creates a user with a supplied password", async () => {
         const result = await exec({ ...baseArgs, password: "user-password" });

--- a/packages/tools-atlas/src/tools/create/createDBUser.test.ts
+++ b/packages/tools-atlas/src/tools/create/createDBUser.test.ts
@@ -10,7 +10,6 @@ import { Keychain } from "@mongodb-js/mcp-core";
 import { ensureCurrentIpInAccessList } from "../../helpers/accessListUtils.js";
 import type * as AccessListUtils from "../../helpers/accessListUtils.js";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 vi.mock("../../helpers/accessListUtils.js", async (importOriginal) => {
     const actual = await importOriginal<typeof AccessListUtils>();
@@ -67,14 +66,19 @@ describe("CreateDBUserTool", () => {
             telemetry: { isTelemetryEnabled: () => false, emitEvents: vi.fn() } as unknown as ITelemetry,
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new CreateDBUserTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = baseArgs) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("creates a user with a supplied password", async () => {
         const result = await exec({ ...baseArgs, password: "user-password" });

--- a/packages/tools-atlas/src/tools/create/createFreeCluster.test.ts
+++ b/packages/tools-atlas/src/tools/create/createFreeCluster.test.ts
@@ -7,7 +7,7 @@ import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("CreateFreeClusterTool", () => {
     let mockApiClient: {
@@ -53,19 +53,14 @@ describe("CreateFreeClusterTool", () => {
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        };
+        } as unknown as AtlasToolServer;
 
         tool = new CreateFreeClusterTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = baseArgs) =>
-        tool["execute"](args as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     it("creates a free cluster and notes that the current IP was added to the access list", async () => {
         const result = await exec();

--- a/packages/tools-atlas/src/tools/create/createFreeCluster.test.ts
+++ b/packages/tools-atlas/src/tools/create/createFreeCluster.test.ts
@@ -7,7 +7,6 @@ import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("CreateFreeClusterTool", () => {
     let mockApiClient: {
@@ -53,14 +52,19 @@ describe("CreateFreeClusterTool", () => {
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new CreateFreeClusterTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = baseArgs) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("creates a free cluster and notes that the current IP was added to the access list", async () => {
         const result = await exec();

--- a/packages/tools-atlas/src/tools/create/createProject.test.ts
+++ b/packages/tools-atlas/src/tools/create/createProject.test.ts
@@ -7,7 +7,6 @@ import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("CreateProjectTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -38,14 +37,19 @@ describe("CreateProjectTool", () => {
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new CreateProjectTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = {}) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("requires projectName and orgId, rejecting missing values", () => {
         const schema = z.object(tool.argsShape);

--- a/packages/tools-atlas/src/tools/create/createProject.test.ts
+++ b/packages/tools-atlas/src/tools/create/createProject.test.ts
@@ -7,7 +7,7 @@ import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("CreateProjectTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -38,19 +38,14 @@ describe("CreateProjectTool", () => {
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        };
+        } as unknown as AtlasToolServer;
 
         tool = new CreateProjectTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = {}) =>
-        tool["execute"](args as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     it("requires projectName and orgId, rejecting missing values", () => {
         const schema = z.object(tool.argsShape);

--- a/packages/tools-atlas/src/tools/create/loadSampleDataset.test.ts
+++ b/packages/tools-atlas/src/tools/create/loadSampleDataset.test.ts
@@ -8,7 +8,7 @@ import { MockMetrics } from "../../mockMetrics.js";
 import { createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const PROJECT_ID = "651b1d2a3a3f3a0001a1b2c3";
 const CLUSTER_NAME = "MyCluster";
@@ -79,19 +79,14 @@ describe("LoadSampleDatasetTool", () => {
             telemetry: mockTelemetry,
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
-        };
+        } as unknown as AtlasToolServer;
 
         return new LoadSampleDatasetTool(server);
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](z.object(LoadSampleDatasetArgs).parse(args) as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](z.object(LoadSampleDatasetArgs).parse(args) as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     function getStructuredContent(result: { structuredContent?: unknown }): Record<string, unknown> {
         expect(result.structuredContent).toBeDefined();

--- a/packages/tools-atlas/src/tools/create/loadSampleDataset.test.ts
+++ b/packages/tools-atlas/src/tools/create/loadSampleDataset.test.ts
@@ -8,7 +8,6 @@ import { MockMetrics } from "../../mockMetrics.js";
 import { createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const PROJECT_ID = "651b1d2a3a3f3a0001a1b2c3";
 const CLUSTER_NAME = "MyCluster";
@@ -79,14 +78,19 @@ describe("LoadSampleDatasetTool", () => {
             telemetry: mockTelemetry,
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
-        } as unknown as AtlasToolServer;
+        };
 
         return new LoadSampleDatasetTool(server);
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](z.object(LoadSampleDatasetArgs).parse(args) as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](z.object(LoadSampleDatasetArgs).parse(args) as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     function getStructuredContent(result: { structuredContent?: unknown }): Record<string, unknown> {
         expect(result.structuredContent).toBeDefined();

--- a/packages/tools-atlas/src/tools/read/getPerformanceAdvisor.test.ts
+++ b/packages/tools-atlas/src/tools/read/getPerformanceAdvisor.test.ts
@@ -8,7 +8,7 @@ import { ApiClientError } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const emptyDropSuggestions = {
     hiddenIndexes: [],
@@ -54,7 +54,7 @@ describe("GetPerformanceAdvisorTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        };
+        } as unknown as AtlasToolServer;
 
         tool = new GetPerformanceAdvisorTool(server);
     });
@@ -66,12 +66,7 @@ describe("GetPerformanceAdvisorTool", () => {
     };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     const text = (result: { content: unknown[] }): string =>
         result.content.map((c) => (c as { text: string }).text).join("\n");

--- a/packages/tools-atlas/src/tools/read/getPerformanceAdvisor.test.ts
+++ b/packages/tools-atlas/src/tools/read/getPerformanceAdvisor.test.ts
@@ -8,7 +8,6 @@ import { ApiClientError } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const emptyDropSuggestions = {
     hiddenIndexes: [],
@@ -54,7 +53,7 @@ describe("GetPerformanceAdvisorTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new GetPerformanceAdvisorTool(server);
     });
@@ -66,7 +65,12 @@ describe("GetPerformanceAdvisorTool", () => {
     };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     const text = (result: { content: unknown[] }): string =>
         result.content.map((c) => (c as { text: string }).text).join("\n");

--- a/packages/tools-atlas/src/tools/read/getRegions.test.ts
+++ b/packages/tools-atlas/src/tools/read/getRegions.test.ts
@@ -8,7 +8,7 @@ import { ATLAS_REGIONS, GetRegionsArgsShape, GetRegionsTool } from "./getRegions
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("GetRegionsTool", () => {
     let mockSession: Partial<AtlasToolServer>;
@@ -58,11 +58,8 @@ describe("GetRegionsTool", () => {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
         tool["invoke"](z.object(GetRegionsArgsShape).strict().parse(tool.normalizeRawArgs(args)), {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+            request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal },
+        } as unknown as ToolExecutionContext);
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-atlas/src/tools/read/getRegions.test.ts
+++ b/packages/tools-atlas/src/tools/read/getRegions.test.ts
@@ -8,7 +8,6 @@ import { ATLAS_REGIONS, GetRegionsArgsShape, GetRegionsTool } from "./getRegions
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("GetRegionsTool", () => {
     let mockSession: Partial<AtlasToolServer>;
@@ -58,8 +57,11 @@ describe("GetRegionsTool", () => {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
         tool["invoke"](z.object(GetRegionsArgsShape).strict().parse(tool.normalizeRawArgs(args)), {
-            request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal },
-        } as unknown as ToolExecutionContext);
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-atlas/src/tools/read/inspectAccessList.test.ts
+++ b/packages/tools-atlas/src/tools/read/inspectAccessList.test.ts
@@ -7,7 +7,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("InspectAccessListTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -43,7 +42,7 @@ describe("InspectAccessListTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new InspectAccessListTool(server);
     });
@@ -51,7 +50,12 @@ describe("InspectAccessListTool", () => {
     const baseArgs = { projectId: "507f1f77bcf86cd799439011" };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("returns access list entries when they exist", async () => {
         mockApiClient.listAccessListEntries!.mockResolvedValue({

--- a/packages/tools-atlas/src/tools/read/inspectAccessList.test.ts
+++ b/packages/tools-atlas/src/tools/read/inspectAccessList.test.ts
@@ -7,7 +7,7 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("InspectAccessListTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -43,7 +43,7 @@ describe("InspectAccessListTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        };
+        } as unknown as AtlasToolServer;
 
         tool = new InspectAccessListTool(server);
     });
@@ -51,12 +51,7 @@ describe("InspectAccessListTool", () => {
     const baseArgs = { projectId: "507f1f77bcf86cd799439011" };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     it("returns access list entries when they exist", async () => {
         mockApiClient.listAccessListEntries!.mockResolvedValue({

--- a/packages/tools-atlas/src/tools/read/inspectCluster.test.ts
+++ b/packages/tools-atlas/src/tools/read/inspectCluster.test.ts
@@ -7,7 +7,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const freeClusterApiResponse = {
     name: "my-cluster",
@@ -84,7 +83,7 @@ describe("InspectClusterTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new InspectClusterTool(server);
     });
@@ -92,7 +91,12 @@ describe("InspectClusterTool", () => {
     const baseArgs = { projectId: "507f1f77bcf86cd799439011", clusterName: "my-cluster" };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("returns cluster details when getCluster succeeds", async () => {
         mockApiClient.getCluster!.mockResolvedValue(freeClusterApiResponse);

--- a/packages/tools-atlas/src/tools/read/inspectCluster.test.ts
+++ b/packages/tools-atlas/src/tools/read/inspectCluster.test.ts
@@ -7,7 +7,7 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const freeClusterApiResponse = {
     name: "my-cluster",
@@ -84,7 +84,7 @@ describe("InspectClusterTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        };
+        } as unknown as AtlasToolServer;
 
         tool = new InspectClusterTool(server);
     });
@@ -92,12 +92,7 @@ describe("InspectClusterTool", () => {
     const baseArgs = { projectId: "507f1f77bcf86cd799439011", clusterName: "my-cluster" };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     it("returns cluster details when getCluster succeeds", async () => {
         mockApiClient.getCluster!.mockResolvedValue(freeClusterApiResponse);

--- a/packages/tools-atlas/src/tools/read/listAlerts.test.ts
+++ b/packages/tools-atlas/src/tools/read/listAlerts.test.ts
@@ -9,7 +9,7 @@ import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("ListAlertsTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -53,7 +53,7 @@ describe("ListAlertsTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        };
+        } as unknown as AtlasToolServer;
 
         tool = new ListAlertsTool(server);
     });
@@ -61,12 +61,7 @@ describe("ListAlertsTool", () => {
     const baseArgs = { projectId: "proj1", status: "OPEN" as const, limit: 10, pageNum: 1, includeCount: false };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     it("should return alerts when they exist", async () => {
         mockApiClient.listAlerts!.mockResolvedValue({
@@ -347,41 +342,6 @@ describe("ListAlertsTool", () => {
                 alerts: [],
                 totalCount: 0,
             });
-        });
-
-        it("omits totalCount when it is an explicit 0 with results present", async () => {
-            // Some environments return totalCount: 0 with includeCount=false even when
-            // results are present; the tool should not report a misleading 0.
-            mockApiClient.listAlerts!.mockResolvedValue({
-                results: [
-                    {
-                        id: "alert1",
-                        status: "OPEN",
-                        created: "2025-01-01T00:00:00Z",
-                        updated: "2025-01-02T00:00:00Z",
-                        eventTypeName: "HOST_DOWN",
-                        acknowledgementComment: null,
-                    },
-                ],
-                totalCount: 0,
-            });
-
-            const result = await exec({ ...baseArgs });
-
-            expect(result.structuredContent).toMatchObject({
-                projectId: "proj1",
-                status: "OPEN",
-                alerts: [
-                    {
-                        id: "alert1",
-                        status: "OPEN",
-                    },
-                ],
-            });
-            expect(result.structuredContent).not.toHaveProperty("totalCount");
-
-            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).not.toContain("(total:");
         });
 
         it("omits structuredContent on error paths", async () => {

--- a/packages/tools-atlas/src/tools/read/listAlerts.test.ts
+++ b/packages/tools-atlas/src/tools/read/listAlerts.test.ts
@@ -9,7 +9,6 @@ import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("ListAlertsTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -53,7 +52,7 @@ describe("ListAlertsTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new ListAlertsTool(server);
     });
@@ -61,7 +60,12 @@ describe("ListAlertsTool", () => {
     const baseArgs = { projectId: "proj1", status: "OPEN" as const, limit: 10, pageNum: 1, includeCount: false };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("should return alerts when they exist", async () => {
         mockApiClient.listAlerts!.mockResolvedValue({

--- a/packages/tools-atlas/src/tools/read/listClusters.test.ts
+++ b/packages/tools-atlas/src/tools/read/listClusters.test.ts
@@ -7,7 +7,7 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const projectId = "507f1f77bcf86cd799439011";
 
@@ -79,19 +79,14 @@ describe("ListClustersTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        };
+        } as unknown as AtlasToolServer;
 
         tool = new ListClustersTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = { projectId }) =>
-        tool["execute"](args as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     describe("with projectId", () => {
         beforeEach(() => {

--- a/packages/tools-atlas/src/tools/read/listClusters.test.ts
+++ b/packages/tools-atlas/src/tools/read/listClusters.test.ts
@@ -7,7 +7,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const projectId = "507f1f77bcf86cd799439011";
 
@@ -79,14 +78,19 @@ describe("ListClustersTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new ListClustersTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = { projectId }) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     describe("with projectId", () => {
         beforeEach(() => {

--- a/packages/tools-atlas/src/tools/read/listDBUsers.test.ts
+++ b/packages/tools-atlas/src/tools/read/listDBUsers.test.ts
@@ -7,7 +7,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("ListDBUsersTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -43,7 +42,7 @@ describe("ListDBUsersTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new ListDBUsersTool(server);
     });
@@ -51,7 +50,12 @@ describe("ListDBUsersTool", () => {
     const baseArgs = { projectId: "507f1f77bcf86cd799439011" };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("returns database users when they exist", async () => {
         mockApiClient.listDatabaseUsers!.mockResolvedValue({

--- a/packages/tools-atlas/src/tools/read/listDBUsers.test.ts
+++ b/packages/tools-atlas/src/tools/read/listDBUsers.test.ts
@@ -7,7 +7,7 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("ListDBUsersTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -43,7 +43,7 @@ describe("ListDBUsersTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        };
+        } as unknown as AtlasToolServer;
 
         tool = new ListDBUsersTool(server);
     });
@@ -51,12 +51,7 @@ describe("ListDBUsersTool", () => {
     const baseArgs = { projectId: "507f1f77bcf86cd799439011" };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
 
     it("returns database users when they exist", async () => {
         mockApiClient.listDatabaseUsers!.mockResolvedValue({

--- a/packages/tools-atlas/src/tools/read/listOrgs.test.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.test.ts
@@ -55,7 +55,7 @@ describe("ListOrganizationsTool", () => {
             { limit: 10, pageNum: 1, includeCount: false, ...args },
             {
                 request: {
-                    config: (tool as unknown as { server: AtlasToolServer }).server.config,
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
                     signal: new AbortController().signal,
                 },
             }

--- a/packages/tools-atlas/src/tools/read/listOrgs.test.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.test.ts
@@ -8,7 +8,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 describe("ListOrganizationsTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -260,26 +259,6 @@ describe("ListOrganizationsTool", () => {
                 organizations: [],
                 totalCount: 0,
             });
-        });
-
-        it("treats an explicit totalCount of 0 with results as unknown and falls back to the page length", async () => {
-            // Some environments (e.g. cloud-dev) return totalCount: 0 with includeCount=false
-            // even when results are present; the tool should not report 0 in that case.
-            mockApiClient.listOrgs!.mockResolvedValue({
-                results: [{ name: "Org A", id: "org-a" }],
-                totalCount: 0,
-            });
-
-            const result = await exec();
-
-            expect(result.structuredContent).toEqual({
-                organizations: [{ name: "Org A", id: "org-a" }],
-                totalCount: 1,
-            });
-
-            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Found 1 organizations in your MongoDB Atlas account.");
-            expect(text).not.toContain("pagination");
         });
 
         it("omits structuredContent on error paths", async () => {

--- a/packages/tools-atlas/src/tools/read/listProjects.test.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.test.ts
@@ -8,7 +8,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 const orgId = "507f1f77bcf86cd799439011";
 
@@ -292,22 +291,6 @@ describe("ListProjectsTool", () => {
                 orgId,
                 projects: [],
                 totalCount: 0,
-            });
-        });
-
-        it("treats an explicit totalCount of 0 with results as unknown and falls back to the page length", async () => {
-            // Some environments return totalCount: 0 with includeCount=false even when
-            // results are present; the tool should not report 0 in that case.
-            mockApiClient.listGroups!.mockResolvedValue({
-                results: [projectApiResponse],
-                totalCount: 0,
-            });
-
-            const result = await exec();
-
-            expect(result.structuredContent).toEqual({
-                projects: [formattedProject],
-                totalCount: 1,
             });
         });
 

--- a/packages/tools-atlas/src/tools/read/listProjects.test.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.test.ts
@@ -70,7 +70,7 @@ describe("ListProjectsTool", () => {
     const exec = (args: Record<string, unknown> = {}) =>
         tool["execute"]({ limit: 10, pageNum: 1, includeCount: false, ...args } as never, {
             request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
+                server: (tool as unknown as { server: AtlasToolServer }).server,
                 signal: new AbortController().signal,
             },
         });

--- a/packages/tools-atlas/src/tools/streams/build.test.ts
+++ b/packages/tools-atlas/src/tools/streams/build.test.ts
@@ -1,4 +1,3 @@
-import type {} from "@mongodb-js/mcp-metrics";
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { IAtlasConfig } from "@mongodb-js/mcp-tools-atlas";
@@ -10,7 +9,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 describe("StreamsBuildTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;

--- a/packages/tools-atlas/src/tools/streams/build.test.ts
+++ b/packages/tools-atlas/src/tools/streams/build.test.ts
@@ -87,7 +87,7 @@ describe("StreamsBuildTool", () => {
     const exec = (args: Record<string, unknown>) =>
         tool["execute"](args as never, {
             request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
+                server: (tool as unknown as { server: AtlasToolServer }).server,
                 signal: new AbortController().signal,
             },
         });

--- a/packages/tools-atlas/src/tools/streams/discover.test.ts
+++ b/packages/tools-atlas/src/tools/streams/discover.test.ts
@@ -7,9 +7,7 @@ import type { CompositeLogger } from "@mongodb-js/mcp-core";
 import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
-import type {} from "@mongodb-js/mcp-metrics";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 describe("StreamsDiscoverTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;

--- a/packages/tools-atlas/src/tools/streams/discover.test.ts
+++ b/packages/tools-atlas/src/tools/streams/discover.test.ts
@@ -70,7 +70,7 @@ describe("StreamsDiscoverTool", () => {
     const exec = (args: Record<string, unknown>) =>
         tool["execute"](args as never, {
             request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
+                server: (tool as unknown as { server: AtlasToolServer }).server,
                 signal: new AbortController().signal,
             },
         });

--- a/packages/tools-atlas/src/tools/streams/manage.test.ts
+++ b/packages/tools-atlas/src/tools/streams/manage.test.ts
@@ -79,7 +79,7 @@ describe("StreamsManageTool", () => {
     const exec = (args: Record<string, unknown>) =>
         tool["execute"](args as never, {
             request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
+                server: (tool as unknown as { server: AtlasToolServer }).server,
                 signal: new AbortController().signal,
             },
         });
@@ -330,7 +330,7 @@ describe("StreamsManageTool", () => {
 
             await tool["execute"]({ ...baseArgs, action: "stop-processor", resourceName: "proc1" } as never, {
                 request: {
-                    config: (tool as unknown as { server: AtlasToolServer }).server.config,
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
                     signal: new AbortController().signal,
                     headers: { "x-request-id": "req-stop-1" },
                 },

--- a/packages/tools-atlas/src/tools/streams/manage.test.ts
+++ b/packages/tools-atlas/src/tools/streams/manage.test.ts
@@ -1,4 +1,3 @@
-import type {} from "@mongodb-js/mcp-metrics";
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { IAtlasConfig } from "@mongodb-js/mcp-tools-atlas";
@@ -10,7 +9,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 describe("StreamsManageTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;

--- a/packages/tools-atlas/src/tools/streams/teardown.test.ts
+++ b/packages/tools-atlas/src/tools/streams/teardown.test.ts
@@ -74,7 +74,7 @@ describe("StreamsTeardownTool", () => {
     const exec = (args: Record<string, unknown>) =>
         tool["execute"](args as never, {
             request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
+                server: (tool as unknown as { server: AtlasToolServer }).server,
                 signal: new AbortController().signal,
             },
         });
@@ -164,7 +164,7 @@ describe("StreamsTeardownTool", () => {
                 { ...baseArgs, resource: "processor", workspaceName: "ws1", resourceName: "proc1" } as never,
                 {
                     request: {
-                        config: (tool as unknown as { server: AtlasToolServer }).server.config,
+                        server: (tool as unknown as { server: AtlasToolServer }).server,
                         signal: new AbortController().signal,
                         headers: { "x-request-id": "req-del-1" },
                     },

--- a/packages/tools-atlas/src/tools/streams/teardown.test.ts
+++ b/packages/tools-atlas/src/tools/streams/teardown.test.ts
@@ -1,16 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { IAtlasConfig } from "@mongodb-js/mcp-tools-atlas";
 import { StreamsTeardownTool } from "@mongodb-js/mcp-tools-atlas";
-import { ErrorCodes, MongoDBError } from "@mongodb-js/mcp-tools-mongodb";
 import type { AtlasTelemetry } from "@mongodb-js/mcp-atlas-telemetry";
 import type { Elicitation } from "@mongodb-js/mcp-core";
 import type { CompositeLogger } from "@mongodb-js/mcp-core";
 import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
-import type {} from "@mongodb-js/mcp-metrics";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 describe("StreamsTeardownTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -79,39 +76,6 @@ describe("StreamsTeardownTool", () => {
             },
         });
     const confirmMsg = (args: Record<string, unknown>): string => tool["getConfirmationMessage"](args as never);
-
-    describe("error classification boundary", () => {
-        it("passes the raw invalid argument error to a wrapped handleError through invoke", async () => {
-            const wrappedHandleError = vi.fn(() => ({
-                content: [{ type: "text" as const, text: "classified error" }],
-                isError: true,
-            }));
-            Object.assign(tool, { handleError: wrappedHandleError });
-
-            const result = await tool.invoke(
-                {
-                    ...baseArgs,
-                    resource: "processor",
-                    resourceName: "proc1",
-                },
-                {
-                    request: {
-                        config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                        signal: new AbortController().signal,
-                    },
-                }
-            );
-
-            expect(wrappedHandleError).toHaveBeenCalledOnce();
-            const error = wrappedHandleError.mock.calls[0]?.[0];
-            expect(error).toBeInstanceOf(MongoDBError);
-            expect(error).toMatchObject({
-                code: ErrorCodes.InvalidArgument,
-                message: expect.stringContaining("workspaceName is required") as string,
-            });
-            expect(result.isError).toBe(true);
-        });
-    });
 
     describe("deleteProcessor", () => {
         it("should stop then delete a STARTED processor", async () => {
@@ -196,32 +160,24 @@ describe("StreamsTeardownTool", () => {
             expect(result.structuredContent).toEqual({ resource: "processor" });
         });
 
-        it("should throw a caller-addressable error when workspaceName is missing", async () => {
-            const error = await exec({
-                ...baseArgs,
-                resource: "processor",
-                resourceName: "proc1",
-            }).catch((error: unknown) => error);
-
-            expect(error).toBeInstanceOf(MongoDBError);
-            expect(error).toMatchObject({
-                code: ErrorCodes.InvalidArgument,
-                message: expect.stringContaining("workspaceName is required") as string,
-            });
+        it("should throw when workspaceName is missing", async () => {
+            await expect(
+                exec({
+                    ...baseArgs,
+                    resource: "processor",
+                    resourceName: "proc1",
+                })
+            ).rejects.toThrow("workspaceName is required");
         });
 
-        it("should throw a caller-addressable error when resourceName is missing", async () => {
-            const error = await exec({
-                ...baseArgs,
-                resource: "processor",
-                workspaceName: "ws1",
-            }).catch((error: unknown) => error);
-
-            expect(error).toBeInstanceOf(MongoDBError);
-            expect(error).toMatchObject({
-                code: ErrorCodes.InvalidArgument,
-                message: expect.stringContaining("resourceName is required") as string,
-            });
+        it("should throw when resourceName is missing", async () => {
+            await expect(
+                exec({
+                    ...baseArgs,
+                    resource: "processor",
+                    workspaceName: "ws1",
+                })
+            ).rejects.toThrow("resourceName is required");
         });
     });
 

--- a/packages/tools-atlas/src/tools/update/pauseResumeCluster.test.ts
+++ b/packages/tools-atlas/src/tools/update/pauseResumeCluster.test.ts
@@ -17,7 +17,7 @@ import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { UserConfigSchema, type UserConfig } from "@mongodb-js/mcp-cli";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const defaultTestConfig: UserConfig = {
     ...UserConfigSchema.parse({}),
@@ -93,11 +93,8 @@ describe("PauseResumeClusterTool", () => {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
         tool["invoke"](z.object(PauseResumeClusterArgsShape).parse(args), {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+            request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal },
+        } as unknown as ToolExecutionContext);
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-atlas/src/tools/update/pauseResumeCluster.test.ts
+++ b/packages/tools-atlas/src/tools/update/pauseResumeCluster.test.ts
@@ -17,7 +17,6 @@ import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { UserConfigSchema, type UserConfig } from "@mongodb-js/mcp-cli";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const defaultTestConfig: UserConfig = {
     ...UserConfigSchema.parse({}),
@@ -93,8 +92,11 @@ describe("PauseResumeClusterTool", () => {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
         tool["invoke"](z.object(PauseResumeClusterArgsShape).parse(args), {
-            request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal },
-        } as unknown as ToolExecutionContext);
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-atlas/src/tools/update/upgradeCluster.test.ts
+++ b/packages/tools-atlas/src/tools/update/upgradeCluster.test.ts
@@ -9,7 +9,6 @@ import { ApiClientError } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 function notFoundError(): ApiClientError {
     return ApiClientError.fromError(new Response(null, { status: 404, statusText: "Not Found" }), "cluster not found");
@@ -195,8 +194,11 @@ describe("UpgradeClusterTool", () => {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
         tool["invoke"](args, {
-            request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal },
-        } as unknown as ToolExecutionContext);
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-atlas/src/tools/update/upgradeCluster.test.ts
+++ b/packages/tools-atlas/src/tools/update/upgradeCluster.test.ts
@@ -9,7 +9,7 @@ import { ApiClientError } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
+import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 function notFoundError(): ApiClientError {
     return ApiClientError.fromError(new Response(null, { status: 404, statusText: "Not Found" }), "cluster not found");
@@ -195,11 +195,8 @@ describe("UpgradeClusterTool", () => {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
         tool["invoke"](args, {
-            request: {
-                config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                signal: new AbortController().signal,
-            },
-        });
+            request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal },
+        } as unknown as ToolExecutionContext);
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-mongodb/src/mongodbTool.ts
+++ b/packages/tools-mongodb/src/mongodbTool.ts
@@ -135,7 +135,7 @@ export abstract class MongoDBToolBase extends ToolBase<MongoDBToolServer> {
     protected getOperationOptions(request: ToolRequest<IMongoDBConfig>): { signal?: AbortSignal; maxTimeMS?: number } {
         return {
             ...(request.signal && { signal: request.signal }),
-            ...(request.config.maxTimeMS !== undefined && { maxTimeMS: request.config.maxTimeMS }),
+            ...(request.server.config.maxTimeMS !== undefined && { maxTimeMS: request.server.config.maxTimeMS }),
         };
     }
 

--- a/packages/tools-mongodb/src/tools/delete/deleteMany.ts
+++ b/packages/tools-mongodb/src/tools/delete/deleteMany.ts
@@ -56,7 +56,9 @@ export class DeleteManyTool extends MongoDBToolBase {
                             ],
                         },
                         verbosity: "queryPlanner",
-                        ...(request.server.config.maxTimeMS !== undefined && { maxTimeMS: request.server.config.maxTimeMS }),
+                        ...(request.server.config.maxTimeMS !== undefined && {
+                            maxTimeMS: request.server.config.maxTimeMS,
+                        }),
                     });
                 },
                 logger: this.server.logger,

--- a/packages/tools-mongodb/src/tools/delete/deleteMany.ts
+++ b/packages/tools-mongodb/src/tools/delete/deleteMany.ts
@@ -36,10 +36,10 @@ export class DeleteManyTool extends MongoDBToolBase {
     ): Promise<ToolResult<typeof this.outputSchema>> {
         const provider = await this.resolveConnection(connectionId);
 
-        this.assertMqlIsAllowed(request.config, filter);
+        this.assertMqlIsAllowed(request.server.config, filter);
 
         // Check if delete operation uses an index if enabled
-        if (request.config.indexCheck) {
+        if (request.server.config.indexCheck) {
             await checkIndexUsage({
                 database,
                 collection,
@@ -56,7 +56,7 @@ export class DeleteManyTool extends MongoDBToolBase {
                             ],
                         },
                         verbosity: "queryPlanner",
-                        ...(request.config.maxTimeMS !== undefined && { maxTimeMS: request.config.maxTimeMS }),
+                        ...(request.server.config.maxTimeMS !== undefined && { maxTimeMS: request.server.config.maxTimeMS }),
                     });
                 },
                 logger: this.server.logger,

--- a/packages/tools-mongodb/src/tools/metadata/collectionSchema.ts
+++ b/packages/tools-mongodb/src/tools/metadata/collectionSchema.ts
@@ -51,7 +51,7 @@ export class CollectionSchemaTool extends MongoDBToolBase {
         );
         const { documents } = await collectCursorUntilMaxBytesLimit({
             cursor,
-            configuredMaxBytesPerQuery: request.config.maxBytesPerQuery,
+            configuredMaxBytesPerQuery: request.server.config.maxBytesPerQuery,
             toolResponseBytesLimit: responseBytesLimit,
             abortSignal: request.signal,
         });

--- a/packages/tools-mongodb/src/tools/metadata/dbStats.ts
+++ b/packages/tools-mongodb/src/tools/metadata/dbStats.ts
@@ -29,7 +29,7 @@ export class DbStatsTool extends MongoDBToolBase {
             {
                 dbStats: 1,
                 scale: 1,
-                ...(request.config.maxTimeMS !== undefined && { maxTimeMS: request.config.maxTimeMS }),
+                ...(request.server.config.maxTimeMS !== undefined && { maxTimeMS: request.server.config.maxTimeMS }),
             },
             { signal: request.signal }
         );

--- a/packages/tools-mongodb/src/tools/metadata/explain.ts
+++ b/packages/tools-mongodb/src/tools/metadata/explain.ts
@@ -76,7 +76,7 @@ export class ExplainTool extends MongoDBToolBase {
         switch (method.name) {
             case "aggregate": {
                 const { pipeline } = method.arguments;
-                this.assertMqlIsAllowed(request.config, pipeline);
+                this.assertMqlIsAllowed(request.server.config, pipeline);
                 result = await provider
                     .aggregate(
                         database,
@@ -94,7 +94,7 @@ export class ExplainTool extends MongoDBToolBase {
             }
             case "find": {
                 const { filter, ...rest } = method.arguments;
-                this.assertMqlIsAllowed(request.config, filter, rest.projection);
+                this.assertMqlIsAllowed(request.server.config, filter, rest.projection);
                 result = await provider
                     .find(database, collection, filter, {
                         ...rest,
@@ -105,7 +105,7 @@ export class ExplainTool extends MongoDBToolBase {
             }
             case "count": {
                 const { query } = method.arguments;
-                this.assertMqlIsAllowed(request.config, query);
+                this.assertMqlIsAllowed(request.server.config, query);
                 result = await provider.runCommandWithCheck(
                     database,
                     {

--- a/packages/tools-mongodb/src/tools/metadata/logs.ts
+++ b/packages/tools-mongodb/src/tools/metadata/logs.ts
@@ -47,7 +47,7 @@ export class LogsTool extends MongoDBToolBase {
             "admin",
             {
                 getLog: type,
-                ...(request.config.maxTimeMS !== undefined && { maxTimeMS: request.config.maxTimeMS }),
+                ...(request.server.config.maxTimeMS !== undefined && { maxTimeMS: request.server.config.maxTimeMS }),
             },
             {
                 signal: request.signal,

--- a/packages/tools-mongodb/src/tools/read/aggregate.ts
+++ b/packages/tools-mongodb/src/tools/read/aggregate.ts
@@ -161,7 +161,7 @@ export class AggregateTool extends MongoDBToolBase {
         try {
             const provider = await this.resolveConnection(connectionId);
             const isSearchSupported = await this.isSearchSupported(connectionId);
-            this.assertOnlyUsesPermittedStages(request.config, { isSearchSupported }, pipeline);
+            this.assertOnlyUsesPermittedStages(request.server.config, { isSearchSupported }, pipeline);
             if (isSearchSupported) {
                 let searchIndexes: SearchIndex[] | undefined;
                 try {
@@ -183,7 +183,7 @@ export class AggregateTool extends MongoDBToolBase {
             }
 
             // Check if aggregate operation uses an index if enabled
-            if (request.config.indexCheck) {
+            if (request.server.config.indexCheck) {
                 const [usesVectorSearchIndex, indexName] = await this.isVectorSearchIndexUsed(
                     { isSearchSupported, provider },
                     {
@@ -246,15 +246,15 @@ export class AggregateTool extends MongoDBToolBase {
                 successMessage = "The aggregation pipeline executed successfully.";
             } else {
                 const cappedResultsPipeline: Document[] = [...pipeline];
-                if (request.config.maxDocumentsPerQuery > 0) {
-                    cappedResultsPipeline.push({ $limit: request.config.maxDocumentsPerQuery });
+                if (request.server.config.maxDocumentsPerQuery > 0) {
+                    cappedResultsPipeline.push({ $limit: request.server.config.maxDocumentsPerQuery });
                 }
                 aggregationCursor = provider.aggregate(database, collection, cappedResultsPipeline, {
                     ...this.getOperationOptions(request),
                 });
 
                 const [totalDocuments, cursorResults] = await Promise.all([
-                    this.countAggregationResultDocuments(request.config, {
+                    this.countAggregationResultDocuments(request.server.config, {
                         provider,
                         database,
                         collection,
@@ -263,7 +263,7 @@ export class AggregateTool extends MongoDBToolBase {
                     }),
                     collectCursorUntilMaxBytesLimit({
                         cursor: aggregationCursor,
-                        configuredMaxBytesPerQuery: request.config.maxBytesPerQuery,
+                        configuredMaxBytesPerQuery: request.server.config.maxBytesPerQuery,
                         toolResponseBytesLimit: responseBytesLimit,
                         abortSignal: request.signal,
                     }),
@@ -274,9 +274,9 @@ export class AggregateTool extends MongoDBToolBase {
                 // maxDocumentsPerQuery then we know for sure that the results were
                 // capped.
                 const aggregationResultsCappedByMaxDocumentsLimit =
-                    request.config.maxDocumentsPerQuery > 0 &&
+                    request.server.config.maxDocumentsPerQuery > 0 &&
                     !!totalDocuments &&
-                    totalDocuments > request.config.maxDocumentsPerQuery;
+                    totalDocuments > request.server.config.maxDocumentsPerQuery;
 
                 documents = cursorResults.documents;
                 count = totalDocuments;

--- a/packages/tools-mongodb/src/tools/read/aggregateDB.ts
+++ b/packages/tools-mongodb/src/tools/read/aggregateDB.ts
@@ -61,7 +61,7 @@ export class AggregateDBTool extends MongoDBToolBase {
         let aggregationCursor: AggregationCursor | undefined = undefined;
         try {
             const provider = await this.resolveConnection(connectionId);
-            this.assertOnlyUsesPermittedStages(request.config, pipeline);
+            this.assertOnlyUsesPermittedStages(request.server.config, pipeline);
 
             let successMessage: string;
             let documents: unknown[];
@@ -84,15 +84,15 @@ export class AggregateDBTool extends MongoDBToolBase {
                 successMessage = "The aggregation pipeline executed successfully.";
             } else {
                 const cappedResultsPipeline = [...pipeline];
-                if (request.config.maxDocumentsPerQuery > 0) {
-                    cappedResultsPipeline.push({ $limit: request.config.maxDocumentsPerQuery });
+                if (request.server.config.maxDocumentsPerQuery > 0) {
+                    cappedResultsPipeline.push({ $limit: request.server.config.maxDocumentsPerQuery });
                 }
                 aggregationCursor = provider.aggregateDb(database, cappedResultsPipeline, {
                     ...this.getOperationOptions(request),
                 });
 
                 const [totalDocuments, cursorResults] = await Promise.all([
-                    this.countAggregationResultDocuments(request.config, {
+                    this.countAggregationResultDocuments(request.server.config, {
                         provider,
                         database,
                         pipeline,
@@ -100,7 +100,7 @@ export class AggregateDBTool extends MongoDBToolBase {
                     }),
                     collectCursorUntilMaxBytesLimit({
                         cursor: aggregationCursor,
-                        configuredMaxBytesPerQuery: request.config.maxBytesPerQuery,
+                        configuredMaxBytesPerQuery: request.server.config.maxBytesPerQuery,
                         toolResponseBytesLimit: responseBytesLimit,
                         abortSignal: request.signal,
                     }),
@@ -111,9 +111,9 @@ export class AggregateDBTool extends MongoDBToolBase {
                 // maxDocumentsPerQuery then we know for sure that the results were
                 // capped.
                 const aggregationResultsCappedByMaxDocumentsLimit =
-                    request.config.maxDocumentsPerQuery > 0 &&
+                    request.server.config.maxDocumentsPerQuery > 0 &&
                     !!totalDocuments &&
-                    totalDocuments > request.config.maxDocumentsPerQuery;
+                    totalDocuments > request.server.config.maxDocumentsPerQuery;
 
                 documents = bsonToJson(cursorResults.documents);
                 aggResultsCount = totalDocuments;

--- a/packages/tools-mongodb/src/tools/read/count.ts
+++ b/packages/tools-mongodb/src/tools/read/count.ts
@@ -38,10 +38,10 @@ export class CountTool extends MongoDBToolBase {
     ): Promise<ToolResult<typeof this.outputSchema>> {
         const provider = await this.resolveConnection(connectionId);
 
-        this.assertMqlIsAllowed(request.config, query);
+        this.assertMqlIsAllowed(request.server.config, query);
 
         // Check if count operation uses an index if enabled
-        if (request.config.indexCheck) {
+        if (request.server.config.indexCheck) {
             await checkIndexUsage({
                 database,
                 collection,
@@ -55,8 +55,8 @@ export class CountTool extends MongoDBToolBase {
                                 query,
                             },
                             verbosity: "queryPlanner",
-                            ...(request.config.maxTimeMS !== undefined && {
-                                maxTimeMS: request.config.maxTimeMS,
+                            ...(request.server.config.maxTimeMS !== undefined && {
+                                maxTimeMS: request.server.config.maxTimeMS,
                             }),
                         },
                         {

--- a/packages/tools-mongodb/src/tools/read/export.ts
+++ b/packages/tools-mongodb/src/tools/read/export.ts
@@ -78,7 +78,7 @@ export class ExportTool extends MongoDBToolBase {
         let cursor: FindCursor | AggregationCursor;
         if (exportTarget.name === "find") {
             const { filter, projection, sort, limit } = exportTarget.arguments;
-            this.assertMqlIsAllowed(request.config, filter, projection);
+            this.assertMqlIsAllowed(request.server.config, filter, projection);
             cursor = provider.find(database, collection, filter ?? {}, {
                 projection,
                 sort,
@@ -89,7 +89,7 @@ export class ExportTool extends MongoDBToolBase {
             });
         } else {
             const { pipeline } = exportTarget.arguments;
-            this.assertMqlIsAllowed(request.config, pipeline);
+            this.assertMqlIsAllowed(request.server.config, pipeline);
             cursor = provider.aggregate(database, collection, pipeline, {
                 promoteValues: false,
                 bsonRegExp: true,
@@ -128,7 +128,7 @@ export class ExportTool extends MongoDBToolBase {
         // This special case is to make it easier to work with exported data for
         // clients that still cannot reference resources (Cursor).
         // More information here: https://jira.mongodb.org/browse/MCP-104
-        if (this.isServerRunningLocally(request.config)) {
+        if (this.isServerRunningLocally(request.server.config)) {
             toolCallContent.push({
                 type: "text",
                 text: `Optionally, when the export is finished, the exported data can also be accessed under path - "${exportPath}"`,

--- a/packages/tools-mongodb/src/tools/read/find.ts
+++ b/packages/tools-mongodb/src/tools/read/find.ts
@@ -114,7 +114,10 @@ export class FindTool extends MongoDBToolBase {
                             // we don't use the limit provided to the tool either.
                             maxTimeMS:
                                 request.server.config.maxTimeMS !== undefined
-                                    ? Math.min(request.server.config.maxTimeMS, request.server.config.queryCountMaxTimeMsCap)
+                                    ? Math.min(
+                                          request.server.config.maxTimeMS,
+                                          request.server.config.queryCountMaxTimeMsCap
+                                      )
                                     : request.server.config.queryCountMaxTimeMsCap,
                             signal: request.signal,
                         }),

--- a/packages/tools-mongodb/src/tools/read/find.ts
+++ b/packages/tools-mongodb/src/tools/read/find.ts
@@ -73,10 +73,10 @@ export class FindTool extends MongoDBToolBase {
         try {
             const provider = await this.resolveConnection(connectionId);
 
-            this.assertMqlIsAllowed(request.config, filter, projection);
+            this.assertMqlIsAllowed(request.server.config, filter, projection);
 
             // Check if find operation uses an index if enabled
-            if (request.config.indexCheck) {
+            if (request.server.config.indexCheck) {
                 await checkIndexUsage({
                     database,
                     collection,
@@ -95,7 +95,7 @@ export class FindTool extends MongoDBToolBase {
                 });
             }
 
-            const limitOnFindCursor = this.getLimitForFindCursor(request.config, limit);
+            const limitOnFindCursor = this.getLimitForFindCursor(request.server.config, limit);
 
             findCursor = provider.find(database, collection, filter, {
                 projection,
@@ -113,16 +113,16 @@ export class FindTool extends MongoDBToolBase {
                             // use `limitOnFindCursor` calculated above, and
                             // we don't use the limit provided to the tool either.
                             maxTimeMS:
-                                request.config.maxTimeMS !== undefined
-                                    ? Math.min(request.config.maxTimeMS, request.config.queryCountMaxTimeMsCap)
-                                    : request.config.queryCountMaxTimeMsCap,
+                                request.server.config.maxTimeMS !== undefined
+                                    ? Math.min(request.server.config.maxTimeMS, request.server.config.queryCountMaxTimeMsCap)
+                                    : request.server.config.queryCountMaxTimeMsCap,
                             signal: request.signal,
                         }),
                     undefined
                 ),
                 collectCursorUntilMaxBytesLimit({
                     cursor: findCursor,
-                    configuredMaxBytesPerQuery: request.config.maxBytesPerQuery,
+                    configuredMaxBytesPerQuery: request.server.config.maxBytesPerQuery,
                     toolResponseBytesLimit: responseBytesLimit,
                     abortSignal: request.signal,
                 }),

--- a/packages/tools-mongodb/src/tools/update/renameCollection.ts
+++ b/packages/tools-mongodb/src/tools/update/renameCollection.ts
@@ -29,7 +29,7 @@ export class RenameCollectionTool extends MongoDBToolBase {
         { connectionId, database, collection, newName, dropTarget }: ToolArgs<typeof this.argsShape>,
         { request }: ToolExecutionContext<IMongoDBConfig>
     ): Promise<ToolResult<typeof this.outputSchema>> {
-        if (dropTarget && request.config.disabledTools.includes("delete")) {
+        if (dropTarget && request.server.config.disabledTools.includes("delete")) {
             // Renaming with `dropTarget: true` drops the existing target collection, which is a
             // destructive delete operation. Since this tool's operation type is `update`, it remains
             // available even when delete operations are disabled, so reject `dropTarget` in that case

--- a/packages/tools-mongodb/src/tools/update/updateMany.ts
+++ b/packages/tools-mongodb/src/tools/update/updateMany.ts
@@ -45,10 +45,10 @@ export class UpdateManyTool extends MongoDBToolBase {
     ): Promise<ToolResult<typeof this.outputSchema>> {
         const provider = await this.resolveConnection(connectionId);
 
-        this.assertMqlIsAllowed(request.config, filter);
+        this.assertMqlIsAllowed(request.server.config, filter);
 
         // Check if update operation uses an index if enabled
-        if (request.config.indexCheck) {
+        if (request.server.config.indexCheck) {
             await checkIndexUsage({
                 database,
                 collection,
@@ -67,7 +67,7 @@ export class UpdateManyTool extends MongoDBToolBase {
                             ],
                         },
                         verbosity: "queryPlanner",
-                        ...(request.config.maxTimeMS !== undefined && { maxTimeMS: request.config.maxTimeMS }),
+                        ...(request.server.config.maxTimeMS !== undefined && { maxTimeMS: request.server.config.maxTimeMS }),
                     });
                 },
                 logger: this.server.logger,

--- a/packages/tools-mongodb/src/tools/update/updateMany.ts
+++ b/packages/tools-mongodb/src/tools/update/updateMany.ts
@@ -67,7 +67,9 @@ export class UpdateManyTool extends MongoDBToolBase {
                             ],
                         },
                         verbosity: "queryPlanner",
-                        ...(request.server.config.maxTimeMS !== undefined && { maxTimeMS: request.server.config.maxTimeMS }),
+                        ...(request.server.config.maxTimeMS !== undefined && {
+                            maxTimeMS: request.server.config.maxTimeMS,
+                        }),
                     });
                 },
                 logger: this.server.logger,

--- a/packages/types/src/tool.ts
+++ b/packages/types/src/tool.ts
@@ -82,24 +82,28 @@ export type ToolCategory = "mongodb" | "atlas" | "atlas-local" | "assistant" | "
  * The request object passed to tool implementations: everything derived from
  * the individual request being handled. It is built fresh for each tool call
  * and deliberately lives nowhere else — the server holds no per-client or
- * per-request state, so the effective (possibly request-overridden) config
- * and the raw SDK request context travel with the call. Tools read it as
- * `request.config` / `request.raw` (see `ToolExecutionContext.request`).
+ * per-request state. Because every server is request-scoped, the effective
+ * (possibly request-overridden) config lives on it and is read as
+ * `request.server.config`; the raw SDK request context and other per-request
+ * data travel on the request itself (see `ToolExecutionContext.request`).
  */
 export type ToolRequest<TConfig extends IToolConfig = IToolConfig> = {
     /**
-     * The effective configuration for this request — the base server config
-     * merged with any request-level overrides (e.g. HTTP header/query
-     * overrides applied per request). Request-scoped: derived fresh for each
-     * call, never stored on the server. See `raw` for the original request
-     * this was built around.
+     * The request-scoped server instance this request was built around. The
+     * SDK's serving entries construct a fresh server per request
+     * (`createMcpHandler` once per HTTP request, `serveStdio` once per
+     * connection), so the server already carries the effective (possibly
+     * request-overridden) config: read it as `request.server.config`. The
+     * tool's construction-time `this.server` is the same instance and remains
+     * a valid shortcut. There is no `request.config` alias — the server is
+     * the single carrier of the effective config.
      */
-    readonly config: TConfig;
+    readonly server: ToolServer<ToolServices<TConfig>>;
     /**
      * The original request this request object was built around: the SDK's
      * per-request `mcpReq` object the tool call handler received. Undefined
      * when the tool is invoked directly in unit tests without a real SDK
-     * request. Prefer the normalized fields (`config`, `headers`, `id`,
+     * request. Prefer the normalized fields (`server`, `headers`, `id`,
      * `clientInfo`, ...); reach for `raw` only when the typed surface does
      * not cover what you need.
      */
@@ -148,9 +152,10 @@ export type ToolRequest<TConfig extends IToolConfig = IToolConfig> = {
 /**
  * Request-scoped context provided during tool execution. The request object
  * ({@link ToolRequest}) holds everything derived from the individual request
- * — the effective `config`, the original `raw` request, signal, request id,
- * client identity, elicitation state — and is built fresh per call by
- * `toToolExecutionContext`. Tools receive it as the `request` argument.
+ * — the request-scoped `server` (which carries the effective config), the
+ * original `raw` request, signal, request id, client identity, elicitation
+ * state — and is built fresh per call by `toToolExecutionContext`. Tools
+ * receive it as the `request` argument.
  */
 export type ToolExecutionContext<TConfig extends IToolConfig = IToolConfig> = {
     /** The request object this execution is built around. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,9 +265,6 @@ importers:
       '@modelcontextprotocol/core':
         specifier: ^2.0.0
         version: 2.0.0
-      '@modelcontextprotocol/node':
-        specifier: ^2.0.0
-        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.14)
       '@modelcontextprotocol/server':
         specifier: ^2.0.0
         version: 2.0.0
@@ -480,9 +477,6 @@ importers:
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
-      '@modelcontextprotocol/node':
-        specifier: ^2.0.0
-        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.14)
       '@modelcontextprotocol/server':
         specifier: ^2.0.0
         version: 2.0.0


### PR DESCRIPTION
Final slice: the effective (request-overridden) config moves from the request envelope to the request-scoped server (`request.server.config`), and the branch-wide lint/format/api-report sweep lands here so every part of the stack is standalone-green.

Final part of the session-removal stack (#1474); builds on part 3 (#1479). The net of parts 1-4 equals the original #1474 branch.