### PR TITLE
chore: backport telemetry fixes to v2 CLOUDP-440981 MCP-636 CLOUDP-440980

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -652,18 +652,17 @@ export enum ErrorCodes {
 }
 
 // @public
-export class EventCache {
+export class EventCache<T extends BaseEvent = BaseEvent> {
     constructor();
-    appendEvents(events: BaseEvent[]): void;
+    appendEvents(events: T[]): void;
     getEvents(): {
         id: number;
-        event: BaseEvent;
+        event: T;
     }[];
-    static getInstance(): EventCache;
-    processOldestBatch<T>(batchSize: number, processor: (events: BaseEvent[]) => Promise<{
+    processOldestBatch<R>(batchSize: number, processor: (events: T[]) => Promise<{
         removeProcessed: boolean;
-        result: T;
-    }>): Promise<T | undefined>;
+        result: R;
+    }>): Promise<R | undefined>;
     removeEvents(ids: number[]): void;
     get size(): number;
 }
@@ -1185,7 +1184,7 @@ export class Telemetry {
     // @deprecated (undocumented)
     static create(session: Session, userConfig: UserConfig, deviceId: DeviceId, options?: {
         commonProperties?: Partial<CommonProperties>;
-        eventCache?: EventCache;
+        eventCache?: EventCache<TelemetryEvent<CommonProperties>>;
     }): Telemetry;
     // (undocumented)
     static create(config: TelemetryConfig): Telemetry;
@@ -1202,7 +1201,7 @@ export interface TelemetryConfig {
     apiClient: ApiClient;
     deviceId: DeviceId;
     enabled: boolean;
-    eventCache?: EventCache;
+    eventCache?: EventCache<TelemetryEvent<CommonProperties>>;
     getCommonProperties?: () => Partial<CommonProperties>;
     keychain?: Keychain;
     logger: LoggerBase;

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -1271,6 +1271,7 @@ export class ListClustersTool extends AtlasToolBase {
             projectName: z.ZodOptional<z.ZodString>;
         }, z.core.$strip>, z.ZodObject<{
             name: z.ZodOptional<z.ZodString>;
+            clusterId: z.ZodOptional<z.ZodString>;
             instanceType: z.ZodEnum<{
                 DEDICATED: "DEDICATED";
                 FLEX: "FLEX";

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -219,19 +219,12 @@ export interface ApiClientOptions {
 // @public
 export interface AtlasClusterConnectionInfo {
     // (undocumented)
+    clusterId: string;
+    // (undocumented)
     clusterName: string;
-    // (undocumented)
-    expiryDate: Date;
-    // (undocumented)
-    instanceType: "FREE" | "FLEX" | "DEDICATED";
-    // (undocumented)
+    instanceType?: "FREE" | "FLEX" | "DEDICATED";
     projectId: string;
-    // (undocumented)
-    provider?: string;
-    // (undocumented)
-    region?: string;
-    // (undocumented)
-    username: string;
+    username?: string;
 }
 
 // @public
@@ -422,6 +415,8 @@ export type ConnectionMetadata = AtlasMetadata & AtlasLocalToolMetadata & {
     connection_id?: string;
     connection_auth_type?: string;
     connection_host_type?: string;
+    cluster_name?: string;
+    cluster_id?: string;
     shared_tier_alerts_detected?: TelemetryBoolSet;
     shared_tier_tier?: SharedTierTier;
     shared_tier_alerts?: SharedTierMetricName[];

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -652,18 +652,17 @@ export enum ErrorCodes {
 }
 
 // @public
-export class EventCache {
+export class EventCache<T extends BaseEvent = BaseEvent> {
     constructor();
-    appendEvents(events: BaseEvent[]): void;
+    appendEvents(events: T[]): void;
     getEvents(): {
         id: number;
-        event: BaseEvent;
+        event: T;
     }[];
-    static getInstance(): EventCache;
-    processOldestBatch<T>(batchSize: number, processor: (events: BaseEvent[]) => Promise<{
+    processOldestBatch<R>(batchSize: number, processor: (events: T[]) => Promise<{
         removeProcessed: boolean;
-        result: T;
-    }>): Promise<T | undefined>;
+        result: R;
+    }>): Promise<R | undefined>;
     removeEvents(ids: number[]): void;
     get size(): number;
 }
@@ -986,7 +985,7 @@ export class Telemetry {
     // @deprecated (undocumented)
     static create(session: Session, userConfig: UserConfig, deviceId: DeviceId, options?: {
         commonProperties?: Partial<CommonProperties>;
-        eventCache?: EventCache;
+        eventCache?: EventCache<TelemetryEvent<CommonProperties>>;
     }): Telemetry;
     // (undocumented)
     static create(config: TelemetryConfig): Telemetry;
@@ -1006,7 +1005,7 @@ export interface TelemetryConfig {
     apiClient: ApiClient;
     deviceId: DeviceId;
     enabled: boolean;
-    eventCache?: EventCache;
+    eventCache?: EventCache<TelemetryEvent<CommonProperties>>;
     getCommonProperties?: () => Partial<CommonProperties>;
     keychain?: Keychain;
     logger: LoggerBase;

--- a/src/common/atlas/cluster.ts
+++ b/src/common/atlas/cluster.ts
@@ -24,6 +24,7 @@ export interface Cluster {
     provider?: string;
     region?: string;
     paused: boolean;
+    clusterId?: string;
     state?: "IDLE" | "CREATING" | "UPDATING" | "DELETING" | "REPAIRING";
     mongoDBVersion?: string;
     connectionStrings?: ClusterConnectionStrings;
@@ -33,6 +34,7 @@ export interface Cluster {
 export function formatFlexCluster(cluster: FlexClusterDescription20241113): Cluster {
     return {
         name: cluster.name,
+        clusterId: cluster.id,
         instanceType: "FLEX",
         instanceSize: undefined,
         provider: cluster.providerSettings?.backingProviderName,
@@ -85,6 +87,7 @@ export function formatCluster(cluster: ClusterDescription20240805): Cluster {
 
     return {
         name: cluster.name,
+        clusterId: cluster.id,
         instanceType: clusterInstanceType,
         instanceSize: clusterInstanceType === "DEDICATED" ? instanceSize : undefined,
         provider,

--- a/src/common/connectionInfo.ts
+++ b/src/common/connectionInfo.ts
@@ -24,15 +24,32 @@ export interface ConnectionStringInfo {
 /**
  * Atlas cluster connection info containing details about the connected Atlas cluster.
  * When provided, indicates the connection is to an Atlas cluster.
+ *
+ * The cluster's projectId, name and id are required. A host that establishes the
+ * connection without minting a temporary database user — via its own credential
+ * issuance, X.509, a pre-provisioned user, a proxy — still knows which cluster it
+ * connected to and needs to be able to specify it: this field is what marks a
+ * connection as pointing at Atlas, and leaving it unset prevents cluster
+ * attribution on tool telemetry, the `atlas` host type, and the ability of
+ * `pause-resume-cluster` to find connections to the cluster it just paused.
+ * Hosts that only know the cluster name should resolve the id through the Atlas
+ * API before connecting.
  */
 export interface AtlasClusterConnectionInfo {
-    username: string;
+    /** Which Atlas cluster this connection points at. */
     projectId: string;
     clusterName: string;
-    instanceType: "FREE" | "FLEX" | "DEDICATED";
-    provider?: string;
-    region?: string;
-    expiryDate: Date;
+    clusterId: string;
+
+    /**
+     * The temporary database user backing the connection. Set only by
+     * `connect-cluster`, which also schedules its deletion; absent when the
+     * host supplied its own credentials.
+     */
+    username?: string;
+
+    /** The cluster's tier, set when the host resolved it. */
+    instanceType?: "FREE" | "FLEX" | "DEDICATED";
 }
 
 /**

--- a/src/telemetry/eventCache.ts
+++ b/src/telemetry/eventCache.ts
@@ -2,15 +2,14 @@ import { LRUCache } from "lru-cache";
 import type { BaseEvent } from "./types.js";
 
 /**
- * Singleton class for in-memory telemetry event caching
- * Provides a central storage for telemetry events that couldn't be sent
+ * In-memory telemetry event cache. Each telemetry pipeline owns its own
+ * instance so events are only ever sent through the pipeline that emitted them.
  * Uses LRU cache to automatically drop oldest events when limit is exceeded
  */
-export class EventCache {
-    private static instance: EventCache;
+export class EventCache<T extends BaseEvent = BaseEvent> {
     private static readonly MAX_EVENTS = 1000;
 
-    private cache: LRUCache<number, BaseEvent>;
+    private cache: LRUCache<number, T>;
     private nextId = 0;
     /** Current exclusive operation, if any. The next caller awaits this before starting. */
     private currentOperation: { promise: Promise<void>; resolve: () => void } | undefined;
@@ -25,17 +24,6 @@ export class EventCache {
     }
 
     /**
-     * Gets the singleton instance of EventCache
-     * @returns The EventCache instance
-     */
-    public static getInstance(): EventCache {
-        if (!EventCache.instance) {
-            EventCache.instance = new EventCache();
-        }
-        return EventCache.instance;
-    }
-
-    /**
      * Gets the number of currently cached events
      */
     public get size(): number {
@@ -44,9 +32,9 @@ export class EventCache {
 
     /**
      * Runs a callback with exclusive access to the cache so operations
-     * are serialized across all callers (e.g. multiple Telemetry instances / sessions).
+     * are serialized across all callers (e.g. the send timer racing a close() flush).
      */
-    private async runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    private async runExclusive<R>(fn: () => Promise<R>): Promise<R> {
         const prevOperation = this.currentOperation;
 
         let resolve: (() => void) | undefined;
@@ -72,10 +60,10 @@ export class EventCache {
      * are removed from the cache; otherwise they remain untouched.
      * Returns the `result` from the processor, or `undefined` if the cache was empty.
      */
-    public async processOldestBatch<T>(
+    public async processOldestBatch<R>(
         batchSize: number,
-        processor: (events: BaseEvent[]) => Promise<{ removeProcessed: boolean; result: T }>
-    ): Promise<T | undefined> {
+        processor: (events: T[]) => Promise<{ removeProcessed: boolean; result: R }>
+    ): Promise<R | undefined> {
         return this.runExclusive(async () => {
             const allEvents = this.getEvents();
             const batch = allEvents.slice(0, batchSize);
@@ -98,7 +86,7 @@ export class EventCache {
      * Gets a copy of the currently cached events along with their ids
      * @returns Array of cached BaseEvent objects
      */
-    public getEvents(): { id: number; event: BaseEvent }[] {
+    public getEvents(): { id: number; event: T }[] {
         return Array.from(this.cache.entries()).map(([id, event]) => ({ id, event }));
     }
 
@@ -106,7 +94,7 @@ export class EventCache {
      * Appends new events to the cache.
      * LRU cache automatically handles dropping oldest events when limit is exceeded.
      */
-    public appendEvents(events: BaseEvent[]): void {
+    public appendEvents(events: T[]): void {
         for (const event of events) {
             this.cache.set(this.nextId++, event);
         }

--- a/src/telemetry/telemetry.ts
+++ b/src/telemetry/telemetry.ts
@@ -1,4 +1,4 @@
-import type { BaseEvent, CommonProperties } from "./types.js";
+import type { BaseEvent, CommonProperties, TelemetryEvent } from "./types.js";
 import type { LoggerBase } from "../common/logging/index.js";
 import { LogId } from "../common/logging/index.js";
 import type { ApiClient } from "../common/atlas/apiClient.js";
@@ -53,10 +53,11 @@ export interface TelemetryConfig {
 
     /**
      * Returns the host-supplied common properties merged onto every event
-     * (e.g. hosting mode, MCP client identity, transport). Invoked on every
-     * send so values resolved after construction — like the client name/
-     * version exchanged during handshake — are captured. Static properties
-     * can simply be returned as constants from this callback.
+     * (e.g. hosting mode, MCP client identity, transport). Invoked when
+     * events are emitted, so each event carries the properties of the
+     * pipeline that produced it; values like the MCP client name/version
+     * must be available before the events that should carry them are
+     * emitted. Static properties can simply be returned as constants.
      *
      * Machine metadata, device id, and container environment are provided by
      * the pipeline itself and don't need to be returned here.
@@ -64,11 +65,12 @@ export interface TelemetryConfig {
     getCommonProperties?: () => Partial<CommonProperties>;
 
     /**
-     * Optional override for the underlying event cache. Defaults to the
-     * process-wide singleton returned by {@link EventCache.getInstance}.
-     * Mostly useful for tests or callers that need to isolate caching.
+     * Optional override for the underlying event cache. Defaults to a new
+     * cache owned exclusively by this pipeline, so events are only ever sent
+     * through the pipeline (and API client) that emitted them. Holds events
+     * that already include this pipeline's common properties.
      */
-    eventCache?: EventCache;
+    eventCache?: EventCache<TelemetryEvent<CommonProperties>>;
 }
 
 /** The timeout for individual send requests in milliseconds. */
@@ -112,10 +114,11 @@ export class Telemetry {
      * top of this at send time.
      */
     private readonly pipelineCommonProperties: CommonProperties;
-    private readonly eventCache: EventCache;
+    private readonly eventCache: EventCache<TelemetryEvent<CommonProperties>>;
     private readonly deviceId: DeviceId;
     private backoffMs: number = INITIAL_BACKOFF_MS;
     private readonly timer = new Timer();
+    private closed = false;
 
     private constructor(config: TelemetryConfig) {
         this.logger = config.logger;
@@ -123,7 +126,7 @@ export class Telemetry {
         this.keychain = config.keychain;
         this.enabled = config.enabled;
         this.getHostCommonProperties = config.getCommonProperties ?? ((): Partial<CommonProperties> => ({}));
-        this.eventCache = config.eventCache ?? EventCache.getInstance();
+        this.eventCache = config.eventCache ?? new EventCache<TelemetryEvent<CommonProperties>>();
         this.deviceId = config.deviceId;
         this.pipelineCommonProperties = {
             ...MACHINE_METADATA,
@@ -141,7 +144,7 @@ export class Telemetry {
         deviceId: DeviceId,
         options?: {
             commonProperties?: Partial<CommonProperties>;
-            eventCache?: EventCache;
+            eventCache?: EventCache<TelemetryEvent<CommonProperties>>;
         }
     ): Telemetry;
     static create(config: TelemetryConfig): Telemetry;
@@ -151,10 +154,10 @@ export class Telemetry {
         deviceId?: DeviceId,
         {
             commonProperties = {},
-            eventCache = EventCache.getInstance(),
+            eventCache,
         }: {
             commonProperties?: Partial<CommonProperties>;
-            eventCache?: EventCache;
+            eventCache?: EventCache<TelemetryEvent<CommonProperties>>;
         } = {}
     ): Telemetry {
         const config: TelemetryConfig =
@@ -191,7 +194,18 @@ export class Telemetry {
     }
 
     public async close(): Promise<void> {
+        // Set before cancelling so that a setup() still in flight cannot schedule a new send afterwards.
+        this.closed = true;
         this.timer.cancel();
+
+        // The whole close is best-effort and bounded by CLOSE_TIMEOUT_MS: waiting for
+        // setup (so events emitted before it finished make it into the cache) and the
+        // final flush share the same budget, so a hung setup cannot block shutdown.
+        const signal = AbortSignal.timeout(CLOSE_TIMEOUT_MS);
+        await Promise.race([
+            this.whenReady(),
+            new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), { once: true })),
+        ]);
 
         this.logger.debug({
             id: LogId.telemetryClose,
@@ -199,23 +213,62 @@ export class Telemetry {
             context: "telemetry",
         });
 
-        // Best-effort: send one final batch before closing, bounded by CLOSE_TIMEOUT_MS
-        await this.sendBatch({ signal: AbortSignal.timeout(CLOSE_TIMEOUT_MS) });
+        await this.sendBatch({ signal });
     }
 
     /**
-     * Caches events for sending via the background timer.
+     * Merges the common properties into the events and caches them for
+     * sending via the background timer.
+     *
+     * The merge is deferred until setup has resolved `device_id` and
+     * `is_container_env`. Callbacks chained on an already-settled promise run
+     * in registration order, so events are cached in the order they were emitted.
      */
     public emitEvents(events: BaseEvent[]): void {
         if (!this.isTelemetryEnabled()) {
             this.events.emit("events-skipped");
             return;
         }
-        this.eventCache.appendEvents(events);
+        this.whenReady()
+            .then(() => {
+                const commonProperties = this.getCommonProperties();
+                this.eventCache.appendEvents(
+                    events.map((event) => ({
+                        ...event,
+                        properties: { ...commonProperties, ...event.properties },
+                    }))
+                );
+            })
+            .catch((error: unknown) => {
+                // Telemetry must never take the process down via an unhandled rejection,
+                // e.g. when a getCommonProperties override throws.
+                this.logger.debug({
+                    id: LogId.telemetryEmitFailure,
+                    context: "telemetry",
+                    message: `Error caching telemetry events: ${error instanceof Error ? error.message : String(error)}`,
+                    noRedaction: true,
+                });
+            });
     }
 
     /**
-     * Gets the common properties for events
+     * Resolves once setup has completed (or immediately if setup never ran).
+     * Never rejects — a failed setup must not turn emitEvents into an unhandled rejection.
+     */
+    private whenReady(): Promise<void> {
+        return (this.setupPromise ?? Promise.resolve()).then(
+            () => undefined,
+            () => undefined
+        );
+    }
+
+    /**
+     * Returns common properties merged onto every event at emit time, so each
+     * event carries the identity of the pipeline that produced it. Defaults to
+     * machine metadata plus pipeline-resolved `device_id` and
+     * `is_container_env`, with the host-supplied properties from
+     * {@link TelemetryConfig.getCommonProperties} merged on top; those must be
+     * available before the events that should carry them are emitted.
      */
     public getCommonProperties(): CommonProperties {
         return {
@@ -247,8 +300,12 @@ export class Telemetry {
 
     /**
      * Schedules the next send attempt. Replaces any previously scheduled send.
+     * No-op once close() has been called.
      */
     private scheduleSend(delayMs: number = SEND_INTERVAL_MS): void {
+        if (this.closed) {
+            return;
+        }
         this.timer.schedule(() => {
             void this.sendBatchAndReschedule();
         }, delayMs);
@@ -336,18 +393,16 @@ export class Telemetry {
     /**
      * Sends events through the API client after redacting sensitive data.
      */
-    private async sendEvents(client: ApiClient, events: BaseEvent[], signal?: AbortSignal): Promise<SendResult> {
+    private async sendEvents(
+        client: ApiClient,
+        events: TelemetryEvent<CommonProperties>[],
+        signal?: AbortSignal
+    ): Promise<SendResult> {
         try {
             const effectiveSignal = signal ?? AbortSignal.timeout(SEND_TIMEOUT_MS);
             const secrets = this.keychain?.allSecrets ?? [];
             await client.sendEvents(
-                events.map((event) => ({
-                    ...event,
-                    properties: {
-                        ...redact(this.getCommonProperties(), secrets),
-                        ...redact(event.properties, secrets),
-                    },
-                })),
+                events.map((event) => ({ ...event, properties: redact(event.properties, secrets) })),
                 { signal: effectiveSignal }
             );
             return { status: "success" };
@@ -377,7 +432,7 @@ function legacyConfigFromSession(
         eventCache,
     }: {
         commonProperties: Partial<CommonProperties>;
-        eventCache: EventCache;
+        eventCache?: EventCache<TelemetryEvent<CommonProperties>>;
     }
 ): TelemetryConfig {
     return {

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -265,6 +265,9 @@ export type ConnectionMetadata = AtlasMetadata &
         connection_id?: string;
         connection_auth_type?: string;
         connection_host_type?: string;
+        /** Atlas cluster the connection points at, when it is an Atlas connection. */
+        cluster_name?: string;
+        cluster_id?: string;
         shared_tier_alerts_detected?: TelemetryBoolSet;
         shared_tier_tier?: SharedTierTier;
         shared_tier_alerts?: SharedTierMetricName[];

--- a/src/tools/atlas/connect/connectCluster.ts
+++ b/src/tools/atlas/connect/connectCluster.ts
@@ -55,6 +55,9 @@ export class ConnectClusterTool extends AtlasToolBase {
     ): Promise<{ connectionString: string; atlas: AtlasClusterConnectionInfo }> {
         const cluster = await inspectCluster(this.apiClient, projectId, clusterName, context);
 
+        if (cluster.clusterId === undefined) {
+            throw new Error(`Atlas did not return an id for cluster "${clusterName}" in project "${projectId}"`);
+        }
         if (cluster.connectionStrings === undefined) {
             throw new Error("Connection strings not available");
         }
@@ -101,10 +104,8 @@ export class ConnectClusterTool extends AtlasToolBase {
             username,
             projectId,
             clusterName,
+            clusterId: cluster.clusterId,
             instanceType: cluster.instanceType,
-            provider: cluster.provider,
-            region: cluster.region,
-            expiryDate,
         };
 
         const cn = new URL(connectionString);

--- a/src/tools/atlas/read/listClusters.ts
+++ b/src/tools/atlas/read/listClusters.ts
@@ -17,6 +17,7 @@ export const ListClustersArgs = {
 
 export const ClusterOutputSchema = {
     name: z.string().optional(),
+    clusterId: z.string().optional(),
     instanceType: z.enum(["FREE", "DEDICATED", "FLEX"]),
     instanceSize: z.string().optional(),
     provider: z.string().optional(),

--- a/src/tools/tool.ts
+++ b/src/tools/tool.ts
@@ -1105,8 +1105,10 @@ export abstract class ToolBase<
             metadata.connection_host_type = connectionState.connectionStringInfo.hostType;
         }
 
-        if (connectionState.connectedAtlasCluster?.projectId) {
+        if (connectionState.connectedAtlasCluster) {
             metadata.project_id = connectionState.connectedAtlasCluster.projectId;
+            metadata.cluster_name = connectionState.connectedAtlasCluster.clusterName;
+            metadata.cluster_id = connectionState.connectedAtlasCluster.clusterId;
         }
 
         return metadata;

--- a/tests/integration/common/connectionManager.test.ts
+++ b/tests/integration/common/connectionManager.test.ts
@@ -152,8 +152,8 @@ describeWithMongoDB("Connection Manager", (integration) => {
                 username: "",
                 projectId: "",
                 clusterName: "My Atlas Cluster",
+                clusterId: "my-atlas-cluster-id",
                 instanceType: "FREE" as const,
-                expiryDate: new Date(),
             };
 
             beforeEach(async () => {
@@ -185,6 +185,40 @@ describeWithMongoDB("Connection Manager", (integration) => {
 
             it("should be marked explicitly as errored", () => {
                 expect(manager.currentConnectionState.tag).toEqual("errored");
+            });
+        });
+
+        describe("when fails to connect to a new atlas cluster given only its coordinates", () => {
+            // A host that issues its own credentials (X.509, a pre-provisioned
+            // user, a proxy) knows the cluster but none of the temporary-user
+            // details, and must still be able to mark the connection as Atlas.
+            const atlas = {
+                projectId: "test-project-id",
+                clusterName: "My Atlas Cluster",
+                clusterId: "my-atlas-cluster-id",
+            };
+
+            beforeEach(async () => {
+                try {
+                    await manager.connect({
+                        connectionString: "mongodb://localhost:xxxxx",
+                        atlas,
+                    });
+                } catch (_error: unknown) {
+                    void _error;
+                }
+            });
+
+            it("should carry the coordinates and the atlas host type on the errored state", () => {
+                expect(connectionManagerSpies["connection-error"]).toHaveBeenCalledWith({
+                    tag: "errored",
+                    connectedAtlasCluster: atlas,
+                    connectionStringInfo: {
+                        authType: "scram",
+                        hostType: "atlas",
+                    },
+                    errorReason: "Unable to parse localhost:xxxxx with URL",
+                });
             });
         });
     });

--- a/tests/integration/tools/mongodb/metadata/explain.test.ts
+++ b/tests/integration/tools/mongodb/metadata/explain.test.ts
@@ -345,8 +345,9 @@ describeWithMongoDB("explain tool with write stages", (integration) => {
             ]);
     });
 
-    // executionStats (and allPlansExecution) actually run the pipeline, so explaining an
-    // aggregation with a $out/$merge stage could otherwise perform a write even in readOnly mode.
+    // Explaining a pipeline never executes its $out/$merge stage, so this is not a data-safety
+    // guard. It keeps explain consistent with aggregate: a pipeline that cannot be run in the
+    // current mode cannot be explained either.
     for (const writeStage of ["$out", "$merge"] as const) {
         it(`rejects explaining aggregations with a ${writeStage} stage in readOnly mode`, async () => {
             integration.mcpServer().userConfig.readOnly = true;

--- a/tests/unit/common/cluster.test.ts
+++ b/tests/unit/common/cluster.test.ts
@@ -1,6 +1,70 @@
 import { describe, it, expect, vi } from "vitest";
-import { inspectCluster } from "../../../src/common/atlas/cluster.js";
+import { formatCluster, formatFlexCluster, inspectCluster } from "../../../src/common/atlas/cluster.js";
 import type { ApiClient } from "../../../src/common/atlas/apiClient.js";
+import type { ClusterDescription20240805, FlexClusterDescription20241113 } from "../../../src/common/atlas/openapi.js";
+
+// The generated API types mark nearly every field required; cast so fixtures
+// only carry what the formatters read.
+const dedicatedClusterDescription = {
+    id: "dedicated-cluster-id",
+    name: "dedicated-cluster",
+    stateName: "IDLE",
+    mongoDBVersion: "8.0",
+    connectionStrings: { standard: "mongodb://host-00:27017,host-01:27017" },
+    replicationSpecs: [
+        {
+            regionConfigs: [{ providerName: "AWS", regionName: "US_EAST_1", electableSpecs: { instanceSize: "M10" } }],
+        },
+    ],
+} as ClusterDescription20240805;
+
+const flexClusterDescription = {
+    id: "flex-cluster-id",
+    name: "flex-cluster",
+    stateName: "IDLE",
+    mongoDBVersion: "8.0",
+    connectionStrings: { standard: "mongodb://flex-host:27017" },
+    providerSettings: { backingProviderName: "AWS", regionName: "US_EAST_1" },
+} as FlexClusterDescription20241113;
+
+describe("formatCluster", () => {
+    it("maps the Atlas cluster id to clusterId", () => {
+        const cluster = formatCluster(dedicatedClusterDescription);
+
+        expect(cluster).toMatchObject({
+            name: "dedicated-cluster",
+            clusterId: "dedicated-cluster-id",
+            instanceType: "DEDICATED",
+            instanceSize: "M10",
+        });
+    });
+
+    it("leaves clusterId undefined when the Atlas API omits the id", () => {
+        const { id: _id, ...withoutId } = dedicatedClusterDescription;
+        void _id;
+
+        expect(formatCluster(withoutId).clusterId).toBeUndefined();
+    });
+});
+
+describe("formatFlexCluster", () => {
+    it("maps the Atlas cluster id to clusterId", () => {
+        const cluster = formatFlexCluster(flexClusterDescription);
+
+        expect(cluster).toMatchObject({
+            name: "flex-cluster",
+            clusterId: "flex-cluster-id",
+            instanceType: "FLEX",
+        });
+    });
+
+    it("leaves clusterId undefined when the Atlas API omits the id", () => {
+        const { id: _id, ...withoutId } = flexClusterDescription;
+        void _id;
+
+        expect(formatFlexCluster(withoutId).clusterId).toBeUndefined();
+    });
+});
 
 describe("inspectCluster", () => {
     it("includes x-request-id in error log when both getCluster and getFlexCluster fail", async () => {

--- a/tests/unit/common/connectionInfo.test.ts
+++ b/tests/unit/common/connectionInfo.test.ts
@@ -218,8 +218,8 @@ describe("connectionInfo", () => {
             username: "testuser",
             projectId: "project123",
             clusterName: "TestCluster",
+            clusterId: "cluster123",
             instanceType: "FREE",
-            expiryDate: new Date("2025-12-31"),
         };
 
         it("should return both authType and hostType for a standard connection string", () => {
@@ -251,6 +251,22 @@ describe("connectionInfo", () => {
             const config = {} as UserConfig;
 
             const result = getConnectionStringInfo(connectionString, config, atlasClusterInfo);
+
+            expect(result).toEqual({
+                authType: "scram",
+                hostType: "atlas",
+            });
+        });
+
+        it("should override hostType to atlas for a coordinates-only atlasInfo", () => {
+            const connectionString = "mongodb://localhost:27017";
+            const config = {} as UserConfig;
+
+            const result = getConnectionStringInfo(connectionString, config, {
+                projectId: "test-project-id",
+                clusterName: "test-cluster",
+                clusterId: "test-cluster-id",
+            });
 
             expect(result).toEqual({
                 authType: "scram",

--- a/tests/unit/resources/common/debug.test.ts
+++ b/tests/unit/resources/common/debug.test.ts
@@ -126,9 +126,9 @@ describe("debug resource", () => {
                 atlas: {
                     clusterName: "My Test Cluster",
                     projectId: "COFFEEFABADA",
+                    clusterId: "DEADBEEF",
                     username: "",
                     instanceType: "FREE",
-                    expiryDate: new Date(),
                 },
             },
         });

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -65,7 +65,10 @@ describe("Telemetry", () => {
     const sessionId = "test-session-id";
     const mcpClient = { name: "test-agent", version: "1.0.0" };
 
-    function createTelemetry(overrides: Partial<TelemetryConfig> = {}): Telemetry {
+    function createTelemetry(
+        overrides: Partial<TelemetryConfig> & { commonPropertiesOverride?: () => Partial<CommonProperties> } = {}
+    ): Telemetry {
+        const { commonPropertiesOverride, ...configOverrides } = overrides;
         return Telemetry.create({
             logger: new NullLogger(),
             deviceId: mockDeviceId,
@@ -79,8 +82,10 @@ describe("Telemetry", () => {
                 session_id: sessionId,
                 config_atlas_auth: mockApiClient.isAuthConfigured() ? "true" : "false",
                 config_connection_string: "false",
+                ...commonPropertiesOverride?.(),
             }),
-            ...overrides,
+            eventCache: mockEventCache as unknown as EventCache<TelemetryEvent<CommonProperties>>,
+            ...configOverrides,
         });
     }
 
@@ -179,8 +184,7 @@ describe("Telemetry", () => {
                         return result;
                     }
                 ),
-        } as unknown as typeof mockEventCache;
-        vi.spyOn(EventCache, "getInstance").mockReturnValue(mockEventCache as unknown as EventCache);
+        };
 
         mockDeviceId = {
             get: vi.fn().mockResolvedValue("test-device-id"),
@@ -202,13 +206,134 @@ describe("Telemetry", () => {
             await telemetry.setupPromise;
 
             telemetry.emitEvents([testEvent]);
+            await vi.advanceTimersByTimeAsync(0);
 
             expect(mockApiClient.sendEvents).not.toHaveBeenCalled();
-            expect(mockEventCache.appendEvents).toHaveBeenCalledWith([testEvent]);
+            expect(mockEventCache.appendEvents).toHaveBeenCalledTimes(1);
+            expect(_cachedEvents[0]?.properties).toMatchObject({
+                ...testEvent.properties,
+                device_id: "test-device-id",
+            });
 
             await vi.advanceTimersByTimeAsync(SEND_INTERVAL_MS);
 
             expect(mockApiClient.sendEvents).toHaveBeenCalledTimes(1);
+        });
+
+        it("should add common properties when events are emitted, not when they are sent", async () => {
+            let sessionIdOverride = "session-at-emit";
+            vi.clearAllTimers();
+            telemetry = createTelemetry({
+                commonPropertiesOverride: () => ({ session_id: sessionIdOverride }),
+            });
+            await telemetry.setupPromise;
+
+            telemetry.emitEvents([createTestEvent()]);
+            await vi.advanceTimersByTimeAsync(0);
+            sessionIdOverride = "session-at-send";
+
+            await emitEventsForTest([]);
+
+            const sentEvent = mockApiClient.sendEvents.mock.calls[0]?.[0]?.[0] as {
+                properties: Record<string, unknown>;
+            };
+            expectDefined(sentEvent);
+            expect(sentEvent.properties.session_id).toBe("session-at-emit");
+        });
+
+        it("should not reject or throw when getCommonProperties throws", async () => {
+            vi.clearAllTimers();
+            telemetry = createTelemetry({
+                commonPropertiesOverride: () => {
+                    throw new Error("override failed");
+                },
+            });
+            await telemetry.setupPromise;
+            const unhandled = vi.fn();
+            process.on("unhandledRejection", unhandled);
+
+            try {
+                expect(() => telemetry.emitEvents([createTestEvent()])).not.toThrow();
+                await vi.advanceTimersByTimeAsync(SEND_INTERVAL_MS);
+            } finally {
+                process.off("unhandledRejection", unhandled);
+            }
+
+            expect(unhandled).not.toHaveBeenCalled();
+            expect(mockEventCache.appendEvents).not.toHaveBeenCalled();
+            expect(mockApiClient.sendEvents).not.toHaveBeenCalled();
+        });
+
+        it("should add device_id to events emitted before setup completes", async () => {
+            vi.clearAllTimers();
+            let resolveDeviceId: (value: string) => void = () => {};
+            const devId = {
+                get: vi.fn().mockReturnValue(
+                    new Promise<string>((resolve) => {
+                        resolveDeviceId = resolve;
+                    })
+                ),
+                close: vi.fn(),
+            } as unknown as DeviceId;
+            telemetry = createTelemetry({ deviceId: devId });
+
+            telemetry.emitEvents([createTestEvent()]);
+            await vi.advanceTimersByTimeAsync(0);
+            expect(mockEventCache.appendEvents).not.toHaveBeenCalled();
+
+            resolveDeviceId("late-device-id");
+            await telemetry.setupPromise;
+            await vi.advanceTimersByTimeAsync(0);
+
+            expect(mockEventCache.appendEvents).toHaveBeenCalledTimes(1);
+            expect(_cachedEvents[0]?.properties).toMatchObject({ device_id: "late-device-id" });
+        });
+
+        it("should flush events emitted before setup completes on close", async () => {
+            vi.clearAllTimers();
+            let resolveDeviceId: (value: string) => void = () => {};
+            const devId = {
+                get: vi.fn().mockReturnValue(
+                    new Promise<string>((resolve) => {
+                        resolveDeviceId = resolve;
+                    })
+                ),
+                close: vi.fn(),
+            } as unknown as DeviceId;
+            telemetry = createTelemetry({ deviceId: devId });
+
+            telemetry.emitEvents([createTestEvent()]);
+            const closePromise = telemetry.close();
+            resolveDeviceId("late-device-id");
+            await closePromise;
+
+            expect(mockApiClient.sendEvents).toHaveBeenCalledTimes(1);
+            expect(_cachedEvents).toHaveLength(0);
+        });
+
+        it("should not schedule sends when setup completes after close", async () => {
+            vi.clearAllTimers();
+            let resolveDeviceId: (value: string) => void = () => {};
+            const devId = {
+                get: vi.fn().mockReturnValue(
+                    new Promise<string>((resolve) => {
+                        resolveDeviceId = resolve;
+                    })
+                ),
+                close: vi.fn(),
+            } as unknown as DeviceId;
+            telemetry = createTelemetry({ deviceId: devId });
+
+            const closePromise = telemetry.close();
+            resolveDeviceId("late-device-id");
+            await closePromise;
+            vi.clearAllMocks();
+
+            _cachedEvents.push(createTestEvent());
+            await vi.advanceTimersByTimeAsync(SEND_INTERVAL_MS * 2);
+
+            expect(mockApiClient.sendEvents).not.toHaveBeenCalled();
+            expect(_cachedEvents).toHaveLength(1);
         });
 
         it("should send events successfully and remove them from cache", async () => {
@@ -574,18 +699,15 @@ describe("Telemetry", () => {
      */
     describe("when sendBatch is triggered concurrently", () => {
         it("should not send the same cached event twice when two batches overlap", async () => {
-            const eventCache = new EventCache();
             const CACHED_MARKER = "cached-race-test";
-
-            eventCache.appendEvents([createTestEvent({ command: CACHED_MARKER, component: "cached" })]);
-
             mockApiClient.sendEvents.mockResolvedValue(undefined);
 
             vi.clearAllTimers();
-            // Route the Telemetry instance to the real cache via the mocked getInstance.
-            vi.spyOn(EventCache, "getInstance").mockReturnValue(eventCache);
-            const raceTelemetry = createTelemetry();
+            const raceTelemetry = createTelemetry({ eventCache: new EventCache() });
             await raceTelemetry.setupPromise;
+
+            raceTelemetry.emitEvents([createTestEvent({ command: CACHED_MARKER, component: "cached" })]);
+            await vi.advanceTimersByTimeAsync(0);
 
             await Promise.all([raceTelemetry["sendBatch"](), raceTelemetry["sendBatch"]()]);
 
@@ -598,6 +720,71 @@ describe("Telemetry", () => {
             }
             expect(cachedEventSendCount, "Cached event should be sent exactly once").toBe(1);
         });
+    });
+});
+
+/**
+ * Regression tests for multiple pipelines living in the same process (e.g. one
+ * per tenant in a hosted deployment). Each pipeline must only send the events
+ * it emitted, carrying the common properties of the pipeline that emitted them.
+ */
+describe("Telemetry with multiple instances in one process", () => {
+    function createTenant(tenantId: string): {
+        telemetry: Telemetry;
+        sendEvents: MockedFunction<(events: unknown[]) => Promise<void>>;
+    } {
+        const sendEvents = vi.fn().mockResolvedValue(undefined);
+        const apiClient = { sendEvents, isAuthConfigured: () => false } as unknown as ApiClient;
+        const telemetry = Telemetry.create({
+            logger: new NullLogger(),
+            deviceId: { get: vi.fn().mockResolvedValue(`device-${tenantId}`), close: vi.fn() } as unknown as DeviceId,
+            apiClient,
+            keychain: new Keychain(),
+            enabled: true,
+            getCommonProperties: () => ({ session_id: tenantId }),
+        });
+        return { telemetry, sendEvents };
+    }
+
+    function createEvent(command: string): BaseEvent {
+        return {
+            timestamp: new Date().toISOString(),
+            source: "mdbmcp",
+            properties: { component: "test", duration_ms: 1, result: "success", category: "test", command },
+        };
+    }
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("should send each event only through the pipeline that emitted it, with that pipeline's properties", async () => {
+        const tenantA = createTenant("tenant-a");
+        const tenantB = createTenant("tenant-b");
+        await Promise.all([tenantA.telemetry.setupPromise, tenantB.telemetry.setupPromise]);
+
+        tenantA.telemetry.emitEvents([createEvent("from-a")]);
+        tenantB.telemetry.emitEvents([createEvent("from-b")]);
+
+        const bothSent = Promise.all([
+            new Promise<void>((resolve) => tenantA.telemetry.events.once("events-emitted", resolve)),
+            new Promise<void>((resolve) => tenantB.telemetry.events.once("events-emitted", resolve)),
+        ]);
+        await vi.advanceTimersByTimeAsync(SEND_INTERVAL_MS);
+        await bothSent;
+
+        type Sent = { properties: { command: string; session_id: string; device_id: string } };
+        const sentByA = tenantA.sendEvents.mock.calls.flatMap((call) => call[0] as Sent[]);
+        const sentByB = tenantB.sendEvents.mock.calls.flatMap((call) => call[0] as Sent[]);
+
+        expect(sentByA.map((e) => e.properties.command)).toEqual(["from-a"]);
+        expect(sentByB.map((e) => e.properties.command)).toEqual(["from-b"]);
+        expect(sentByA[0]?.properties).toMatchObject({ session_id: "tenant-a", device_id: "device-tenant-a" });
+        expect(sentByB[0]?.properties).toMatchObject({ session_id: "tenant-b", device_id: "device-tenant-b" });
     });
 });
 
@@ -620,7 +807,6 @@ describe("Telemetry credentials handling", () => {
     beforeEach(() => {
         vi.useFakeTimers();
         fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
-        vi.spyOn(EventCache, "getInstance").mockReturnValue(new EventCache());
     });
 
     afterEach(() => {

--- a/tests/unit/toolBase.test.ts
+++ b/tests/unit/toolBase.test.ts
@@ -359,8 +359,8 @@ describe("ToolBase", () => {
             projectId: "test-project-id",
             username: "test-user",
             clusterName: "test-cluster",
+            clusterId: "test-cluster-id",
             instanceType: "FREE",
-            expiryDate: new Date(),
         };
 
         it("should return empty metadata when no connection state is provided", () => {
@@ -372,7 +372,7 @@ describe("ToolBase", () => {
             expect(metadata).not.toHaveProperty("connection_host_type");
         });
 
-        it("should return metadata with project_id when connectedAtlasCluster.projectId is set", () => {
+        it("should return project_id, cluster_name and cluster_id when connectedAtlasCluster is set", () => {
             const metadata = testTool["getConnectionInfoMetadata"]({
                 tag: "disconnected",
                 connectedAtlasCluster: atlasCluster,
@@ -380,19 +380,30 @@ describe("ToolBase", () => {
 
             expect(metadata).toEqual({
                 project_id: "test-project-id",
+                cluster_name: "test-cluster",
+                cluster_id: "test-cluster-id",
             });
             expect(metadata).not.toHaveProperty("connection_auth_type");
             expect(metadata).not.toHaveProperty("connection_host_type");
         });
 
-        it("should return empty metadata when connectedAtlasCluster exists but projectId is falsy", () => {
+        it("should return the same metadata for a coordinates-only connectedAtlasCluster", () => {
+            // What a host that dials Atlas without minting a temporary database
+            // user can supply: coordinates, no credential or tier details.
             const metadata = testTool["getConnectionInfoMetadata"]({
                 tag: "disconnected",
-                connectedAtlasCluster: { ...atlasCluster, projectId: "" },
+                connectedAtlasCluster: {
+                    projectId: "test-project-id",
+                    clusterName: "test-cluster",
+                    clusterId: "test-cluster-id",
+                },
             });
 
-            expect(metadata).toEqual({});
-            expect(metadata).not.toHaveProperty("project_id");
+            expect(metadata).toEqual({
+                project_id: "test-project-id",
+                cluster_name: "test-cluster",
+                cluster_id: "test-cluster-id",
+            });
         });
 
         it("should return metadata with connection_auth_type and connection_host_type when connectionStringInfo is set", () => {
@@ -423,6 +434,8 @@ describe("ToolBase", () => {
 
             expect(metadata).toEqual({
                 project_id: "test-project-id",
+                cluster_name: "test-cluster",
+                cluster_id: "test-cluster-id",
                 connection_auth_type: "oidc-auth-flow",
                 connection_host_type: "atlas",
             });

--- a/tests/unit/tools/atlas/connect/connectCluster.test.ts
+++ b/tests/unit/tools/atlas/connect/connectCluster.test.ts
@@ -20,14 +20,15 @@ const ATLAS_INFO: AtlasClusterConnectionInfo = {
     username: "user1",
     projectId: "proj1",
     clusterName: "cluster1",
+    clusterId: "cluster1-id",
     instanceType: "DEDICATED",
-    expiryDate: new Date(),
 };
 
 // A dedicated (M10) cluster description as returned by the Atlas API. Dedicated
 // clusters skip the shared-tier alerts hook, keeping execute() free of extra
 // API calls.
 const CLUSTER_DESCRIPTION = {
+    id: "cluster1-id",
     name: "cluster1",
     stateName: "IDLE",
     replicationSpecs: [
@@ -119,6 +120,30 @@ describe("ConnectClusterTool", () => {
             const connectionId = result.structuredContent?.connectionId;
             const entry = await connectionRegistry.peek(connectionId);
             expect(entry?.name).toMatch(/^test-project-cluster1-[0-9a-f]{4}$/);
+        });
+
+        it("records the cluster id alongside the project and cluster name on the connection", async () => {
+            const result = await tool["execute"](args, { signal: new AbortController().signal });
+
+            const connectionId = result.structuredContent?.connectionId;
+            const entry = await connectionRegistry.peek(connectionId);
+            expect(entry?.state.connectedAtlasCluster).toMatchObject({
+                projectId: "proj1",
+                clusterName: "cluster1",
+                clusterId: "cluster1-id",
+                instanceType: "DEDICATED",
+            });
+        });
+
+        it("fails before creating a temporary user when the Atlas API omits the cluster id", async () => {
+            const { id: _id, ...withoutId } = CLUSTER_DESCRIPTION;
+            void _id;
+            mockApiClient.getCluster?.mockResolvedValue(withoutId);
+
+            await expect(tool["execute"](args, { signal: new AbortController().signal })).rejects.toThrow(
+                'Atlas did not return an id for cluster "cluster1" in project "proj1"'
+            );
+            expect(mockApiClient.createDatabaseUser).not.toHaveBeenCalled();
         });
 
         it("falls back to the cluster name alone when the project lookup fails", async () => {

--- a/tests/unit/tools/atlas/read/listClusters.test.ts
+++ b/tests/unit/tools/atlas/read/listClusters.test.ts
@@ -13,6 +13,7 @@ import { MockMetrics } from "../../../mocks/metrics.js";
 const projectId = "507f1f77bcf86cd799439011";
 
 const freeClusterApiResponse = {
+    id: "free-cluster-id",
     name: "free-cluster",
     paused: false,
     stateName: "IDLE",
@@ -33,6 +34,7 @@ const freeClusterApiResponse = {
 };
 
 const flexClusterApiResponse = {
+    id: "flex-cluster-id",
     name: "flex-cluster",
     stateName: "IDLE",
     mongoDBVersion: "8.0",
@@ -121,6 +123,10 @@ describe("ListClustersTool", () => {
             const [description, untrusted] = result.content.map((c) => (c as { text: string }).text);
             expect(description).not.toContain("My Project");
             expect(untrusted).toContain("My Project");
+            expect(result.structuredContent?.clusters).toEqual([
+                expect.objectContaining({ name: "free-cluster", clusterId: "free-cluster-id" }),
+                expect.objectContaining({ name: "flex-cluster", clusterId: "flex-cluster-id" }),
+            ]);
         });
 
         it("calls getGroup, listClusters, and listFlexClusters", async () => {
@@ -197,6 +203,7 @@ describe("ListClustersTool", () => {
                     clusters: [
                         {
                             name: "free-cluster",
+                            clusterId: "free-cluster-id",
                             instanceType: "FREE",
                             instanceSize: undefined,
                             provider: "AWS",

--- a/tests/unit/tools/atlas/update/pauseResumeCluster.test.ts
+++ b/tests/unit/tools/atlas/update/pauseResumeCluster.test.ts
@@ -162,11 +162,9 @@ describe("PauseResumeClusterTool", () => {
         const connectedCluster: AtlasClusterConnectionInfo = {
             projectId: PROJECT_ID,
             clusterName: CLUSTER_NAME,
+            clusterId: "test-cluster-id",
             instanceType: "DEDICATED",
             username: "test-user",
-            provider: "AWS",
-            region: "US_EAST_1",
-            expiryDate: new Date(Date.now() + 3_600_000),
         };
 
         it("revokes matching connections and mentions them in the response when pausing the cluster", async () => {


### PR DESCRIPTION
## Proposed changes

Backports https://github.com/mongodb-js/mongodb-mcp-server/pull/1484 and https://github.com/mongodb-js/mongodb-mcp-server/pull/1465 to the v2 branch
