### PR TITLE
fix: remove shared event cache, finalize events before storing them CLOUDP-440981

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -590,18 +590,17 @@ export const ErrorCodes: {
 };
 
 // @public
-export class EventCache {
+export class EventCache<T extends TelemetryBaseEvent = TelemetryBaseEvent> {
     constructor();
-    appendEvents(events: TelemetryBaseEvent[]): void;
+    appendEvents(events: T[]): void;
     getEvents(): {
         id: number;
-        event: TelemetryBaseEvent;
+        event: T;
     }[];
-    static getInstance(): EventCache;
-    processOldestBatch<T>(batchSize: number, processor: (events: TelemetryBaseEvent[]) => Promise<{
+    processOldestBatch<R>(batchSize: number, processor: (events: T[]) => Promise<{
         removeProcessed: boolean;
-        result: T;
-    }>): Promise<T | undefined>;
+        result: R;
+    }>): Promise<R | undefined>;
     removeEvents(ids: number[]): void;
     get size(): number;
 }
@@ -1052,7 +1051,7 @@ export type TelemetryConfig = {
     keychain: IKeychain;
     enabled: boolean;
     serverMetadata: ServerMetadata;
-    eventCache?: EventCache;
+    eventCache?: EventCache<TelemetryEvent<TelemetryCommonProperties>>;
 };
 
 // @public (undocumented)

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -485,18 +485,17 @@ export type ElicitedInputResult = {
 };
 
 // @public
-export class EventCache {
+export class EventCache<T extends TelemetryBaseEvent = TelemetryBaseEvent> {
     constructor();
-    appendEvents(events: TelemetryBaseEvent[]): void;
+    appendEvents(events: T[]): void;
     getEvents(): {
         id: number;
-        event: TelemetryBaseEvent;
+        event: T;
     }[];
-    static getInstance(): EventCache;
-    processOldestBatch<T>(batchSize: number, processor: (events: TelemetryBaseEvent[]) => Promise<{
+    processOldestBatch<R>(batchSize: number, processor: (events: T[]) => Promise<{
         removeProcessed: boolean;
-        result: T;
-    }>): Promise<T | undefined>;
+        result: R;
+    }>): Promise<R | undefined>;
     removeEvents(ids: number[]): void;
     get size(): number;
 }
@@ -732,7 +731,7 @@ export type TelemetryConfig = {
     keychain: IKeychain;
     enabled: boolean;
     serverMetadata: ServerMetadata;
-    eventCache?: EventCache;
+    eventCache?: EventCache<TelemetryEvent<TelemetryCommonProperties>>;
 };
 
 // @public (undocumented)

--- a/packages/atlas-telemetry/src/atlasTelemetry.test.ts
+++ b/packages/atlas-telemetry/src/atlasTelemetry.test.ts
@@ -272,6 +272,29 @@ describe("AtlasTelemetry", () => {
             expect(sentEvent.properties.session_id).toBe("session-at-emit");
         });
 
+        it("should not reject or throw when getCommonProperties throws", async () => {
+            vi.clearAllTimers();
+            telemetry = createAtlasTelemetry({
+                commonPropertiesOverride: () => {
+                    throw new Error("override failed");
+                },
+            });
+            await telemetry.setupPromise;
+            const unhandled = vi.fn();
+            process.on("unhandledRejection", unhandled);
+
+            try {
+                expect(() => telemetry.emitEvents([createTestEvent()])).not.toThrow();
+                await vi.advanceTimersByTimeAsync(SEND_INTERVAL_MS);
+            } finally {
+                process.off("unhandledRejection", unhandled);
+            }
+
+            expect(unhandled).not.toHaveBeenCalled();
+            expect(mockEventCache.appendEvents).not.toHaveBeenCalled();
+            expect(mockApiClient.sendEvents).not.toHaveBeenCalled();
+        });
+
         it("should add device_id to events emitted before setup completes", async () => {
             vi.clearAllTimers();
             let resolveDeviceId: (value: string) => void = () => {};

--- a/packages/atlas-telemetry/src/atlasTelemetry.test.ts
+++ b/packages/atlas-telemetry/src/atlasTelemetry.test.ts
@@ -342,6 +342,31 @@ describe("AtlasTelemetry", () => {
             expect(_cachedEvents).toHaveLength(0);
         });
 
+        it("should not schedule sends when setup completes after close", async () => {
+            vi.clearAllTimers();
+            let resolveDeviceId: (value: string) => void = () => {};
+            const devId = {
+                get: vi.fn().mockReturnValue(
+                    new Promise<string>((resolve) => {
+                        resolveDeviceId = resolve;
+                    })
+                ),
+                close: vi.fn(),
+            } as unknown as IDeviceId;
+            telemetry = createAtlasTelemetry({ deviceId: devId });
+
+            const closePromise = telemetry.close();
+            resolveDeviceId("late-device-id");
+            await closePromise;
+            vi.clearAllMocks();
+
+            _cachedEvents.push(createTestEvent());
+            await vi.advanceTimersByTimeAsync(SEND_INTERVAL_MS * 2);
+
+            expect(mockApiClient.sendEvents).not.toHaveBeenCalled();
+            expect(_cachedEvents).toHaveLength(1);
+        });
+
         it("should send events successfully and remove them from cache", async () => {
             const testEvent = createTestEvent();
             await telemetry.setupPromise;

--- a/packages/atlas-telemetry/src/atlasTelemetry.test.ts
+++ b/packages/atlas-telemetry/src/atlasTelemetry.test.ts
@@ -112,6 +112,7 @@ describe("AtlasTelemetry", () => {
                 keychain,
                 enabled: true,
                 serverMetadata,
+                eventCache: mockEventCache as unknown as EventCache<TelemetryEvent<TelemetryCommonProperties>>,
                 ...configOverrides,
             },
             { commonPropertiesOverride }
@@ -214,7 +215,6 @@ describe("AtlasTelemetry", () => {
                     }
                 ),
         };
-        vi.spyOn(EventCache, "getInstance").mockReturnValue(mockEventCache as unknown as EventCache);
 
         mockDeviceId = {
             get: vi.fn().mockResolvedValue("test-device-id"),
@@ -237,13 +237,86 @@ describe("AtlasTelemetry", () => {
             await telemetry.setupPromise;
 
             telemetry.emitEvents([testEvent]);
+            await vi.advanceTimersByTimeAsync(0);
 
             expect(mockApiClient.sendEvents).not.toHaveBeenCalled();
-            expect(mockEventCache.appendEvents).toHaveBeenCalledWith([testEvent]);
+            expect(mockEventCache.appendEvents).toHaveBeenCalledTimes(1);
+            expect(_cachedEvents[0]?.properties).toMatchObject({
+                ...testEvent.properties,
+                device_id: "test-device-id",
+            });
 
             await vi.advanceTimersByTimeAsync(SEND_INTERVAL_MS);
 
             expect(mockApiClient.sendEvents).toHaveBeenCalledTimes(1);
+        });
+
+        it("should add common properties when events are emitted, not when they are sent", async () => {
+            let sessionIdOverride = "session-at-emit";
+            vi.clearAllTimers();
+            telemetry = createAtlasTelemetry({
+                commonPropertiesOverride: () => ({ session_id: sessionIdOverride }),
+            });
+            await telemetry.setupPromise;
+
+            telemetry.emitEvents([createTestEvent()]);
+            await vi.advanceTimersByTimeAsync(0);
+            sessionIdOverride = "session-at-send";
+
+            await emitEventsForTest([]);
+
+            const sentEvent = mockApiClient.sendEvents.mock.calls[0]?.[0]?.[0] as {
+                properties: Record<string, unknown>;
+            };
+            expectDefined(sentEvent);
+            expect(sentEvent.properties.session_id).toBe("session-at-emit");
+        });
+
+        it("should add device_id to events emitted before setup completes", async () => {
+            vi.clearAllTimers();
+            let resolveDeviceId: (value: string) => void = () => {};
+            const devId = {
+                get: vi.fn().mockReturnValue(
+                    new Promise<string>((resolve) => {
+                        resolveDeviceId = resolve;
+                    })
+                ),
+                close: vi.fn(),
+            } as unknown as IDeviceId;
+            telemetry = createAtlasTelemetry({ deviceId: devId });
+
+            telemetry.emitEvents([createTestEvent()]);
+            await vi.advanceTimersByTimeAsync(0);
+            expect(mockEventCache.appendEvents).not.toHaveBeenCalled();
+
+            resolveDeviceId("late-device-id");
+            await telemetry.setupPromise;
+            await vi.advanceTimersByTimeAsync(0);
+
+            expect(mockEventCache.appendEvents).toHaveBeenCalledTimes(1);
+            expect(_cachedEvents[0]?.properties).toMatchObject({ device_id: "late-device-id" });
+        });
+
+        it("should flush events emitted before setup completes on close", async () => {
+            vi.clearAllTimers();
+            let resolveDeviceId: (value: string) => void = () => {};
+            const devId = {
+                get: vi.fn().mockReturnValue(
+                    new Promise<string>((resolve) => {
+                        resolveDeviceId = resolve;
+                    })
+                ),
+                close: vi.fn(),
+            } as unknown as IDeviceId;
+            telemetry = createAtlasTelemetry({ deviceId: devId });
+
+            telemetry.emitEvents([createTestEvent()]);
+            const closePromise = telemetry.close();
+            resolveDeviceId("late-device-id");
+            await closePromise;
+
+            expect(mockApiClient.sendEvents).toHaveBeenCalledTimes(1);
+            expect(_cachedEvents).toHaveLength(0);
         });
 
         it("should send events successfully and remove them from cache", async () => {
@@ -614,18 +687,15 @@ describe("AtlasTelemetry", () => {
      */
     describe("when sendBatch is triggered concurrently", () => {
         it("should not send the same cached event twice when two batches overlap", async () => {
-            const eventCache = new EventCache();
             const CACHED_MARKER = "cached-race-test";
-
-            eventCache.appendEvents([createTestEvent({ command: CACHED_MARKER, component: "cached" })]);
-
             mockApiClient.sendEvents.mockResolvedValue(undefined);
 
             vi.clearAllTimers();
-            // Route the AtlasTelemetry instance to the real cache via the mocked getInstance.
-            vi.spyOn(EventCache, "getInstance").mockReturnValue(eventCache);
-            const raceAtlasTelemetry = createAtlasTelemetry();
+            const raceAtlasTelemetry = createAtlasTelemetry({ eventCache: new EventCache() });
             await raceAtlasTelemetry.setupPromise;
+
+            raceAtlasTelemetry.emitEvents([createTestEvent({ command: CACHED_MARKER, component: "cached" })]);
+            await vi.advanceTimersByTimeAsync(0);
 
             await Promise.all([raceAtlasTelemetry["sendBatch"](), raceAtlasTelemetry["sendBatch"]()]);
 
@@ -638,6 +708,95 @@ describe("AtlasTelemetry", () => {
             }
             expect(cachedEventSendCount, "Cached event should be sent exactly once").toBe(1);
         });
+    });
+});
+
+/**
+ * Regression tests for multiple pipelines living in the same process (e.g. one
+ * per tenant in a hosted deployment). Each pipeline must only send the events
+ * it emitted, carrying the common properties of the pipeline that emitted them.
+ */
+describe("AtlasTelemetry with multiple instances in one process", () => {
+    const TEST_SERVER_METADATA = { mcpServerName: "test-server", version: "1.0.0" };
+
+    class TenantTelemetry extends AtlasTelemetry {
+        private readonly tenantId: string;
+
+        constructor(config: TelemetryConfig, tenantId: string) {
+            super(config);
+            this.tenantId = tenantId;
+        }
+
+        public override getCommonProperties(): TelemetryCommonProperties {
+            return { ...super.getCommonProperties(), session_id: this.tenantId };
+        }
+
+        static createForTenant(config: TelemetryConfig, tenantId: string): TenantTelemetry {
+            const instance = new TenantTelemetry(config, tenantId);
+            void instance.setup();
+            return instance;
+        }
+    }
+
+    function createTenant(tenantId: string): {
+        telemetry: TenantTelemetry;
+        sendEvents: MockedFunction<(events: unknown[]) => Promise<void>>;
+    } {
+        const sendEvents = vi.fn().mockResolvedValue(undefined);
+        const apiClient = { sendEvents, isAuthConfigured: () => false } as unknown as ApiClient;
+        const telemetry = TenantTelemetry.createForTenant(
+            {
+                logger: new NoopLogger(),
+                deviceId: { get: vi.fn().mockResolvedValue(`device-${tenantId}`), close: vi.fn() },
+                apiClient,
+                keychain: new Keychain(),
+                enabled: true,
+                serverMetadata: TEST_SERVER_METADATA,
+            },
+            tenantId
+        );
+        return { telemetry, sendEvents };
+    }
+
+    function createEvent(command: string): TelemetryBaseEvent {
+        return {
+            timestamp: new Date().toISOString(),
+            source: "mdbmcp",
+            properties: { component: "test", duration_ms: 1, result: "success", category: "test", command },
+        };
+    }
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("should send each event only through the pipeline that emitted it, with that pipeline's properties", async () => {
+        const tenantA = createTenant("tenant-a");
+        const tenantB = createTenant("tenant-b");
+        await Promise.all([tenantA.telemetry.setupPromise, tenantB.telemetry.setupPromise]);
+
+        tenantA.telemetry.emitEvents([createEvent("from-a")]);
+        tenantB.telemetry.emitEvents([createEvent("from-b")]);
+
+        const bothSent = Promise.all([
+            new Promise<void>((resolve) => tenantA.telemetry.events.once("events-emitted", resolve)),
+            new Promise<void>((resolve) => tenantB.telemetry.events.once("events-emitted", resolve)),
+        ]);
+        await vi.advanceTimersByTimeAsync(SEND_INTERVAL_MS);
+        await bothSent;
+
+        type Sent = { properties: { command: string; session_id: string; device_id: string } };
+        const sentByA = tenantA.sendEvents.mock.calls.flatMap((call) => call[0] as Sent[]);
+        const sentByB = tenantB.sendEvents.mock.calls.flatMap((call) => call[0] as Sent[]);
+
+        expect(sentByA.map((e) => e.properties.command)).toEqual(["from-a"]);
+        expect(sentByB.map((e) => e.properties.command)).toEqual(["from-b"]);
+        expect(sentByA[0]?.properties).toMatchObject({ session_id: "tenant-a", device_id: "device-tenant-a" });
+        expect(sentByB[0]?.properties).toMatchObject({ session_id: "tenant-b", device_id: "device-tenant-b" });
     });
 });
 
@@ -662,7 +821,6 @@ describe("AtlasTelemetry credentials handling", () => {
     beforeEach(() => {
         vi.useFakeTimers();
         fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
-        vi.spyOn(EventCache, "getInstance").mockReturnValue(new EventCache());
     });
 
     afterEach(() => {

--- a/packages/atlas-telemetry/src/atlasTelemetry.ts
+++ b/packages/atlas-telemetry/src/atlasTelemetry.ts
@@ -1,4 +1,4 @@
-import type { TelemetryBaseEvent, TelemetryCommonProperties } from "./types.js";
+import type { TelemetryBaseEvent, TelemetryCommonProperties, TelemetryEvent } from "./types.js";
 import { LogId } from "@mongodb-js/mcp-core";
 import { detectContainerEnv as detectContainerEnvImpl } from "./containerEnv.js";
 import type { LoggerBase } from "@mongodb-js/mcp-core";
@@ -55,11 +55,12 @@ export type TelemetryConfig = {
     serverMetadata: ServerMetadata;
 
     /**
-     * Optional override for the underlying event cache. Defaults to the
-     * process-wide singleton returned by {@link EventCache.getInstance}.
-     * Mostly useful for tests or callers that need to isolate caching.
+     * Optional override for the underlying event cache. Defaults to a new
+     * cache owned exclusively by this pipeline, so events are only ever sent
+     * through the pipeline (and API client) that emitted them. Holds events
+     * that already include this pipeline's common properties.
      */
-    eventCache?: EventCache;
+    eventCache?: EventCache<TelemetryEvent<TelemetryCommonProperties>>;
 };
 
 /** The timeout for individual send requests in milliseconds. */
@@ -102,7 +103,7 @@ export class AtlasTelemetry implements ITelemetry {
      * of {@link getCommonProperties} should call `super` to include these.
      */
     private readonly pipelineCommonProperties: Partial<TelemetryCommonProperties>;
-    private readonly eventCache: EventCache;
+    private readonly eventCache: EventCache<TelemetryEvent<TelemetryCommonProperties>>;
     private readonly deviceId: IDeviceId;
     private backoffMs: number = INITIAL_BACKOFF_MS;
     private readonly timer = new Timer();
@@ -113,7 +114,7 @@ export class AtlasTelemetry implements ITelemetry {
         this.keychain = config.keychain;
         this.enabled = config.enabled;
         this.serverMetadata = config.serverMetadata;
-        this.eventCache = config.eventCache ?? EventCache.getInstance();
+        this.eventCache = config.eventCache ?? new EventCache<TelemetryEvent<TelemetryCommonProperties>>();
         this.deviceId = config.deviceId;
         this.pipelineCommonProperties = {};
     }
@@ -156,6 +157,10 @@ export class AtlasTelemetry implements ITelemetry {
     public async close(): Promise<void> {
         this.timer.cancel();
 
+        // Events emitted before setup finished are appended once setup resolves;
+        // wait for that so the final flush can include them.
+        await this.whenReady();
+
         this.logger.debug({
             id: LogId.telemetryClose,
             message: `Closing telemetry, attempting to flush up to ${BATCH_SIZE} of ${this.eventCache.size} remaining events`,
@@ -167,22 +172,47 @@ export class AtlasTelemetry implements ITelemetry {
     }
 
     /**
-     * Caches events for sending via the background timer.
+     * Merges the common properties into the events and caches them for
+     * sending via the background timer.
+     *
+     * The merge is deferred until setup has resolved `device_id` and
+     * `is_container_env`. Callbacks chained on an already-settled promise run
+     * in registration order, so events are cached in the order they were emitted.
      */
     public emitEvents(events: TelemetryBaseEvent[]): void {
         if (!this.isTelemetryEnabled()) {
             this.events.emit("events-skipped");
             return;
         }
-        this.eventCache.appendEvents(events);
+        void this.whenReady().then(() => {
+            const commonProperties = this.getCommonProperties();
+            this.eventCache.appendEvents(
+                events.map((event) => ({
+                    ...event,
+                    properties: { ...commonProperties, ...event.properties },
+                }))
+            );
+        });
     }
 
     /**
-     * Returns common properties merged onto every event. Invoked on every send
-     * so values resolved after construction — like MCP client identity — are
-     * captured. Defaults to server/platform metadata plus pipeline-resolved
-     * `device_id` and `is_container_env`. Extend {@link AtlasTelemetry} and
-     * override this method (calling `super`) to add host-specific properties.
+     * Resolves once setup has completed (or immediately if setup never ran).
+     * Never rejects — a failed setup must not turn emitEvents into an unhandled rejection.
+     */
+    private whenReady(): Promise<void> {
+        return (this.setupPromise ?? Promise.resolve()).then(
+            () => undefined,
+            () => undefined
+        );
+    }
+
+    /**
+     * Returns common properties merged onto every event at emit time, so each
+     * event carries the identity of the pipeline that produced it. Defaults to
+     * server/platform metadata plus pipeline-resolved `device_id` and
+     * `is_container_env`. Extend {@link AtlasTelemetry} and override this
+     * method (calling `super`) to add host-specific properties; those must be
+     * available before the events that should carry them are emitted.
      */
     public getCommonProperties(): TelemetryCommonProperties {
         return {
@@ -314,20 +344,14 @@ export class AtlasTelemetry implements ITelemetry {
         signal,
     }: {
         client: ApiClient;
-        events: TelemetryBaseEvent[];
+        events: TelemetryEvent<TelemetryCommonProperties>[];
         signal?: AbortSignal;
     }): Promise<SendResult> {
         try {
             const effectiveSignal = signal ?? AbortSignal.timeout(SEND_TIMEOUT_MS);
             const redact = <T>(value: T): T => this.keychain?.redact(value) ?? value;
             await client.sendEvents(
-                events.map((event) => ({
-                    ...event,
-                    properties: {
-                        ...redact(this.getCommonProperties()),
-                        ...redact(event.properties),
-                    },
-                })),
+                events.map((event) => ({ ...event, properties: redact(event.properties) })),
                 { signal: effectiveSignal }
             );
             return { status: "success" };

--- a/packages/atlas-telemetry/src/atlasTelemetry.ts
+++ b/packages/atlas-telemetry/src/atlasTelemetry.ts
@@ -107,6 +107,7 @@ export class AtlasTelemetry implements ITelemetry {
     private readonly deviceId: IDeviceId;
     private backoffMs: number = INITIAL_BACKOFF_MS;
     private readonly timer = new Timer();
+    private closed = false;
 
     protected constructor(config: TelemetryConfig) {
         this.logger = config.logger;
@@ -155,6 +156,8 @@ export class AtlasTelemetry implements ITelemetry {
     }
 
     public async close(): Promise<void> {
+        // Set before cancelling so that a setup() still in flight cannot schedule a new send afterwards.
+        this.closed = true;
         this.timer.cancel();
 
         // The whole close is best-effort and bounded by CLOSE_TIMEOUT_MS: waiting for
@@ -264,8 +267,12 @@ export class AtlasTelemetry implements ITelemetry {
 
     /**
      * Schedules the next send attempt. Replaces any previously scheduled send.
+     * No-op once close() has been called.
      */
     private scheduleSend(delayMs: number = SEND_INTERVAL_MS): void {
+        if (this.closed) {
+            return;
+        }
         this.timer.schedule(() => {
             void this.sendBatchAndReschedule();
         }, delayMs);

--- a/packages/atlas-telemetry/src/atlasTelemetry.ts
+++ b/packages/atlas-telemetry/src/atlasTelemetry.ts
@@ -157,9 +157,14 @@ export class AtlasTelemetry implements ITelemetry {
     public async close(): Promise<void> {
         this.timer.cancel();
 
-        // Events emitted before setup finished are appended once setup resolves;
-        // wait for that so the final flush can include them.
-        await this.whenReady();
+        // The whole close is best-effort and bounded by CLOSE_TIMEOUT_MS: waiting for
+        // setup (so events emitted before it finished make it into the cache) and the
+        // final flush share the same budget, so a hung setup cannot block shutdown.
+        const signal = AbortSignal.timeout(CLOSE_TIMEOUT_MS);
+        await Promise.race([
+            this.whenReady(),
+            new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), { once: true })),
+        ]);
 
         this.logger.debug({
             id: LogId.telemetryClose,
@@ -167,8 +172,7 @@ export class AtlasTelemetry implements ITelemetry {
             context: "telemetry",
         });
 
-        // Best-effort: send one final batch before closing, bounded by CLOSE_TIMEOUT_MS
-        await this.sendBatch({ signal: AbortSignal.timeout(CLOSE_TIMEOUT_MS) });
+        await this.sendBatch({ signal });
     }
 
     /**
@@ -184,15 +188,26 @@ export class AtlasTelemetry implements ITelemetry {
             this.events.emit("events-skipped");
             return;
         }
-        void this.whenReady().then(() => {
-            const commonProperties = this.getCommonProperties();
-            this.eventCache.appendEvents(
-                events.map((event) => ({
-                    ...event,
-                    properties: { ...commonProperties, ...event.properties },
-                }))
-            );
-        });
+        this.whenReady()
+            .then(() => {
+                const commonProperties = this.getCommonProperties();
+                this.eventCache.appendEvents(
+                    events.map((event) => ({
+                        ...event,
+                        properties: { ...commonProperties, ...event.properties },
+                    }))
+                );
+            })
+            .catch((error: unknown) => {
+                // Telemetry must never take the process down via an unhandled rejection,
+                // e.g. when a getCommonProperties override throws.
+                this.logger.debug({
+                    id: LogId.telemetryEmitFailure,
+                    context: "telemetry",
+                    message: `Error caching telemetry events: ${error instanceof Error ? error.message : String(error)}`,
+                    noRedaction: true,
+                });
+            });
     }
 
     /**

--- a/packages/atlas-telemetry/src/eventCache.ts
+++ b/packages/atlas-telemetry/src/eventCache.ts
@@ -34,7 +34,7 @@ export class EventCache<T extends TelemetryBaseEvent = TelemetryBaseEvent> {
      * Runs a callback with exclusive access to the cache so operations
      * are serialized across all callers (e.g. the send timer racing a close() flush).
      */
-    private async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    private async runExclusive<R>(fn: () => Promise<R>): Promise<R> {
         const prevOperation = this.currentOperation;
 
         let resolve: (() => void) | undefined;

--- a/packages/atlas-telemetry/src/eventCache.ts
+++ b/packages/atlas-telemetry/src/eventCache.ts
@@ -2,15 +2,14 @@ import { LRUCache } from "lru-cache";
 import type { TelemetryBaseEvent } from "./types.js";
 
 /**
- * Singleton class for in-memory telemetry event caching
- * Provides a central storage for telemetry events that couldn't be sent
+ * In-memory telemetry event cache. Each telemetry pipeline owns its own
+ * instance so events are only ever sent through the pipeline that emitted them.
  * Uses LRU cache to automatically drop oldest events when limit is exceeded
  */
-export class EventCache {
-    private static instance: EventCache;
+export class EventCache<T extends TelemetryBaseEvent = TelemetryBaseEvent> {
     private static readonly MAX_EVENTS = 1000;
 
-    private cache: LRUCache<number, TelemetryBaseEvent>;
+    private cache: LRUCache<number, T>;
     private nextId = 0;
     /** Current exclusive operation, if any. The next caller awaits this before starting. */
     private currentOperation: { promise: Promise<void>; resolve: () => void } | undefined;
@@ -25,17 +24,6 @@ export class EventCache {
     }
 
     /**
-     * Gets the singleton instance of EventCache
-     * @returns The EventCache instance
-     */
-    public static getInstance(): EventCache {
-        if (!EventCache.instance) {
-            EventCache.instance = new EventCache();
-        }
-        return EventCache.instance;
-    }
-
-    /**
      * Gets the number of currently cached events
      */
     public get size(): number {
@@ -44,7 +32,7 @@ export class EventCache {
 
     /**
      * Runs a callback with exclusive access to the cache so operations
-     * are serialized across all callers (e.g. multiple Telemetry instances / sessions).
+     * are serialized across all callers (e.g. the send timer racing a close() flush).
      */
     private async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
         const prevOperation = this.currentOperation;
@@ -72,10 +60,10 @@ export class EventCache {
      * are removed from the cache; otherwise they remain untouched.
      * Returns the `result` from the processor, or `undefined` if the cache was empty.
      */
-    public async processOldestBatch<T>(
+    public async processOldestBatch<R>(
         batchSize: number,
-        processor: (events: TelemetryBaseEvent[]) => Promise<{ removeProcessed: boolean; result: T }>
-    ): Promise<T | undefined> {
+        processor: (events: T[]) => Promise<{ removeProcessed: boolean; result: R }>
+    ): Promise<R | undefined> {
         return this.runExclusive(async () => {
             const allEvents = this.getEvents();
             const batch = allEvents.slice(0, batchSize);
@@ -98,7 +86,7 @@ export class EventCache {
      * Gets a copy of the currently cached events along with their ids
      * @returns Array of cached BaseEvent objects
      */
-    public getEvents(): { id: number; event: TelemetryBaseEvent }[] {
+    public getEvents(): { id: number; event: T }[] {
         return Array.from(this.cache.entries()).map(([id, event]) => ({ id, event }));
     }
 
@@ -106,7 +94,7 @@ export class EventCache {
      * Appends new events to the cache.
      * LRU cache automatically handles dropping oldest events when limit is exceeded.
      */
-    public appendEvents(events: TelemetryBaseEvent[]): void {
+    public appendEvents(events: T[]): void {
         for (const event of events) {
             this.cache.set(this.nextId++, event);
         }

--- a/packages/integration-tests/src/tools/mongodb/metadata/explain.test.ts
+++ b/packages/integration-tests/src/tools/mongodb/metadata/explain.test.ts
@@ -345,8 +345,9 @@ describeWithMongoDB("explain tool with write stages", (integration) => {
             ]);
     });
 
-    // executionStats (and allPlansExecution) actually run the pipeline, so explaining an
-    // aggregation with a $out/$merge stage could otherwise perform a write even in readOnly mode.
+    // Explaining a pipeline never executes its $out/$merge stage, so this is not a data-safety
+    // guard. It keeps explain consistent with aggregate: a pipeline that cannot be run in the
+    // current mode cannot be explained either.
     for (const writeStage of ["$out", "$merge"] as const) {
         it(`rejects explaining aggregations with a ${writeStage} stage in readOnly mode`, async () => {
             integration.mcpServer().userConfig.readOnly = true;


### PR DESCRIPTION
## Proposed changes

Removes the shared EventCache instance and instead ensure each telemetry instance has its own. Additionally, updates property merging to happen prior to storing the events in the cache as opposed to at emission time.