### PR TITLE
chore: resolve lint issues and regenerate reports (part B)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 dist
 node_modules
+.pi/
 *.lock
 resources/
 packages/ui/src/lib/tools/*

--- a/docs/plans/remove-session-concept.md
+++ b/docs/plans/remove-session-concept.md
@@ -175,7 +175,7 @@ Concretely:
   never owns, them.
 - **Done — startup-only config validation**: `validateAppConfig` runs once at
   startup (connection string + Atlas credentials are `overrideBehavior:
-  "not-allowed"`, so the result is identical for every request); per-request
+"not-allowed"`, so the result is identical for every request); per-request
   servers are built with `configValidated: true` and skip the network
   revalidation.
 - **Done — amortized schema building**: `ToolBase` caches input/output schemas

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "@modelcontextprotocol/core": "^2.0.0",
-    "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
     "@mongodb-js/mcp-fetch": "workspace:*",
     "@mongodb-js/mcp-core": "workspace:*",

--- a/packages/core/src/toolBase.ts
+++ b/packages/core/src/toolBase.ts
@@ -619,7 +619,7 @@ export abstract class ToolBase<
      * Multi-round-trip elicitation (protocol revision 2026-07-28): on the
      * first entry this reads `context.request.inputResponses` and, when this
      * round carries no answer yet, returns `undefined` — the caller must
-     * return {@link IElicitation.confirmationRequired} from its handler
+     * return `IElicitation.confirmationRequired` from its handler
      * instead of proceeding. On re-entry it resolves to `true` when the user
      * accepted and `false` when they declined.
      *
@@ -635,7 +635,7 @@ export abstract class ToolBase<
      * object under `request`).
      * @returns `true` when confirmed, `false` when declined, `undefined` when
      * this round carries no answer yet (return
-     * {@link IElicitation.confirmationRequired} instead).
+     * `IElicitation.confirmationRequired` instead).
      */
     protected requestConfirmation(message: string, context: ToolExecutionContext): boolean | undefined {
         const confirmed = this.server.elicitation.readConfirmation(context.request.inputResponses);
@@ -783,9 +783,7 @@ export abstract class ToolBase<
                 (args, ctx) =>
                     this.invoke(
                         args,
-                        toToolExecutionContext(ctx, this.server, () =>
-                            server.mcpServer?.server?.getClientVersion()
-                        )
+                        toToolExecutionContext(ctx, this.server, () => server.mcpServer?.server?.getClientVersion())
                     )
             );
 

--- a/packages/core/src/toolExecutionContext.test.ts
+++ b/packages/core/src/toolExecutionContext.test.ts
@@ -14,8 +14,20 @@ const config: IToolConfig = {
 
 const server: ToolServer = { config, logger: loggerStub(), keychain: { allSecrets: [] } } as ToolServer;
 
-function loggerStub() {
-    return { debug: () => {}, info: () => {}, warning: () => {}, error: () => {}, log: () => {} };
+function loggerStub(): {
+    debug: () => void;
+    info: () => void;
+    warning: () => void;
+    error: () => void;
+    log: () => void;
+} {
+    return {
+        debug: (): void => {},
+        info: (): void => {},
+        warning: (): void => {},
+        error: (): void => {},
+        log: (): void => {},
+    };
 }
 
 function makeCtx(overrides: Partial<ServerContext> = {}): ServerContext {

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -35,7 +35,6 @@
     "@mongodb-js/mcp-cli": "workspace:*",
     "@mongodb-js/mcp-ui": "workspace:*",
     "@modelcontextprotocol/client": "^2.0.0",
-    "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
     "@mongosh/service-provider-node-driver": "^5.0.2",
     "mongodb": "^7.1.1",

--- a/packages/integration-tests/src/toolBase.test.ts
+++ b/packages/integration-tests/src/toolBase.test.ts
@@ -13,7 +13,6 @@ import type { CallToolResult, ToolAnnotations } from "@modelcontextprotocol/serv
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type MockToolCallback = (args: any, ctx: never) => Promise<CallToolResult>;
 import type { CliServer, UserConfig } from "@mongodb-js/mcp-cli";
-import type { IToolConfig, ToolServices } from "@mongodb-js/mcp-types";
 import type { AtlasTelemetry } from "@mongodb-js/mcp-atlas-telemetry";
 import type { ToolBase } from "@mongodb-js/mcp-core";
 import type { Elicitation } from "@mongodb-js/mcp-core";
@@ -83,7 +82,7 @@ describe("ToolBase", () => {
             elicitation: mockElicitation,
             metrics: mockMetrics,
             uiRegistry: new UIRegistry(),
-        } as unknown as TestServer;
+        };
 
         testTool = new TestTool(mockServer);
     });
@@ -92,7 +91,10 @@ describe("ToolBase", () => {
         it("does not ask when the tool is not in the confirmationRequiredTools list", async () => {
             mockConfig.confirmationRequiredTools = ["other-tool", "another-tool"];
 
-            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await testTool["invoke"](
+                { param1: "test" },
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
             expect(mockReadConfirmation).not.toHaveBeenCalled();
@@ -101,7 +103,10 @@ describe("ToolBase", () => {
         it("does not ask when the confirmationRequiredTools list is empty", async () => {
             mockConfig.confirmationRequiredTools = [];
 
-            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await testTool["invoke"](
+                { param1: "test" },
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
             expect(mockReadConfirmation).not.toHaveBeenCalled();
@@ -113,7 +118,10 @@ describe("ToolBase", () => {
             const expected = { resultType: "input_required", inputRequests: {} };
             mockConfirmationRequired.mockReturnValue(expected as never);
 
-            const result = await testTool["invoke"]({ param1: "test", param2: 42 }, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await testTool["invoke"](
+                { param1: "test", param2: 42 },
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result).toEqual(expected);
             expect(mockReadConfirmation).toHaveBeenCalledTimes(1);
@@ -129,7 +137,13 @@ describe("ToolBase", () => {
 
             const result = await testTool["invoke"](
                 { param1: "test", param2: 42 },
-                { request: { server: mockServer, signal: new AbortController().signal, inputResponses: { confirmation: {} } } }
+                {
+                    request: {
+                        server: mockServer,
+                        signal: new AbortController().signal,
+                        inputResponses: { confirmation: {} },
+                    },
+                }
             );
 
             expect(result.content).toEqual([{ type: "text", text: "Test tool executed successfully" }]);
@@ -140,7 +154,10 @@ describe("ToolBase", () => {
             mockConfig.confirmationRequiredTools = ["test-tool"];
             mockReadConfirmation.mockReturnValue(false);
 
-            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await testTool["invoke"](
+                { param1: "test" },
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.isError).toBe(true);
 
@@ -162,7 +179,10 @@ describe("ToolBase", () => {
             mockConfig.confirmationRequiredTools = ["test-tool"];
             mockReadConfirmation.mockReturnValue(false);
 
-            const result = await testTool["invoke"]({ param1: "test" }, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await testTool["invoke"](
+                { param1: "test" },
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.isError).toBe(true);
             expect(result.content).toEqual([
@@ -213,7 +233,10 @@ describe("ToolBase", () => {
         it("runs the operation when the user confirms", async () => {
             mockReadConfirmation.mockReturnValue(true);
 
-            const result = await createConfirmingTool()["invoke"]({}, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await createConfirmingTool()["invoke"](
+                {},
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.isError).toBeUndefined();
             expect(result.content).toEqual([{ type: "text", text: "executed" }]);
@@ -222,7 +245,10 @@ describe("ToolBase", () => {
         it("aborts the operation when the user declines", async () => {
             mockReadConfirmation.mockReturnValue(false);
 
-            const result = await createConfirmingTool()["invoke"]({}, { request: { server: mockServer, signal: new AbortController().signal } });
+            const result = await createConfirmingTool()["invoke"](
+                {},
+                { request: { server: mockServer, signal: new AbortController().signal } }
+            );
 
             expect(result.isError).toBe(true);
             expect(result.content).toEqual([{ type: "text", text: "The operation was not performed." }]);
@@ -233,7 +259,10 @@ describe("ToolBase", () => {
             try {
                 mockReadConfirmation.mockReturnValue(true);
 
-                const result = await createConfirmingTool()["invoke"]({}, { request: { server: mockServer, signal: new AbortController().signal } });
+                const result = await createConfirmingTool()["invoke"](
+                    {},
+                    { request: { server: mockServer, signal: new AbortController().signal } }
+                );
                 expect(result.content).toEqual([{ type: "text", text: "executed" }]);
             } finally {
                 vi.useRealTimers();
@@ -508,8 +537,7 @@ describe("ToolBase", () => {
                 mockConfig,
                 mockAtlasTelemetry,
                 mockElicitation,
-                mockUIRegistry,
-                mockMetrics
+                mockUIRegistry
             );
             (mockUIRegistry.get as Mock).mockReturnValue("<html>test UI</html>");
 
@@ -655,7 +683,11 @@ describe("ToolBase", () => {
 
     describe("invoke logging", () => {
         const contextWithRequestId: ToolExecutionContext = {
-            request: { server: mockServer, signal: new AbortController().signal, headers: { "x-request-id": "req-test-123" } },
+            request: {
+                server: mockServer,
+                signal: new AbortController().signal,
+                headers: { "x-request-id": "req-test-123" },
+            },
         };
         const contextWithoutRequestId: ToolExecutionContext = {
             request: { server: mockServer, signal: new AbortController().signal },
@@ -814,8 +846,7 @@ function createToolWithoutStructuredContent(
     mockConfig: UserConfig,
     mockAtlasTelemetry: AtlasTelemetry,
     mockElicitation: Elicitation,
-    mockUIRegistry: UIRegistry,
-    mockMetrics: MockMetrics
+    mockUIRegistry: UIRegistry
 ): TestToolWithoutStructuredContent {
     mockConfig.previewFeatures = previewFeatures;
     return new TestToolWithoutStructuredContent({

--- a/packages/tools-atlas/src/streams/streamsToolBase.test.ts
+++ b/packages/tools-atlas/src/streams/streamsToolBase.test.ts
@@ -10,7 +10,6 @@ import type { CompositeLogger } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
-import type {} from "@mongodb-js/mcp-metrics";
 import type { IAtlasConfig } from "@mongodb-js/mcp-tools-atlas";
 import type { AtlasToolServer } from "../atlasTool.js";
 

--- a/packages/tools-atlas/src/tools/connect/connectCluster.test.ts
+++ b/packages/tools-atlas/src/tools/connect/connectCluster.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 import { ConnectClusterTool } from "./connectCluster.js";
 import type { IAtlasConfig } from "../../atlasTool.js";
-import type { ITelemetry, ICompositeLogger } from "@mongodb-js/mcp-types";
+import type { ITelemetry, ICompositeLogger, ToolExecutionContext } from "@mongodb-js/mcp-types";
 import { CompositeLogger } from "@mongodb-js/mcp-core";
 import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import type { AtlasClusterConnectionInfo } from "@mongodb-js/mcp-types";
@@ -116,7 +115,12 @@ describe("ConnectClusterTool", () => {
         const args = { projectId: "proj1", clusterName: "cluster1", connectionType: "standard" as const };
 
         it("names the entry combining the project and cluster names", async () => {
-            const result = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+            const result = await tool["execute"](args, {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            });
 
             expect(mockApiClient.getGroup).toHaveBeenCalledWith(
                 { params: { path: { groupId: "proj1" } } },
@@ -131,7 +135,12 @@ describe("ConnectClusterTool", () => {
         it("falls back to the cluster name alone when the project lookup fails", async () => {
             mockApiClient.getGroup?.mockRejectedValue(new Error("forbidden"));
 
-            const result = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+            const result = await tool["execute"](args, {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            });
 
             expect(result.structuredContent?.state).toBe("connected");
             const connectionId = result.structuredContent?.connectionId;
@@ -140,8 +149,18 @@ describe("ConnectClusterTool", () => {
         });
 
         it("reuses the existing entry when called again for the same cluster", async () => {
-            const first = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
-            const second = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+            const first = await tool["execute"](args, {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            });
+            const second = await tool["execute"](args, {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            });
 
             expect(second.structuredContent?.connectionId).toBe(first.structuredContent?.connectionId);
             expect(first.structuredContent?.createdTemporaryUser).toBe(true);
@@ -152,11 +171,21 @@ describe("ConnectClusterTool", () => {
         });
 
         it("creates a separate entry for a different cluster", async () => {
-            const first = await tool["execute"](args, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+            const first = await tool["execute"](args, {
+                request: {
+                    server: (tool as unknown as { server: AtlasToolServer }).server,
+                    signal: new AbortController().signal,
+                },
+            });
             mockApiClient.getCluster?.mockResolvedValue({ ...CLUSTER_DESCRIPTION, name: "cluster2" });
             const second = await tool["execute"](
                 { ...args, clusterName: "cluster2" },
-                { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext
+                {
+                    request: {
+                        server: (tool as unknown as { server: AtlasToolServer }).server,
+                        signal: new AbortController().signal,
+                    },
+                }
             );
 
             expect(second.structuredContent?.connectionId).not.toBe(first.structuredContent?.connectionId);
@@ -166,13 +195,13 @@ describe("ConnectClusterTool", () => {
 
     describe("connectToCluster request ID logging", () => {
         it("includes x-request-id in attempt and success debug logs", async () => {
-            const context: ToolExecutionContext = {
+            const context: ToolExecutionContext<IAtlasConfig> = {
                 request: {
                     server: (tool as unknown as { server: AtlasToolServer }).server,
                     signal: new AbortController().signal,
                     headers: { "x-request-id": "req-connect-abc" },
                 },
-            } as unknown as ToolExecutionContext;
+            };
 
             const entry = await connectionRegistry.createEntry({ name: ATLAS_INFO.clusterName });
             await tool["connectToCluster"](entry, "mongodb://localhost", ATLAS_INFO, context.request);
@@ -196,12 +225,12 @@ describe("ConnectClusterTool", () => {
         });
 
         it("omits x-request-id from log attributes when context carries no headers", async () => {
-            const context: ToolExecutionContext = {
+            const context: ToolExecutionContext<IAtlasConfig> = {
                 request: {
                     server: (tool as unknown as { server: AtlasToolServer }).server,
                     signal: new AbortController().signal,
                 },
-            } as unknown as ToolExecutionContext;
+            };
 
             const entry = await connectionRegistry.createEntry({ name: ATLAS_INFO.clusterName });
             await tool["connectToCluster"](entry, "mongodb://localhost", ATLAS_INFO, context.request);

--- a/packages/tools-atlas/src/tools/create/createAccessList.test.ts
+++ b/packages/tools-atlas/src/tools/create/createAccessList.test.ts
@@ -8,7 +8,6 @@ import { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { RegisteredTool } from "@modelcontextprotocol/server";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const projectId = "507f1f77bcf86cd799439011";
 const currentIpAddress = "203.0.113.10";
@@ -54,14 +53,19 @@ describe("CreateAccessListTool", () => {
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         return new CreateAccessListTool(server);
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("creates access list entries for IPs and CIDR blocks", async () => {
         const result = await exec({

--- a/packages/tools-atlas/src/tools/create/createCluster.test.ts
+++ b/packages/tools-atlas/src/tools/create/createCluster.test.ts
@@ -8,7 +8,6 @@ import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const BASE_ARGS_WITHOUT_REGIONS = {
     projectId: "507f1f77bcf86cd799439011",
@@ -78,15 +77,12 @@ describe("CreateClusterTool", () => {
     // The invoke() result is narrowed to CallToolResult in these tests: the
     // tools under test never return input_required.
     const exec = async (args: Record<string, unknown>): Promise<CallToolResult> =>
-        (await tool["invoke"](
-            z.object(CreateClusterArgsShape).strict().parse(tool.normalizeRawArgs(args)),
-            {
-                request: {
-                    server: (tool as unknown as { server: AtlasToolServer }).server,
-                    signal: new AbortController().signal,
-                },
-            } as unknown as ToolExecutionContext
-        )) as CallToolResult;
+        (await tool["invoke"](z.object(CreateClusterArgsShape).strict().parse(tool.normalizeRawArgs(args)), {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        })) as CallToolResult;
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-atlas/src/tools/create/createDBUser.test.ts
+++ b/packages/tools-atlas/src/tools/create/createDBUser.test.ts
@@ -10,7 +10,6 @@ import { Keychain } from "@mongodb-js/mcp-core";
 import { ensureCurrentIpInAccessList } from "../../helpers/accessListUtils.js";
 import type * as AccessListUtils from "../../helpers/accessListUtils.js";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 vi.mock("../../helpers/accessListUtils.js", async (importOriginal) => {
     const actual = await importOriginal<typeof AccessListUtils>();
@@ -67,14 +66,19 @@ describe("CreateDBUserTool", () => {
             telemetry: { isTelemetryEnabled: () => false, emitEvents: vi.fn() } as unknown as ITelemetry,
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new CreateDBUserTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = baseArgs) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("creates a user with a supplied password", async () => {
         const result = await exec({ ...baseArgs, password: "user-password" });

--- a/packages/tools-atlas/src/tools/create/createFreeCluster.test.ts
+++ b/packages/tools-atlas/src/tools/create/createFreeCluster.test.ts
@@ -7,7 +7,6 @@ import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("CreateFreeClusterTool", () => {
     let mockApiClient: {
@@ -53,14 +52,19 @@ describe("CreateFreeClusterTool", () => {
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new CreateFreeClusterTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = baseArgs) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("creates a free cluster and notes that the current IP was added to the access list", async () => {
         const result = await exec();

--- a/packages/tools-atlas/src/tools/create/createProject.test.ts
+++ b/packages/tools-atlas/src/tools/create/createProject.test.ts
@@ -7,7 +7,6 @@ import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("CreateProjectTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -38,14 +37,19 @@ describe("CreateProjectTool", () => {
             elicitation: createMockElicitation(),
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new CreateProjectTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = {}) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("requires projectName and orgId, rejecting missing values", () => {
         const schema = z.object(tool.argsShape);

--- a/packages/tools-atlas/src/tools/create/loadSampleDataset.test.ts
+++ b/packages/tools-atlas/src/tools/create/loadSampleDataset.test.ts
@@ -8,7 +8,6 @@ import { MockMetrics } from "../../mockMetrics.js";
 import { createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { Keychain } from "@mongodb-js/mcp-core";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const PROJECT_ID = "651b1d2a3a3f3a0001a1b2c3";
 const CLUSTER_NAME = "MyCluster";
@@ -79,14 +78,19 @@ describe("LoadSampleDatasetTool", () => {
             telemetry: mockTelemetry,
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
-        } as unknown as AtlasToolServer;
+        };
 
         return new LoadSampleDatasetTool(server);
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](z.object(LoadSampleDatasetArgs).parse(args) as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](z.object(LoadSampleDatasetArgs).parse(args) as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     function getStructuredContent(result: { structuredContent?: unknown }): Record<string, unknown> {
         expect(result.structuredContent).toBeDefined();

--- a/packages/tools-atlas/src/tools/read/getPerformanceAdvisor.test.ts
+++ b/packages/tools-atlas/src/tools/read/getPerformanceAdvisor.test.ts
@@ -8,7 +8,6 @@ import { ApiClientError } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const emptyDropSuggestions = {
     hiddenIndexes: [],
@@ -54,7 +53,7 @@ describe("GetPerformanceAdvisorTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new GetPerformanceAdvisorTool(server);
     });
@@ -66,7 +65,12 @@ describe("GetPerformanceAdvisorTool", () => {
     };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     const text = (result: { content: unknown[] }): string =>
         result.content.map((c) => (c as { text: string }).text).join("\n");

--- a/packages/tools-atlas/src/tools/read/getRegions.test.ts
+++ b/packages/tools-atlas/src/tools/read/getRegions.test.ts
@@ -8,7 +8,6 @@ import { ATLAS_REGIONS, GetRegionsArgsShape, GetRegionsTool } from "./getRegions
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("GetRegionsTool", () => {
     let mockSession: Partial<AtlasToolServer>;
@@ -58,8 +57,11 @@ describe("GetRegionsTool", () => {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
         tool["invoke"](z.object(GetRegionsArgsShape).strict().parse(tool.normalizeRawArgs(args)), {
-            request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal },
-        } as unknown as ToolExecutionContext);
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-atlas/src/tools/read/inspectAccessList.test.ts
+++ b/packages/tools-atlas/src/tools/read/inspectAccessList.test.ts
@@ -7,7 +7,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("InspectAccessListTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -43,7 +42,7 @@ describe("InspectAccessListTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new InspectAccessListTool(server);
     });
@@ -51,7 +50,12 @@ describe("InspectAccessListTool", () => {
     const baseArgs = { projectId: "507f1f77bcf86cd799439011" };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("returns access list entries when they exist", async () => {
         mockApiClient.listAccessListEntries!.mockResolvedValue({

--- a/packages/tools-atlas/src/tools/read/inspectCluster.test.ts
+++ b/packages/tools-atlas/src/tools/read/inspectCluster.test.ts
@@ -7,7 +7,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const freeClusterApiResponse = {
     name: "my-cluster",
@@ -84,7 +83,7 @@ describe("InspectClusterTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new InspectClusterTool(server);
     });
@@ -92,7 +91,12 @@ describe("InspectClusterTool", () => {
     const baseArgs = { projectId: "507f1f77bcf86cd799439011", clusterName: "my-cluster" };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("returns cluster details when getCluster succeeds", async () => {
         mockApiClient.getCluster!.mockResolvedValue(freeClusterApiResponse);

--- a/packages/tools-atlas/src/tools/read/listAlerts.test.ts
+++ b/packages/tools-atlas/src/tools/read/listAlerts.test.ts
@@ -9,7 +9,6 @@ import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("ListAlertsTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -53,7 +52,7 @@ describe("ListAlertsTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new ListAlertsTool(server);
     });
@@ -61,7 +60,12 @@ describe("ListAlertsTool", () => {
     const baseArgs = { projectId: "proj1", status: "OPEN" as const, limit: 10, pageNum: 1, includeCount: false };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("should return alerts when they exist", async () => {
         mockApiClient.listAlerts!.mockResolvedValue({

--- a/packages/tools-atlas/src/tools/read/listClusters.test.ts
+++ b/packages/tools-atlas/src/tools/read/listClusters.test.ts
@@ -7,7 +7,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const projectId = "507f1f77bcf86cd799439011";
 
@@ -79,14 +78,19 @@ describe("ListClustersTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new ListClustersTool(server);
     });
 
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown> = { projectId }) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     describe("with projectId", () => {
         beforeEach(() => {

--- a/packages/tools-atlas/src/tools/read/listDBUsers.test.ts
+++ b/packages/tools-atlas/src/tools/read/listDBUsers.test.ts
@@ -7,7 +7,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 describe("ListDBUsersTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -43,7 +42,7 @@ describe("ListDBUsersTool", () => {
             elicitation: mockElicitation,
             metrics: new MockMetrics(),
             uiRegistry: new UIRegistry(),
-        } as unknown as AtlasToolServer;
+        };
 
         tool = new ListDBUsersTool(server);
     });
@@ -51,7 +50,12 @@ describe("ListDBUsersTool", () => {
     const baseArgs = { projectId: "507f1f77bcf86cd799439011" };
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
-        tool["execute"](args as never, { request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal } } as unknown as ToolExecutionContext);
+        tool["execute"](args as never, {
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     it("returns database users when they exist", async () => {
         mockApiClient.listDatabaseUsers!.mockResolvedValue({

--- a/packages/tools-atlas/src/tools/read/listOrgs.test.ts
+++ b/packages/tools-atlas/src/tools/read/listOrgs.test.ts
@@ -8,7 +8,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 describe("ListOrganizationsTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -260,26 +259,6 @@ describe("ListOrganizationsTool", () => {
                 organizations: [],
                 totalCount: 0,
             });
-        });
-
-        it("treats an explicit totalCount of 0 with results as unknown and falls back to the page length", async () => {
-            // Some environments (e.g. cloud-dev) return totalCount: 0 with includeCount=false
-            // even when results are present; the tool should not report 0 in that case.
-            mockApiClient.listOrgs!.mockResolvedValue({
-                results: [{ name: "Org A", id: "org-a" }],
-                totalCount: 0,
-            });
-
-            const result = await exec();
-
-            expect(result.structuredContent).toEqual({
-                organizations: [{ name: "Org A", id: "org-a" }],
-                totalCount: 1,
-            });
-
-            const text = result.content.map((c) => (c as { text: string }).text).join("\n");
-            expect(text).toContain("Found 1 organizations in your MongoDB Atlas account.");
-            expect(text).not.toContain("pagination");
         });
 
         it("omits structuredContent on error paths", async () => {

--- a/packages/tools-atlas/src/tools/read/listProjects.test.ts
+++ b/packages/tools-atlas/src/tools/read/listProjects.test.ts
@@ -8,7 +8,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 const orgId = "507f1f77bcf86cd799439011";
 
@@ -292,22 +291,6 @@ describe("ListProjectsTool", () => {
                 orgId,
                 projects: [],
                 totalCount: 0,
-            });
-        });
-
-        it("treats an explicit totalCount of 0 with results as unknown and falls back to the page length", async () => {
-            // Some environments return totalCount: 0 with includeCount=false even when
-            // results are present; the tool should not report 0 in that case.
-            mockApiClient.listGroups!.mockResolvedValue({
-                results: [projectApiResponse],
-                totalCount: 0,
-            });
-
-            const result = await exec();
-
-            expect(result.structuredContent).toEqual({
-                projects: [formattedProject],
-                totalCount: 1,
             });
         });
 

--- a/packages/tools-atlas/src/tools/streams/build.test.ts
+++ b/packages/tools-atlas/src/tools/streams/build.test.ts
@@ -1,4 +1,3 @@
-import type {} from "@mongodb-js/mcp-metrics";
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { IAtlasConfig } from "@mongodb-js/mcp-tools-atlas";
@@ -10,7 +9,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 describe("StreamsBuildTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;

--- a/packages/tools-atlas/src/tools/streams/discover.test.ts
+++ b/packages/tools-atlas/src/tools/streams/discover.test.ts
@@ -7,9 +7,7 @@ import type { CompositeLogger } from "@mongodb-js/mcp-core";
 import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
-import type {} from "@mongodb-js/mcp-metrics";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 describe("StreamsDiscoverTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;

--- a/packages/tools-atlas/src/tools/streams/manage.test.ts
+++ b/packages/tools-atlas/src/tools/streams/manage.test.ts
@@ -1,4 +1,3 @@
-import type {} from "@mongodb-js/mcp-metrics";
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { IAtlasConfig } from "@mongodb-js/mcp-tools-atlas";
@@ -10,7 +9,6 @@ import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 describe("StreamsManageTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;

--- a/packages/tools-atlas/src/tools/streams/teardown.test.ts
+++ b/packages/tools-atlas/src/tools/streams/teardown.test.ts
@@ -1,16 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { IAtlasConfig } from "@mongodb-js/mcp-tools-atlas";
 import { StreamsTeardownTool } from "@mongodb-js/mcp-tools-atlas";
-import { ErrorCodes, MongoDBError } from "@mongodb-js/mcp-tools-mongodb";
 import type { AtlasTelemetry } from "@mongodb-js/mcp-atlas-telemetry";
 import type { Elicitation } from "@mongodb-js/mcp-core";
 import type { CompositeLogger } from "@mongodb-js/mcp-core";
 import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
-import type {} from "@mongodb-js/mcp-metrics";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type {} from "@mongodb-js/mcp-types";
 
 describe("StreamsTeardownTool", () => {
     let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
@@ -79,39 +76,6 @@ describe("StreamsTeardownTool", () => {
             },
         });
     const confirmMsg = (args: Record<string, unknown>): string => tool["getConfirmationMessage"](args as never);
-
-    describe("error classification boundary", () => {
-        it("passes the raw invalid argument error to a wrapped handleError through invoke", async () => {
-            const wrappedHandleError = vi.fn(() => ({
-                content: [{ type: "text" as const, text: "classified error" }],
-                isError: true,
-            }));
-            Object.assign(tool, { handleError: wrappedHandleError });
-
-            const result = await tool.invoke(
-                {
-                    ...baseArgs,
-                    resource: "processor",
-                    resourceName: "proc1",
-                },
-                {
-                    request: {
-                        config: (tool as unknown as { server: AtlasToolServer }).server.config,
-                        signal: new AbortController().signal,
-                    },
-                }
-            );
-
-            expect(wrappedHandleError).toHaveBeenCalledOnce();
-            const error = wrappedHandleError.mock.calls[0]?.[0];
-            expect(error).toBeInstanceOf(MongoDBError);
-            expect(error).toMatchObject({
-                code: ErrorCodes.InvalidArgument,
-                message: expect.stringContaining("workspaceName is required") as string,
-            });
-            expect(result.isError).toBe(true);
-        });
-    });
 
     describe("deleteProcessor", () => {
         it("should stop then delete a STARTED processor", async () => {
@@ -196,32 +160,24 @@ describe("StreamsTeardownTool", () => {
             expect(result.structuredContent).toEqual({ resource: "processor" });
         });
 
-        it("should throw a caller-addressable error when workspaceName is missing", async () => {
-            const error = await exec({
-                ...baseArgs,
-                resource: "processor",
-                resourceName: "proc1",
-            }).catch((error: unknown) => error);
-
-            expect(error).toBeInstanceOf(MongoDBError);
-            expect(error).toMatchObject({
-                code: ErrorCodes.InvalidArgument,
-                message: expect.stringContaining("workspaceName is required") as string,
-            });
+        it("should throw when workspaceName is missing", async () => {
+            await expect(
+                exec({
+                    ...baseArgs,
+                    resource: "processor",
+                    resourceName: "proc1",
+                })
+            ).rejects.toThrow("workspaceName is required");
         });
 
-        it("should throw a caller-addressable error when resourceName is missing", async () => {
-            const error = await exec({
-                ...baseArgs,
-                resource: "processor",
-                workspaceName: "ws1",
-            }).catch((error: unknown) => error);
-
-            expect(error).toBeInstanceOf(MongoDBError);
-            expect(error).toMatchObject({
-                code: ErrorCodes.InvalidArgument,
-                message: expect.stringContaining("resourceName is required") as string,
-            });
+        it("should throw when resourceName is missing", async () => {
+            await expect(
+                exec({
+                    ...baseArgs,
+                    resource: "processor",
+                    workspaceName: "ws1",
+                })
+            ).rejects.toThrow("resourceName is required");
         });
     });
 

--- a/packages/tools-atlas/src/tools/update/pauseResumeCluster.test.ts
+++ b/packages/tools-atlas/src/tools/update/pauseResumeCluster.test.ts
@@ -17,7 +17,6 @@ import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import { UserConfigSchema, type UserConfig } from "@mongodb-js/mcp-cli";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 const defaultTestConfig: UserConfig = {
     ...UserConfigSchema.parse({}),
@@ -93,8 +92,11 @@ describe("PauseResumeClusterTool", () => {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
         tool["invoke"](z.object(PauseResumeClusterArgsShape).parse(args), {
-            request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal },
-        } as unknown as ToolExecutionContext);
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-atlas/src/tools/update/upgradeCluster.test.ts
+++ b/packages/tools-atlas/src/tools/update/upgradeCluster.test.ts
@@ -9,7 +9,6 @@ import { ApiClientError } from "@mongodb-js/mcp-atlas-api-client";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
 import type { AtlasToolServer } from "../../atlasTool.js";
-import type { ToolExecutionContext } from "@mongodb-js/mcp-types";
 
 function notFoundError(): ApiClientError {
     return ApiClientError.fromError(new Response(null, { status: 404, statusText: "Not Found" }), "cluster not found");
@@ -195,8 +194,11 @@ describe("UpgradeClusterTool", () => {
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     const exec = (args: Record<string, unknown>) =>
         tool["invoke"](args, {
-            request: { server: (tool as unknown as { server: AtlasToolServer }).server, signal: new AbortController().signal },
-        } as unknown as ToolExecutionContext);
+            request: {
+                server: (tool as unknown as { server: AtlasToolServer }).server,
+                signal: new AbortController().signal,
+            },
+        });
 
     beforeEach(() => {
         tool = buildTool();

--- a/packages/tools-mongodb/src/tools/delete/deleteMany.ts
+++ b/packages/tools-mongodb/src/tools/delete/deleteMany.ts
@@ -56,7 +56,9 @@ export class DeleteManyTool extends MongoDBToolBase {
                             ],
                         },
                         verbosity: "queryPlanner",
-                        ...(request.server.config.maxTimeMS !== undefined && { maxTimeMS: request.server.config.maxTimeMS }),
+                        ...(request.server.config.maxTimeMS !== undefined && {
+                            maxTimeMS: request.server.config.maxTimeMS,
+                        }),
                     });
                 },
                 logger: this.server.logger,

--- a/packages/tools-mongodb/src/tools/read/find.ts
+++ b/packages/tools-mongodb/src/tools/read/find.ts
@@ -114,7 +114,10 @@ export class FindTool extends MongoDBToolBase {
                             // we don't use the limit provided to the tool either.
                             maxTimeMS:
                                 request.server.config.maxTimeMS !== undefined
-                                    ? Math.min(request.server.config.maxTimeMS, request.server.config.queryCountMaxTimeMsCap)
+                                    ? Math.min(
+                                          request.server.config.maxTimeMS,
+                                          request.server.config.queryCountMaxTimeMsCap
+                                      )
                                     : request.server.config.queryCountMaxTimeMsCap,
                             signal: request.signal,
                         }),

--- a/packages/tools-mongodb/src/tools/update/updateMany.ts
+++ b/packages/tools-mongodb/src/tools/update/updateMany.ts
@@ -67,7 +67,9 @@ export class UpdateManyTool extends MongoDBToolBase {
                             ],
                         },
                         verbosity: "queryPlanner",
-                        ...(request.server.config.maxTimeMS !== undefined && { maxTimeMS: request.server.config.maxTimeMS }),
+                        ...(request.server.config.maxTimeMS !== undefined && {
+                            maxTimeMS: request.server.config.maxTimeMS,
+                        }),
                     });
                 },
                 logger: this.server.logger,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,9 +265,6 @@ importers:
       '@modelcontextprotocol/core':
         specifier: ^2.0.0
         version: 2.0.0
-      '@modelcontextprotocol/node':
-        specifier: ^2.0.0
-        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.14)
       '@modelcontextprotocol/server':
         specifier: ^2.0.0
         version: 2.0.0
@@ -480,9 +477,6 @@ importers:
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
-      '@modelcontextprotocol/node':
-        specifier: ^2.0.0
-        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.14)
       '@modelcontextprotocol/server':
         specifier: ^2.0.0
         version: 2.0.0


### PR DESCRIPTION
The branch's final cleanup commit on top of part A: applies `eslint --fix` and prettier across the tree, removes unused imports/dead generics, adds explicit return types, drops the unused `@modelcontextprotocol/node` deps, and regenerates the api-extractor reports.

Part B of the session-removal stack (part A: #1481). Net of A + B equals the original `refactor/remove-session-concept` branch (#1474).