### PR TITLE
chore: Add classifiable ToolArgumentValidationError for tool argument failures MCP-644

### DIFF
--- a/api-extractor/reports/core.public.api.md
+++ b/api-extractor/reports/core.public.api.md
@@ -469,6 +469,11 @@ export type ToolArgs<T extends ZodRawShape> = {
 };
 
 // @public
+export class ToolArgumentValidationError extends UserFacingError {
+    constructor(message: string);
+}
+
+// @public
 export abstract class ToolBase<TSession extends IToolSession = IToolSession, TMetricsDefinitions extends DefaultMetricDefinitions = DefaultMetricDefinitions> {
     constructor(input: ToolConstructorParams<TSession, TMetricsDefinitions>);
     // (undocumented)

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -512,30 +512,7 @@ export function createDefaultMetrics(): {
 export type DefaultEventMap = Record<string, never[]>;
 
 // @public (undocumented)
-export const defaultParserOptions: {
-    config: string;
-    envPrefix: string;
-    configuration: {
-        "populate--": true;
-        "boolean-negation"?: boolean | undefined;
-        "camel-case-expansion"?: boolean | undefined;
-        "combine-arrays"?: boolean | undefined;
-        "dot-notation"?: boolean | undefined;
-        "duplicate-arguments-array"?: boolean | undefined;
-        "flatten-duplicate-arrays"?: boolean | undefined;
-        "greedy-arrays"?: boolean | undefined;
-        "nargs-eats-options"?: boolean | undefined;
-        "halt-at-non-option"?: boolean | undefined;
-        "negation-prefix"?: string | undefined;
-        "parse-numbers"?: boolean | undefined;
-        "parse-positional-numbers"?: boolean | undefined;
-        "set-placeholder-key"?: boolean | undefined;
-        "short-option-groups"?: boolean | undefined;
-        "strip-aliased"?: boolean | undefined;
-        "strip-dashed"?: boolean | undefined;
-        "unknown-options-as-args"?: boolean | undefined;
-    };
-};
+export const defaultParserOptions: ParserOptions;
 
 // @public (undocumented)
 export type DefaultPrometheusMetricDefinitions = ReturnType<typeof createDefaultMetrics>;
@@ -1073,6 +1050,11 @@ export type ToolArgs<T extends ZodRawShape> = {
 };
 
 // @public
+export class ToolArgumentValidationError extends UserFacingError {
+    constructor(message: string);
+}
+
+// @public
 export abstract class ToolBase<TSession extends IToolSession = IToolSession, TMetricsDefinitions extends DefaultMetricDefinitions = DefaultMetricDefinitions> {
     constructor(input: ToolConstructorParams<TSession, TMetricsDefinitions>);
     // (undocumented)
@@ -1321,6 +1303,11 @@ export const UserConfigSchema: z.ZodObject<{
     }>]>>;
     browser: z.ZodOptional<z.ZodUnion<readonly [z.ZodLiteral<false>, z.ZodString]>>;
 }, z.core.$strip>;
+
+// @public
+export class UserFacingError extends Error {
+    constructor(message: string);
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/cli/src/config/parseUserConfig.ts
+++ b/packages/cli/src/config/parseUserConfig.ts
@@ -13,7 +13,7 @@ const levenshtein = levenshteinModule.default;
 
 export type ParserOptions = typeof defaultArgParserOptions;
 
-export const defaultParserOptions = {
+export const defaultParserOptions: ParserOptions = {
     // This is the name of key that yargs-parser will look up in CLI
     // arguments (--config) and ENV variables (MDB_MCP_CONFIG) to load an
     // initial configuration from.
@@ -26,7 +26,7 @@ export const defaultParserOptions = {
         // populate `--` variable and altogether ignore them later.
         "populate--": true,
     },
-} satisfies ParserOptions;
+};
 
 export function parseUserConfig({
     args,

--- a/packages/cli/src/config/parseUserConfig.ts
+++ b/packages/cli/src/config/parseUserConfig.ts
@@ -13,7 +13,7 @@ const levenshtein = levenshteinModule.default;
 
 export type ParserOptions = typeof defaultArgParserOptions;
 
-export const defaultParserOptions: ParserOptions = {
+export const defaultParserOptions = {
     // This is the name of key that yargs-parser will look up in CLI
     // arguments (--config) and ENV variables (MDB_MCP_CONFIG) to load an
     // initial configuration from.
@@ -26,7 +26,7 @@ export const defaultParserOptions: ParserOptions = {
         // populate `--` variable and altogether ignore them later.
         "populate--": true,
     },
-};
+} satisfies ParserOptions;
 
 export function parseUserConfig({
     args,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -9,3 +9,14 @@ export class UserFacingError extends Error {
         this.name = "UserFacingError";
     }
 }
+
+/**
+ * Thrown by a tool's `execute()` when the supplied arguments fail validation
+ * that the caller can fix by retrying with corrected input.
+ */
+export class ToolArgumentValidationError extends UserFacingError {
+    constructor(message: string) {
+        super(message);
+        this.name = "ToolArgumentValidationError";
+    }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@ export { NoopLogger } from "./logging/noopLogger.js";
 export { CompositeLogger } from "./logging/compositeLogger.js";
 export { Keychain, registerGlobalSecretToRedact } from "./keychain.js";
 export { NoopTelemetry } from "./telemetry/noopTelemetry.js";
-export { UserFacingError } from "./errors.js";
+export { UserFacingError, ToolArgumentValidationError } from "./errors.js";
 export type { Secret } from "mongodb-redact";
 export { McpServer } from "@modelcontextprotocol/server";
 export type { InputRequiredResult, CallToolResult } from "@modelcontextprotocol/server";

--- a/packages/integration-tests/src/tools/atlas/accessLists.test.ts
+++ b/packages/integration-tests/src/tools/atlas/accessLists.test.ts
@@ -102,7 +102,7 @@ describeWithAtlas("ip access lists", (integration) => {
                 expect(response.isError).toBe(true);
                 const message = getResponseContent(response.content);
                 expect(message).toContain("Input validation error:");
-                expect(message).toContain("Comment must be 80 characters or less.");
+                expect(message).toContain("comment: Too big: expected string to have <=80 characters");
             });
         });
 

--- a/packages/integration-tests/src/tools/atlas/accessLists.test.ts
+++ b/packages/integration-tests/src/tools/atlas/accessLists.test.ts
@@ -1,5 +1,10 @@
 import { assertApiClientIsAvailable, describeWithAtlas, withProject } from "./atlasHelpers.js";
-import { expectDefined, getDataFromUntrustedContent, getResponseElements } from "../../integrationHelpers.js";
+import {
+    expectDefined,
+    getDataFromUntrustedContent,
+    getResponseContent,
+    getResponseElements,
+} from "../../integrationHelpers.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { ensureCurrentIpInAccessList } from "@mongodb-js/mcp-tools-atlas";
 
@@ -80,6 +85,24 @@ describeWithAtlas("ip access lists", (integration) => {
                 expect(response.structuredContent).toEqual({
                     projectId,
                 });
+            });
+
+            it("rejects a comment longer than 80 characters", async () => {
+                const projectId = getProjectId();
+
+                const response = await integration.mcpClient().callTool({
+                    name: "atlas-create-access-list",
+                    arguments: {
+                        projectId,
+                        ipAddresses: [generateRandomIp()],
+                        comment: "a".repeat(81),
+                    },
+                });
+
+                expect(response.isError).toBe(true);
+                const message = getResponseContent(response.content);
+                expect(message).toContain("Input validation error:");
+                expect(message).toContain("Comment must be 80 characters or less.");
             });
         });
 

--- a/packages/mongodb-mcp-server/src/lib.ts
+++ b/packages/mongodb-mcp-server/src/lib.ts
@@ -65,6 +65,7 @@ export type {
     TelemetryConfig,
 } from "@mongodb-js/mcp-atlas-telemetry";
 export { Keychain, registerGlobalSecretToRedact } from "@mongodb-js/mcp-core";
+export { UserFacingError, ToolArgumentValidationError } from "@mongodb-js/mcp-core";
 export type { Secret } from "@mongodb-js/mcp-types";
 export { Elicitation } from "@mongodb-js/mcp-core";
 export { applyConfigOverrides, ConfigOverrideError, getConfigMeta, nameToConfigKey } from "@mongodb-js/mcp-cli";

--- a/packages/tools-atlas/src/tools/create/createAccessList.test.ts
+++ b/packages/tools-atlas/src/tools/create/createAccessList.test.ts
@@ -6,7 +6,7 @@ import type { IAtlasConfig, IAtlasSession } from "../../atlasTool.js";
 import type { ITelemetry, ICompositeLogger } from "@mongodb-js/mcp-types";
 import type { ApiClient } from "@mongodb-js/mcp-atlas-api-client";
 import { MockMetrics, createMockElicitation } from "@mongodb-js/mcp-test-utils";
-import { Keychain } from "@mongodb-js/mcp-core";
+import { Keychain, ToolArgumentValidationError } from "@mongodb-js/mcp-core";
 import { UIRegistry } from "@mongodb-js/mcp-ui";
 import type { RegisteredTool } from "@modelcontextprotocol/server";
 
@@ -107,6 +107,7 @@ describe("CreateAccessListTool", () => {
     });
 
     it("throws when no inputs are provided", async () => {
+        await expect(exec({ projectId })).rejects.toThrow(ToolArgumentValidationError);
         await expect(exec({ projectId })).rejects.toThrow(
             "One of ipAddresses, cidrBlocks, currentIpAddress must be provided."
         );
@@ -126,6 +127,7 @@ describe("CreateAccessListTool", () => {
         });
 
         it("directs the user to provide explicit IPs when no inputs are provided", async () => {
+            await expect(exec({ projectId })).rejects.toThrow(ToolArgumentValidationError);
             await expect(exec({ projectId })).rejects.toThrow("Either ipAddresses or cidrBlocks must be provided.");
         });
 

--- a/packages/tools-atlas/src/tools/create/createAccessList.test.ts
+++ b/packages/tools-atlas/src/tools/create/createAccessList.test.ts
@@ -177,6 +177,16 @@ describe("CreateAccessListTool", () => {
             const b = registeredInputSchema(makeTool({ ...mockApiClient, supportsCurrentIpLookup: true }));
             expect(a).toBe(b);
         });
+
+        it("accepts a comment at the 80-character limit and rejects longer ones", () => {
+            const schema = registeredInputSchema(tool);
+            expect(schema.safeParse({ projectId, ipAddresses: ["192.168.1.1"], comment: "a".repeat(80) }).success).toBe(
+                true
+            );
+            expect(schema.safeParse({ projectId, ipAddresses: ["192.168.1.1"], comment: "a".repeat(81) }).success).toBe(
+                false
+            );
+        });
     });
 
     it("uses custom comment when provided", async () => {

--- a/packages/tools-atlas/src/tools/create/createAccessList.ts
+++ b/packages/tools-atlas/src/tools/create/createAccessList.ts
@@ -5,12 +5,17 @@ import { AtlasToolBase } from "../../atlasTool.js";
 import { makeCurrentIpAccessListEntry, DEFAULT_ACCESS_LIST_COMMENT } from "../../helpers/accessListUtils.js";
 import { AtlasArgs, CommonArgs } from "../../args.js";
 
+// Atlas rejects access list entry comments longer than this (INVALID_NETWORK_PERMISSION_COMMENT).
+const ACCESS_LIST_COMMENT_MAX_LENGTH = 80;
+export const ACCESS_LIST_COMMENT_TOO_LONG_ERROR = "Comment must be 80 characters or less.";
+
 export const CreateAccessListArgs = {
     projectId: AtlasArgs.projectId().describe("Atlas project ID"),
     ipAddresses: z.array(AtlasArgs.ipAddress()).describe("IP addresses to allow access from").optional(),
     cidrBlocks: z.array(AtlasArgs.cidrBlock()).describe("CIDR blocks to allow access from").optional(),
     currentIpAddress: z.boolean().describe("Add the current IP address").default(false),
     comment: CommonArgs.asciiOnlyString()
+        .max(ACCESS_LIST_COMMENT_MAX_LENGTH, ACCESS_LIST_COMMENT_TOO_LONG_ERROR)
         .describe("Comment for the access list entries")
         .default(DEFAULT_ACCESS_LIST_COMMENT)
         .optional(),

--- a/packages/tools-atlas/src/tools/create/createAccessList.ts
+++ b/packages/tools-atlas/src/tools/create/createAccessList.ts
@@ -7,7 +7,7 @@ import { AtlasArgs, CommonArgs } from "../../args.js";
 
 // Atlas rejects access list entry comments longer than this (INVALID_NETWORK_PERMISSION_COMMENT).
 const ACCESS_LIST_COMMENT_MAX_LENGTH = 80;
-export const ACCESS_LIST_COMMENT_TOO_LONG_ERROR = "Comment must be 80 characters or less.";
+export const ACCESS_LIST_COMMENT_TOO_LONG_ERROR = `Comment must be ${ACCESS_LIST_COMMENT_MAX_LENGTH} characters or less.`;
 
 export const CreateAccessListArgs = {
     projectId: AtlasArgs.projectId().describe("Atlas project ID"),
@@ -17,8 +17,7 @@ export const CreateAccessListArgs = {
     comment: CommonArgs.asciiOnlyString()
         .max(ACCESS_LIST_COMMENT_MAX_LENGTH, ACCESS_LIST_COMMENT_TOO_LONG_ERROR)
         .describe("Comment for the access list entries")
-        .default(DEFAULT_ACCESS_LIST_COMMENT)
-        .optional(),
+        .default(DEFAULT_ACCESS_LIST_COMMENT),
 };
 
 const CreateAccessListOutputSchema = {

--- a/packages/tools-atlas/src/tools/create/createAccessList.ts
+++ b/packages/tools-atlas/src/tools/create/createAccessList.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { type ToolArgs, type ToolResult } from "@mongodb-js/mcp-core";
+import { type ToolArgs, type ToolResult, ToolArgumentValidationError } from "@mongodb-js/mcp-core";
 import type { OperationType, ToolExecutionContext } from "@mongodb-js/mcp-types";
 import { AtlasToolBase } from "../../atlasTool.js";
 import { makeCurrentIpAccessListEntry, DEFAULT_ACCESS_LIST_COMMENT } from "../../helpers/accessListUtils.js";
@@ -51,10 +51,10 @@ export class CreateAccessListTool extends AtlasToolBase {
     ): Promise<ToolResult<typeof this.outputSchema>> {
         if (!ipAddresses?.length && !cidrBlocks?.length && !currentIpAddress) {
             if (!this.apiClient.supportsCurrentIpLookup) {
-                throw new Error("Either ipAddresses or cidrBlocks must be provided.");
+                throw new ToolArgumentValidationError("Either ipAddresses or cidrBlocks must be provided.");
             }
 
-            throw new Error("One of ipAddresses, cidrBlocks, currentIpAddress must be provided.");
+            throw new ToolArgumentValidationError("One of ipAddresses, cidrBlocks, currentIpAddress must be provided.");
         }
 
         const ipInputs = (ipAddresses || []).map((ipAddress) => ({

--- a/packages/tools-atlas/src/tools/create/createAccessList.ts
+++ b/packages/tools-atlas/src/tools/create/createAccessList.ts
@@ -5,9 +5,8 @@ import { AtlasToolBase } from "../../atlasTool.js";
 import { makeCurrentIpAccessListEntry, DEFAULT_ACCESS_LIST_COMMENT } from "../../helpers/accessListUtils.js";
 import { AtlasArgs, CommonArgs } from "../../args.js";
 
-// Atlas rejects access list entry comments longer than this (INVALID_NETWORK_PERMISSION_COMMENT).
+// Atlas rejects access list entry comments longer than this.
 const ACCESS_LIST_COMMENT_MAX_LENGTH = 80;
-export const ACCESS_LIST_COMMENT_TOO_LONG_ERROR = `Comment must be ${ACCESS_LIST_COMMENT_MAX_LENGTH} characters or less.`;
 
 export const CreateAccessListArgs = {
     projectId: AtlasArgs.projectId().describe("Atlas project ID"),
@@ -15,7 +14,7 @@ export const CreateAccessListArgs = {
     cidrBlocks: z.array(AtlasArgs.cidrBlock()).describe("CIDR blocks to allow access from").optional(),
     currentIpAddress: z.boolean().describe("Add the current IP address").default(false),
     comment: CommonArgs.asciiOnlyString()
-        .max(ACCESS_LIST_COMMENT_MAX_LENGTH, ACCESS_LIST_COMMENT_TOO_LONG_ERROR)
+        .max(ACCESS_LIST_COMMENT_MAX_LENGTH)
         .describe("Comment for the access list entries")
         .default(DEFAULT_ACCESS_LIST_COMMENT),
 };

--- a/packages/tools-atlas/src/tools/create/createCluster.ts
+++ b/packages/tools-atlas/src/tools/create/createCluster.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { type ToolArgs, type ToolResult } from "@mongodb-js/mcp-core";
+import { type ToolArgs, type ToolResult, ToolArgumentValidationError } from "@mongodb-js/mcp-core";
 import type { OperationType, ToolExecutionContext, CallToolResult } from "@mongodb-js/mcp-types";
 import { AtlasToolBase } from "../../atlasTool.js";
 import type { ClusterDescription20240805 } from "@mongodb-js/mcp-atlas-api-client";
@@ -112,7 +112,7 @@ function buildVersionConfig(version: MongoDBVersion): {
     return { versionReleaseSystem: "LTS", mongoDBMajorVersion: version };
 }
 
-class CreateClusterError extends Error {}
+class CreateClusterError extends ToolArgumentValidationError {}
 
 export const CreateClusterArgsShape = {
     projectId: AtlasArgs.projectId().describe(

--- a/packages/tools-atlas/src/tools/update/upgradeCluster.ts
+++ b/packages/tools-atlas/src/tools/update/upgradeCluster.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { type ToolArgs, type ToolResult } from "@mongodb-js/mcp-core";
+import { type ToolArgs, type ToolResult, ToolArgumentValidationError } from "@mongodb-js/mcp-core";
 import type { OperationType, ToolExecutionContext, CallToolResult } from "@mongodb-js/mcp-types";
 import { AtlasToolBase } from "../../atlasTool.js";
 import { formatCluster } from "../../helpers/cluster.js";
@@ -244,7 +244,7 @@ function buildScaleClusterBody(
     return { replicationSpecs };
 }
 
-class UpgradeClusterError extends Error {}
+class UpgradeClusterError extends ToolArgumentValidationError {}
 
 type DedicatedScalingArgs = {
     targetTier?: string;

--- a/packages/tools-mongodb/src/tools/create/createIndex.ts
+++ b/packages/tools-mongodb/src/tools/create/createIndex.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { CollOperationArgs, ConnectionIdArgs, MongoDBToolBase } from "../../mongodbTool.js";
-import { type ToolArgs, type ToolResult } from "@mongodb-js/mcp-core";
+import { type ToolArgs, type ToolResult, ToolArgumentValidationError } from "@mongodb-js/mcp-core";
 import type { OperationType, IndexMetadata } from "@mongodb-js/mcp-types";
 import { IndexDirectionSchema, modelsSupportingAutoEmbedIndexes } from "../../mongodbSchemas.js";
 
@@ -245,7 +245,9 @@ This definition also accepts the following top-level fields, which are forwarded
         let indexes: string[] = [];
         const definition = definitions[0];
         if (!definition) {
-            throw new Error("Index definition not provided. Expected one of the following: `classic`, `vectorSearch`");
+            throw new ToolArgumentValidationError(
+                "Index definition not provided. Expected one of the following: `classic`, `vectorSearch`"
+            );
         }
 
         let responseClarification = "";

--- a/packages/tools-mongodb/src/tools/metadata/explain.ts
+++ b/packages/tools-mongodb/src/tools/metadata/explain.ts
@@ -1,7 +1,7 @@
 import { CollOperationArgs, ConnectionIdArgs, MongoDBToolBase } from "../../mongodbTool.js";
 import type { ToolArgs, ToolResult } from "@mongodb-js/mcp-core";
 import type { OperationType, ToolExecutionContext } from "@mongodb-js/mcp-types";
-import { formatUntrustedData } from "@mongodb-js/mcp-core";
+import { formatUntrustedData, ToolArgumentValidationError } from "@mongodb-js/mcp-core";
 import { z } from "zod";
 import type { Document } from "mongodb";
 import { AggregateArgs } from "../read/aggregate.js";
@@ -69,7 +69,9 @@ export class ExplainTool extends MongoDBToolBase {
         const method = methods[0];
 
         if (!method) {
-            throw new Error("No method provided. Expected one of the following: `aggregate`, `find`, or `count`");
+            throw new ToolArgumentValidationError(
+                "No method provided. Expected one of the following: `aggregate`, `find`, or `count`"
+            );
         }
 
         let result: Document;

--- a/packages/tools-mongodb/src/tools/read/export.ts
+++ b/packages/tools-mongodb/src/tools/read/export.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { ObjectId } from "bson";
 import type { AggregationCursor, FindCursor } from "mongodb";
 import type { CallToolResult } from "@mongodb-js/mcp-types";
-import type { ToolArgs } from "@mongodb-js/mcp-core";
+import { type ToolArgs, ToolArgumentValidationError } from "@mongodb-js/mcp-core";
 import type { OperationType, ToolExecutionContext } from "@mongodb-js/mcp-types";
 import { CollOperationArgs, ConnectionIdArgs, MongoDBToolBase } from "../../mongodbTool.js";
 import { FindArgs } from "./find.js";
@@ -72,7 +72,9 @@ export class ExportTool extends MongoDBToolBase {
         const provider = await this.resolveConnection(connectionId);
         const exportTarget = target[0];
         if (!exportTarget) {
-            throw new Error("Export target not provided. Expected one of the following: `aggregate`, `find`");
+            throw new ToolArgumentValidationError(
+                "Export target not provided. Expected one of the following: `aggregate`, `find`"
+            );
         }
 
         let cursor: FindCursor | AggregationCursor;


### PR DESCRIPTION
## Proposed changes

Tool calls that fail because the caller passed bad arguments were throwing bare `Error`s, so downstream (the remote-mcp error classifier) couldn't tell a caller-fixable input rejection apart from an infrastructure failure - the false-positives that set off the `atlas-create-access-list` page. This adds a `ToolArgumentValidationError` (in core, re-exported from `mongodb-mcp-server`) that tools throw when they reject arguments, giving the classifier a single type to key on and mark those failures as expected.

`createAccessList` is the immediate case, and its recurring `atlas_api_400` from over-long comments is now caught at the schema layer (comments are capped at Atlas's 80-character limit) instead of round-tripping to the API to fail. The same error type is adopted by the other tools that already did argument validation by hand — `explain`, `export`, `createIndex`, and the existing `createCluster` / `upgradeCluster` local error classes now extend it. Messages are unchanged, so tool output is identical.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
