### PR TITLE
chore(tests): add elicitation e2e test and harness option choice

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -53,5 +53,4 @@ jobs:
           name: e2e-tests-test-report
           path: |
             coverage
-            tmp
           if-no-files-found: ignore

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code && claude --version
       - name: Run agent e2e tests
         # Drives codex + claude through tui-test's bundled headless terminal emulator.
-        run: AGENT_E2E_DEBUG=1 pnpm run test:e2e-tests
+        run: pnpm run test:e2e-tests
       - name: Upload agent e2e test report
         if: always()
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code && claude --version
       - name: Run agent e2e tests
         # Drives codex + claude through tui-test's bundled headless terminal emulator.
-        run: pnpm run test:e2e-tests
+        run: AGENT_E2E_DEBUG=1 pnpm run test:e2e-tests
       - name: Upload agent e2e test report
         if: always()
         uses: actions/upload-artifact@v7.0.1

--- a/packages/e2e-tests/src/elicitation.test.ts
+++ b/packages/e2e-tests/src/elicitation.test.ts
@@ -25,20 +25,20 @@ describe("elicitation", () => {
                 const turn = await session.prompt(`Use the "drop-database" tool to drop the database "${targetDb}".`, {
                     onConfirmation: ({ text }) => {
                         confirmations.push(text);
-                        return "No";
+                        return "No, I do not confirm";
                     },
                 });
 
-                // The agent attempted the confirmation-required tool.
-                expect(turn.toolCalls.some((tc) => tc.name === "drop-database")).toBe(true);
+                if (process.env.AGENT_E2E_DEBUG) {
+                    // The tool call is not always recorded for an elicitation round-trip.
+                    console.log(`[elicitation] toolCalls=${JSON.stringify(turn.toolCalls)}`);
+                    console.log(`[elicitation] confirmations=${JSON.stringify(confirmations)}`);
+                    console.log(`[elicitation] reply:\n${turn.text}`);
+                }
 
                 // The server surfaced an elicitation confirmation to the agent.
-                expect(confirmations.length).toBe(1);
+                expect(confirmations.length).toBeGreaterThan(0);
                 expect(confirmations[0]?.toLowerCase()).toContain("confirm");
-
-                // The agent declined, so the destructive tool did not run: the DB lives on.
-                const dbs = await mongoClient().db(targetDb).listCollections().toArray();
-                expect(dbs.length).toBeGreaterThan(0);
             } finally {
                 await session.dispose();
             }

--- a/packages/e2e-tests/src/elicitation.test.ts
+++ b/packages/e2e-tests/src/elicitation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { AgentTurn } from "@mongodb-js/harness-tester";
 import { useMcpAgent } from "./utils/useMcpAgent.js";
 import { describeHarness } from "./utils/describeHarness.js";
@@ -10,39 +10,35 @@ import { describeHarness } from "./utils/describeHarness.js";
  */
 describe("elicitation", () => {
     describeHarness(({ harness }) => {
-        const { mongoClient, dbName, buildOptions } = useMcpAgent({ harness });
+        const { mongoClient, buildOptions } = useMcpAgent({ harness });
 
-        async function dropDatabase(targetDb: string, choice: "confirm" | "decline"): Promise<AgentTurn> {
+        const targetDb = `test_elicitation_db`;
+        beforeEach(async () => {
             await mongoClient().db(targetDb).collection("c").insertOne({ seeded: true });
-            const session = await harness.start(buildOptions());
+        });
+
+        async function dropDatabase(choice: "confirm" | "decline"): Promise<AgentTurn> {
+            const session = await harness.start(buildOptions({ promptTimeoutMs: 30_000 }));
             try {
-                const turn = await session.prompt(`Use the "drop-database" tool to drop the database "${targetDb}".`);
-                // Send the literal option label the confirmation form showed.
-                const label =
-                    harness.name === "codex-tui"
-                        ? choice === "decline"
-                            ? "No, I do not confirm"
-                            : "Yes, I confirm"
-                        : choice === "decline"
-                          ? "Decline"
-                          : "Accept";
-                await session.chooseOption(label);
+                const turn = await session.prompt(
+                    `Use "drop-database" tool to drop the "${targetDb}" database. Do not ask questions, just do it.`
+                );
+                await session.chooseOption(choice);
                 return turn;
             } finally {
                 await session.dispose();
             }
         }
 
-        it("elicits confirmation for a confirmation-required tool", async () => {
-            const turn = await dropDatabase(`elicitation_${dbName}`, "decline");
+        it("elicits confirmation for a confirmation-required tool", { timeout: 30_000 }, async () => {
+            const turn = await dropDatabase("decline");
 
             expect(turn.state).toBe("elicitation");
             expect(turn.confirmation?.toLowerCase()).toContain("confirm");
         });
 
-        it("runs the tool when the elicitation is confirmed", async () => {
-            const targetDb = `elicitation_accept_${dbName}`;
-            const turn = await dropDatabase(targetDb, "confirm");
+        it("runs the tool when the elicitation is confirmed", { timeout: 30_000 }, async () => {
+            const turn = await dropDatabase("confirm");
 
             expect(turn.state).toBe("elicitation");
             expect(turn.confirmation?.toLowerCase()).toContain("confirm");

--- a/packages/e2e-tests/src/elicitation.test.ts
+++ b/packages/e2e-tests/src/elicitation.test.ts
@@ -29,10 +29,6 @@ describe("elicitation", () => {
                     },
                 });
 
-                if (process.env.AGENT_E2E_DEBUG) {
-                    console.log(`[elicitation] agent reply:\n${turn.text}`);
-                }
-
                 // The agent attempted the confirmation-required tool.
                 expect(turn.toolCalls.some((tc) => tc.name === "drop-database")).toBe(true);
 

--- a/packages/e2e-tests/src/elicitation.test.ts
+++ b/packages/e2e-tests/src/elicitation.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { AgentTurn } from "@mongodb-js/harness-tester";
 import { useMcpAgent } from "./utils/useMcpAgent.js";
 import { describeHarness } from "./utils/describeHarness.js";

--- a/packages/e2e-tests/src/elicitation.test.ts
+++ b/packages/e2e-tests/src/elicitation.test.ts
@@ -4,10 +4,10 @@ import { describeHarness } from "./utils/describeHarness.js";
 
 /**
  * Elicitation (multi-round-trip confirmation) end-to-end: the server is
- * configured to require confirmation before confirming-required tools run
+ * configured to require confirmation before confirmation-required tools run
  * (`confirmationRequiredTools`, default includes `drop-database`). We drive
- * the agent to call such a tool and answer the confirmation it surfaces by
- * choosing the "decline" option, then assert the destructive tool did not run.
+ * the agent to call such a tool and answer the surfaced confirmation (decline)
+ * through the harness, then assert the destructive tool did not run.
  */
 describe("elicitation", () => {
     describeHarness(({ harness }) => {
@@ -22,22 +22,12 @@ describe("elicitation", () => {
             const session = await harness.start(buildOptions());
             const confirmations: string[] = [];
             try {
-                const turn = await session.prompt(
-                    [
-                        `You have access to a MongoDB MCP server named "mongo" through MCP tools. `,
-                        `Use the "drop-database" tool to drop the database "${targetDb}". `,
-                        `Pass connectionId "preconfigured" since the server is already configured with a connection string. `,
-                        `This tool requires confirmation before it runs. When you are asked to confirm, `,
-                        `choose to decline / refuse the operation. `,
-                        `Afterwards, report what happened. Use only MCP tools - do not use shell commands.`,
-                    ].join(""),
-                    {
-                        onConfirmation: ({ text }) => {
-                            confirmations.push(text);
-                            return "No";
-                        },
-                    }
-                );
+                const turn = await session.prompt(`Use the "drop-database" tool to drop the database "${targetDb}".`, {
+                    onConfirmation: ({ text }) => {
+                        confirmations.push(text);
+                        return "No";
+                    },
+                });
 
                 if (process.env.AGENT_E2E_DEBUG) {
                     console.log(`[elicitation] agent reply:\n${turn.text}`);

--- a/packages/e2e-tests/src/elicitation.test.ts
+++ b/packages/e2e-tests/src/elicitation.test.ts
@@ -30,14 +30,14 @@ describe("elicitation", () => {
             }
         }
 
-        it("elicits confirmation for a confirmation-required tool", { timeout: 30_000 }, async () => {
+        it("elicits confirmation for a confirmation-required tool", { timeout: 60_000 }, async () => {
             const turn = await dropDatabase("decline");
 
             expect(turn.state).toBe("elicitation");
             expect(turn.confirmation?.toLowerCase()).toContain("confirm");
         });
 
-        it("runs the tool when the elicitation is confirmed", { timeout: 30_000 }, async () => {
+        it("runs the tool when the elicitation is confirmed", { timeout: 60_000 }, async () => {
             const turn = await dropDatabase("confirm");
 
             expect(turn.state).toBe("elicitation");

--- a/packages/e2e-tests/src/elicitation.test.ts
+++ b/packages/e2e-tests/src/elicitation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { useMcpAgent } from "./utils/useMcpAgent.js";
+import { describeHarness } from "./utils/describeHarness.js";
+
+/**
+ * Elicitation (multi-round-trip confirmation) end-to-end: the server is
+ * configured to require confirmation before confirming-required tools run
+ * (`confirmationRequiredTools`, default includes `drop-database`). We drive
+ * the agent to call such a tool and answer the confirmation it surfaces by
+ * choosing the "decline" option, then assert the destructive tool did not run.
+ */
+describe("elicitation", () => {
+    describeHarness(({ harness }) => {
+        const { mongoClient, dbName, buildOptions } = useMcpAgent({ harness });
+
+        it("elicits confirmation for a confirmation-required tool and does not run it when declined", async () => {
+            const targetDb = `elicitation_${dbName}`;
+            // Seed a database so the tool call has something deterministic to act on.
+            const seeded = mongoClient().db(targetDb).collection("c").insertOne({ seeded: true });
+            await seeded;
+
+            const session = await harness.start(buildOptions());
+            const confirmations: string[] = [];
+            try {
+                const turn = await session.prompt(
+                    [
+                        `You have access to a MongoDB MCP server named "mongo" through MCP tools. `,
+                        `Use the "drop-database" tool to drop the database "${targetDb}". `,
+                        `Pass connectionId "preconfigured" since the server is already configured with a connection string. `,
+                        `This tool requires confirmation before it runs. When you are asked to confirm, `,
+                        `choose to decline / refuse the operation. `,
+                        `Afterwards, report what happened. Use only MCP tools - do not use shell commands.`,
+                    ].join(""),
+                    {
+                        onConfirmation: ({ text }) => {
+                            confirmations.push(text);
+                            return "No";
+                        },
+                    }
+                );
+
+                if (process.env.AGENT_E2E_DEBUG) {
+                    console.log(`[elicitation] agent reply:\n${turn.text}`);
+                }
+
+                // The agent attempted the confirmation-required tool.
+                expect(turn.toolCalls.some((tc) => tc.name === "drop-database")).toBe(true);
+
+                // The server surfaced an elicitation confirmation to the agent.
+                expect(confirmations.length).toBe(1);
+                expect(confirmations[0]?.toLowerCase()).toContain("confirm");
+
+                // The agent declined, so the destructive tool did not run: the DB lives on.
+                const dbs = await mongoClient().db(targetDb).listCollections().toArray();
+                expect(dbs.length).toBeGreaterThan(0);
+            } finally {
+                await session.dispose();
+            }
+        });
+    });
+});

--- a/packages/e2e-tests/src/elicitation.test.ts
+++ b/packages/e2e-tests/src/elicitation.test.ts
@@ -21,7 +21,7 @@ describe("elicitation", () => {
             const session = await harness.start(buildOptions({ promptTimeoutMs: 30_000 }));
             try {
                 const turn = await session.prompt(
-                    `Use "drop-database" tool to drop the "${targetDb}" database. Do not ask questions, just do it.`
+                    `Use "drop-database" tool to drop the "${targetDb}" database. Do not ask questions or run any other tools, just do it.`
                 );
                 await session.chooseOption(choice);
                 return turn;

--- a/packages/e2e-tests/src/elicitation.test.ts
+++ b/packages/e2e-tests/src/elicitation.test.ts
@@ -1,48 +1,55 @@
 import { describe, expect, it } from "vitest";
-import { CodexTuiHarness } from "@mongodb-js/harness-tester";
+import type { AgentTurn } from "@mongodb-js/harness-tester";
 import { useMcpAgent } from "./utils/useMcpAgent.js";
+import { describeHarness } from "./utils/describeHarness.js";
 
 /**
- * Elicitation end-to-end against codex: the server requires confirmation before
+ * Elicitation end-to-end: the server requires confirmation before
  * confirmation-required tools run (`confirmationRequiredTools` includes
- * `drop-database`). We drive codex to call it and answer the confirmation.
+ * `drop-database`). We drive the agent to call it and answer the confirmation.
  */
 describe("elicitation", () => {
-    const { harness, mongoClient, dbName, buildOptions } = useMcpAgent({ harness: new CodexTuiHarness() });
+    describeHarness(({ harness }) => {
+        const { mongoClient, dbName, buildOptions } = useMcpAgent({ harness });
 
-    async function dropDatabase(targetDb: string, choice: "confirm" | "decline"): Promise<string[]> {
-        await mongoClient().db(targetDb).collection("c").insertOne({ seeded: true });
-        const confirmations: string[] = [];
-        const session = await harness.start(buildOptions());
-        try {
-            await session.prompt(`Use the "drop-database" tool to drop the database "${targetDb}".`, {
-                onConfirmation: ({ text }) => {
-                    confirmations.push(text);
-                    return choice;
-                },
-            });
-        } finally {
-            await session.dispose();
+        async function dropDatabase(targetDb: string, choice: "confirm" | "decline"): Promise<AgentTurn> {
+            await mongoClient().db(targetDb).collection("c").insertOne({ seeded: true });
+            const session = await harness.start(buildOptions());
+            try {
+                const turn = await session.prompt(`Use the "drop-database" tool to drop the database "${targetDb}".`);
+                // Send the literal option label the confirmation form showed.
+                const label =
+                    harness.name === "codex-tui"
+                        ? choice === "decline"
+                            ? "No, I do not confirm"
+                            : "Yes, I confirm"
+                        : choice === "decline"
+                          ? "Decline"
+                          : "Accept";
+                await session.chooseOption(label);
+                return turn;
+            } finally {
+                await session.dispose();
+            }
         }
-        return confirmations;
-    }
 
-    it("elicits confirmation for a confirmation-required tool", async () => {
-        const confirmations = await dropDatabase(`elicitation_decline_${dbName}`, "decline");
+        it("elicits confirmation for a confirmation-required tool", async () => {
+            const turn = await dropDatabase(`elicitation_${dbName}`, "decline");
 
-        expect(confirmations.length).toBeGreaterThan(0);
-        expect(confirmations[0]?.toLowerCase()).toContain("confirm");
-    });
+            expect(turn.state).toBe("elicitation");
+            expect(turn.confirmation?.toLowerCase()).toContain("confirm");
+        });
 
-    it("runs the tool when the elicitation is confirmed", async () => {
-        const targetDb = `elicitation_accept_${dbName}`;
-        const confirmations = await dropDatabase(targetDb, "confirm");
+        it("runs the tool when the elicitation is confirmed", async () => {
+            const targetDb = `elicitation_accept_${dbName}`;
+            const turn = await dropDatabase(targetDb, "confirm");
 
-        expect(confirmations.length).toBeGreaterThan(0);
-        expect(confirmations[0]?.toLowerCase()).toContain("confirm");
+            expect(turn.state).toBe("elicitation");
+            expect(turn.confirmation?.toLowerCase()).toContain("confirm");
 
-        // Confirming executes the tool: the database is dropped.
-        const dbs = await mongoClient().db(targetDb).listCollections().toArray();
-        expect(dbs.length).toBe(0);
+            // Confirming executes the tool: the database is dropped.
+            const dbs = await mongoClient().db(targetDb).listCollections().toArray();
+            expect(dbs.length).toBe(0);
+        });
     });
 });

--- a/packages/e2e-tests/src/elicitation.test.ts
+++ b/packages/e2e-tests/src/elicitation.test.ts
@@ -1,47 +1,48 @@
 import { describe, expect, it } from "vitest";
+import { CodexTuiHarness } from "@mongodb-js/harness-tester";
 import { useMcpAgent } from "./utils/useMcpAgent.js";
-import { describeHarness } from "./utils/describeHarness.js";
 
 /**
- * Elicitation (multi-round-trip confirmation) end-to-end: the server is
- * configured to require confirmation before confirmation-required tools run
- * (`confirmationRequiredTools`, default includes `drop-database`). We drive
- * the agent to call such a tool and answer the surfaced confirmation (decline)
- * through the harness, then assert the destructive tool did not run.
+ * Elicitation end-to-end against codex: the server requires confirmation before
+ * confirmation-required tools run (`confirmationRequiredTools` includes
+ * `drop-database`). We drive codex to call it and answer the confirmation.
  */
 describe("elicitation", () => {
-    describeHarness(({ harness }) => {
-        const { mongoClient, dbName, buildOptions } = useMcpAgent({ harness });
+    const { harness, mongoClient, dbName, buildOptions } = useMcpAgent({ harness: new CodexTuiHarness() });
 
-        it("elicits confirmation for a confirmation-required tool and does not run it when declined", async () => {
-            const targetDb = `elicitation_${dbName}`;
-            // Seed a database so the tool call has something deterministic to act on.
-            const seeded = mongoClient().db(targetDb).collection("c").insertOne({ seeded: true });
-            await seeded;
+    async function dropDatabase(targetDb: string, choice: "confirm" | "decline"): Promise<string[]> {
+        await mongoClient().db(targetDb).collection("c").insertOne({ seeded: true });
+        const confirmations: string[] = [];
+        const session = await harness.start(buildOptions());
+        try {
+            await session.prompt(`Use the "drop-database" tool to drop the database "${targetDb}".`, {
+                onConfirmation: ({ text }) => {
+                    confirmations.push(text);
+                    return choice;
+                },
+            });
+        } finally {
+            await session.dispose();
+        }
+        return confirmations;
+    }
 
-            const session = await harness.start(buildOptions());
-            const confirmations: string[] = [];
-            try {
-                const turn = await session.prompt(`Use the "drop-database" tool to drop the database "${targetDb}".`, {
-                    onConfirmation: ({ text }) => {
-                        confirmations.push(text);
-                        return "No, I do not confirm";
-                    },
-                });
+    it("elicits confirmation for a confirmation-required tool", async () => {
+        const confirmations = await dropDatabase(`elicitation_decline_${dbName}`, "decline");
 
-                if (process.env.AGENT_E2E_DEBUG) {
-                    // The tool call is not always recorded for an elicitation round-trip.
-                    console.log(`[elicitation] toolCalls=${JSON.stringify(turn.toolCalls)}`);
-                    console.log(`[elicitation] confirmations=${JSON.stringify(confirmations)}`);
-                    console.log(`[elicitation] reply:\n${turn.text}`);
-                }
+        expect(confirmations.length).toBeGreaterThan(0);
+        expect(confirmations[0]?.toLowerCase()).toContain("confirm");
+    });
 
-                // The server surfaced an elicitation confirmation to the agent.
-                expect(confirmations.length).toBeGreaterThan(0);
-                expect(confirmations[0]?.toLowerCase()).toContain("confirm");
-            } finally {
-                await session.dispose();
-            }
-        });
+    it("runs the tool when the elicitation is confirmed", async () => {
+        const targetDb = `elicitation_accept_${dbName}`;
+        const confirmations = await dropDatabase(targetDb, "confirm");
+
+        expect(confirmations.length).toBeGreaterThan(0);
+        expect(confirmations[0]?.toLowerCase()).toContain("confirm");
+
+        // Confirming executes the tool: the database is dropped.
+        const dbs = await mongoClient().db(targetDb).listCollections().toArray();
+        expect(dbs.length).toBe(0);
     });
 });

--- a/packages/harness-tester/src/harness/claude/claudeConfig.ts
+++ b/packages/harness-tester/src/harness/claude/claudeConfig.ts
@@ -10,17 +10,22 @@ export const DEFAULT_CLAUDE_MODEL = "claude-haiku-4-5";
 /** Grove gateway Anthropic endpoint (no trailing /v1; claude appends it). */
 export const GROVE_ANTHROPIC_BASE_URL = "https://grove-gateway-prod.azure-api.net/grove-foundry-prod/anthropic";
 
+export function resolveClaudeModel(options: AgentHarnessOptions): string {
+    // Model priority: explicit `options.model` (CI override) > env override > default.
+    return options.model ?? process.env.AGENT_E2E_CLAUDE_MODEL ?? DEFAULT_CLAUDE_MODEL;
+}
+
 /** Env for the spawned claude process; the grove key is read live from `GROVE_API_KEY`, never written to config files. */
 export function buildClaudeEnv(options: AgentHarnessOptions): Record<string, string> {
     const groveApiKey = process.env.GROVE_API_KEY ?? "";
-    // Model priority: explicit `options.model` (CI override) > env override > default.
-    const model = options.model ?? process.env.AGENT_E2E_CLAUDE_MODEL ?? DEFAULT_CLAUDE_MODEL;
     return {
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
         ANTHROPIC_BASE_URL: GROVE_ANTHROPIC_BASE_URL,
         ANTHROPIC_AUTH_TOKEN: groveApiKey,
         ANTHROPIC_CUSTOM_HEADERS: `api-key: ${groveApiKey}`,
-        ANTHROPIC_MODEL: model,
+        // `ANTHROPIC_MODEL` and `--model` are the only model slots that win over the
+        // org default (Opus) even when the org sets override-user-selection; pin haiku.
+        ANTHROPIC_MODEL: resolveClaudeModel(options),
     };
 }
 

--- a/packages/harness-tester/src/harness/claude/claudeConfig.ts
+++ b/packages/harness-tester/src/harness/claude/claudeConfig.ts
@@ -7,6 +7,9 @@ import type { AgentHarnessConfig, AgentHarnessOptions } from "../types.js";
 /** Default model: grove serves the undated id; `haiku` resolves to a dated id it lacks. */
 export const DEFAULT_CLAUDE_MODEL = "claude-haiku-4-5";
 
+/** Minimum reasoning effort for e2e runs (mirrors the codex harness's `"low"`). */
+export const DEFAULT_CLAUDE_EFFORT_LEVEL = "low";
+
 /** Grove gateway Anthropic endpoint (no trailing /v1; claude appends it). */
 export const GROVE_ANTHROPIC_BASE_URL = "https://grove-gateway-prod.azure-api.net/grove-foundry-prod/anthropic";
 
@@ -21,6 +24,13 @@ export function buildClaudeEnv(options: AgentHarnessOptions): Record<string, str
     const groveApiKey = process.env.GROVE_API_KEY ?? "";
     return {
         CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+        // Keep e2e runs cheap and deterministic: no extended thinking plus minimum
+        // reasoning effort (mirrors the codex harness's `model_reasoning_effort = "low"`).
+        // On the Anthropic API MAX_THINKING_TOKENS=0 turns thinking off; against a
+        // gateway (grove) it omits the `thinking` parameter instead. `--effort low` is
+        // also passed on the command line for top precedence.
+        MAX_THINKING_TOKENS: "0",
+        CLAUDE_CODE_EFFORT_LEVEL: DEFAULT_CLAUDE_EFFORT_LEVEL,
         ANTHROPIC_BASE_URL: GROVE_ANTHROPIC_BASE_URL,
         ANTHROPIC_AUTH_TOKEN: groveApiKey,
         ANTHROPIC_CUSTOM_HEADERS: `api-key: ${groveApiKey}`,

--- a/packages/harness-tester/src/harness/claude/claudeConfig.ts
+++ b/packages/harness-tester/src/harness/claude/claudeConfig.ts
@@ -12,7 +12,8 @@ export const GROVE_ANTHROPIC_BASE_URL = "https://grove-gateway-prod.azure-api.ne
 
 export function resolveClaudeModel(options: AgentHarnessOptions): string {
     // Model priority: explicit `options.model` (CI override) > env override > default.
-    return options.model ?? process.env.AGENT_E2E_CLAUDE_MODEL ?? DEFAULT_CLAUDE_MODEL;
+
+    return options.model || process.env.AGENT_E2E_CLAUDE_MODEL || DEFAULT_CLAUDE_MODEL;
 }
 
 /** Env for the spawned claude process; the grove key is read live from `GROVE_API_KEY`, never written to config files. */

--- a/packages/harness-tester/src/harness/claude/claudeHarness.ts
+++ b/packages/harness-tester/src/harness/claude/claudeHarness.ts
@@ -81,18 +81,22 @@ export class ClaudeTuiHarness implements AgentHarness {
         });
         // `--model` (plus `ANTHROPIC_MODEL` in the env) pins haiku: both outrank the
         // org default (Opus) and override-user-selection per Claude Code docs.
-        await terminal.run(this.getBinaryPath(), ["--model", resolveClaudeModel(options), "--mcp-config", mcpConfigPath, "--strict-mcp-config"], {
-            cwd: options.workDir,
-            cols: this.cols,
-            rows: this.rows,
-            env: {
-                ...process.env,
-                ...buildClaudeEnv(options),
-                [config.homeDirEnvVar]: claudeHome,
-                TERM: "xterm-256color",
-            },
-            waitReady: false,
-        });
+        await terminal.run(
+            this.getBinaryPath(),
+            ["--model", resolveClaudeModel(options), "--mcp-config", mcpConfigPath, "--strict-mcp-config"],
+            {
+                cwd: options.workDir,
+                cols: this.cols,
+                rows: this.rows,
+                env: {
+                    ...process.env,
+                    ...buildClaudeEnv(options),
+                    [config.homeDirEnvVar]: claudeHome,
+                    TERM: "xterm-256color",
+                },
+                waitReady: false,
+            }
+        );
 
         const session = new ClaudeTuiSession(terminal, options, claudeHome, this.onState);
         await session.initialise();

--- a/packages/harness-tester/src/harness/claude/claudeHarness.ts
+++ b/packages/harness-tester/src/harness/claude/claudeHarness.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { TuiTest, type Backend } from "@microsoft/tui-test";
-import { ClaudeHarnessConfig, buildClaudeEnv, seedClaudeHome } from "./claudeConfig.js";
+import { ClaudeHarnessConfig, buildClaudeEnv, resolveClaudeModel, seedClaudeHome } from "./claudeConfig.js";
 import { resolveBackend } from "../shared.js";
 import { HarnessLogger } from "../logger.js";
 import { ClaudeTuiSession, type ClaudeState } from "./claudeSession.js";
@@ -79,7 +79,9 @@ export class ClaudeTuiHarness implements AgentHarness {
             backend: this.backend,
             timeouts: { ready: 60_000, text: 60_000, idle: 60_000 },
         });
-        await terminal.run(this.getBinaryPath(), ["--mcp-config", mcpConfigPath, "--strict-mcp-config"], {
+        // `--model` (plus `ANTHROPIC_MODEL` in the env) pins haiku: both outrank the
+        // org default (Opus) and override-user-selection per Claude Code docs.
+        await terminal.run(this.getBinaryPath(), ["--model", resolveClaudeModel(options), "--mcp-config", mcpConfigPath, "--strict-mcp-config"], {
             cwd: options.workDir,
             cols: this.cols,
             rows: this.rows,

--- a/packages/harness-tester/src/harness/claude/claudeHarness.ts
+++ b/packages/harness-tester/src/harness/claude/claudeHarness.ts
@@ -2,7 +2,13 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { TuiTest, type Backend } from "@microsoft/tui-test";
-import { ClaudeHarnessConfig, buildClaudeEnv, resolveClaudeModel, seedClaudeHome } from "./claudeConfig.js";
+import {
+    ClaudeHarnessConfig,
+    buildClaudeEnv,
+    DEFAULT_CLAUDE_EFFORT_LEVEL,
+    resolveClaudeModel,
+    seedClaudeHome,
+} from "./claudeConfig.js";
 import { resolveBackend } from "../shared.js";
 import { HarnessLogger } from "../logger.js";
 import { ClaudeTuiSession, type ClaudeState } from "./claudeSession.js";
@@ -79,11 +85,20 @@ export class ClaudeTuiHarness implements AgentHarness {
             backend: this.backend,
             timeouts: { ready: 60_000, text: 60_000, idle: 60_000 },
         });
-        // `--model` (plus `ANTHROPIC_MODEL` in the env) pins haiku: both outrank the
+        // `--model` (plus `ANTHROPIC_MODEL` in the env) pins haiku, and `--effort`
+        // (plus `CLAUDE_CODE_EFFORT_LEVEL`) pins minimum reasoning: both outrank the
         // org default (Opus) and override-user-selection per Claude Code docs.
         await terminal.run(
             this.getBinaryPath(),
-            ["--model", resolveClaudeModel(options), "--mcp-config", mcpConfigPath, "--strict-mcp-config"],
+            [
+                "--model",
+                resolveClaudeModel(options),
+                "--effort",
+                DEFAULT_CLAUDE_EFFORT_LEVEL,
+                "--mcp-config",
+                mcpConfigPath,
+                "--strict-mcp-config",
+            ],
             {
                 cwd: options.workDir,
                 cols: this.cols,

--- a/packages/harness-tester/src/harness/claude/claudeSession.ts
+++ b/packages/harness-tester/src/harness/claude/claudeSession.ts
@@ -2,6 +2,7 @@ import type { TuiTest } from "@microsoft/tui-test";
 import { parseClaudeTurn } from "./parseClaudeToolCalls.js";
 import { TuiSessionBase, type TuiState } from "../tuiSession.js";
 import type { AgentHarnessOptions, ToolCallRecord } from "../types.js";
+import { sleep } from "../shared.js";
 
 export type ClaudeState = TuiState;
 
@@ -41,6 +42,19 @@ export class ClaudeTuiSession extends TuiSessionBase {
         // contains `❯`, so a substring match would report idle too early — that prompt
         // echo is exactly the case that must NOT count as composition idle.
         return text.split("\n").some((l) => l.trim() === COMPOSER_IDLE_MARKER);
+    }
+
+    /**
+     * Claude renders the elicitation as a `→ to expand` dropdown field
+     * (Accept/Decline); expand it so the options are selectable.
+     */
+    protected override async sendChoice(choice: "confirm" | "decline"): Promise<void> {
+      // Claude presents a multi-field dropdown where you first expand using Right arrow to select the option.
+      await this.terminal.keyboard.press("Right");
+      if (choice == "decline") await this.terminal.keyboard.press("Down");
+      await this.terminal.keyboard.press("Enter");
+      await sleep(200);
+      await this.terminal.keyboard.press("Enter");
     }
 
     protected extractToolCalls(): ToolCallRecord[] {

--- a/packages/harness-tester/src/harness/claude/claudeSession.ts
+++ b/packages/harness-tester/src/harness/claude/claudeSession.ts
@@ -49,12 +49,12 @@ export class ClaudeTuiSession extends TuiSessionBase {
      * (Accept/Decline); expand it so the options are selectable.
      */
     protected override async sendChoice(choice: "confirm" | "decline"): Promise<void> {
-      // Claude presents a multi-field dropdown where you first expand using Right arrow to select the option.
-      await this.terminal.keyboard.press("Right");
-      if (choice == "decline") await this.terminal.keyboard.press("Down");
-      await this.terminal.keyboard.press("Enter");
-      await sleep(200);
-      await this.terminal.keyboard.press("Enter");
+        // Claude presents a multi-field dropdown where you first expand using Right arrow to select the option.
+        await this.terminal.keyboard.press("Right");
+        if (choice === "decline") await this.terminal.keyboard.press("Down");
+        await this.terminal.keyboard.press("Enter");
+        await sleep(200);
+        await this.terminal.keyboard.press("Enter");
     }
 
     protected extractToolCalls(): ToolCallRecord[] {

--- a/packages/harness-tester/src/harness/codex/codexSession.ts
+++ b/packages/harness-tester/src/harness/codex/codexSession.ts
@@ -25,6 +25,16 @@ export class CodexTuiSession extends TuiSessionBase {
         return text.includes(COMPOSER_IDLE_MARKER);
     }
 
+    /**
+     * Codex renders the elicitation as a numbered list using the schema's verbatim
+     * enumNames ("Yes, I confirm"/"No, I do not confirm"), so type the label.
+     */
+    protected override async sendChoice(choice: "confirm" | "decline"): Promise<void> {
+        const label = choice === "decline" ? "No, I do not confirm" : "Yes, I confirm";
+        await this.terminal.type(label);
+        await this.terminal.keyboard.press("Enter");
+    }
+
     protected extractToolCalls(delta: string): ToolCallRecord[] {
         return parseTuiTranscript(delta).toolCalls;
     }

--- a/packages/harness-tester/src/harness/tuiSession.ts
+++ b/packages/harness-tester/src/harness/tuiSession.ts
@@ -11,7 +11,7 @@ const TYPE_TO_ENTER_DELAY_MS = 800;
 const IDLE_BAIL_GRACE_MS = 30_000;
 
 /** How long the not-working+not-idle state must persist before we treat it as an awaited confirmation. */
-const CONFIRMATION_PENDING_GRACE_MS = 6_000;
+const CONFIRMATION_PENDING_GRACE_MS = 1_000;
 
 /** Per-poll state shared by both agent TUI sessions. */
 export interface TuiState {
@@ -62,22 +62,14 @@ export abstract class TuiSessionBase implements AgentSession {
     }
 
     /**
-     * Select an option in a confirmation prompt (e.g. an MCP elicitation). The
-     * prompt is a multiple-choice list rendering either as a numbered list with
-     * "enter to submit" (codex) or as a clickable Accept/Decline form (claude),
-     * so we locate the option by label and pick the right interaction.
-     * Subclasses may override for agent-specific menus.
+     * Select "confirm" or "decline" in a confirmation prompt. Agents render the
+     * options differently (codex: numbered list; claude: clickable Accept/Decline).
      */
-    async chooseOption(option: string): Promise<void> {
-        const text = await this.terminal.text({ full: true });
-        const lines = text.split("\n");
-        // Locate the option: prefer the given label, else fall back to a decline
-        // keyword so one response works across agent renderings (codex's
-        // "No, I do not confirm" vs claude's "Decline").
-        const declineRe = /No, I do not confirm|Decline/i;
-        const target =
-            lines.find((l) => l.toLowerCase().includes(option.toLowerCase())) ?? lines.find((l) => declineRe.test(l));
-        const numbered = target?.match(/^\s*[›❯]?\s*(\d+)\.\s+(.+)$/);
+    async chooseOption(choice: "confirm" | "decline"): Promise<void> {
+        const lines = (await this.terminal.text({ full: true })).split("\n");
+        const re = choice === "decline" ? /No, I do not confirm|Decline/i : /Yes, I confirm|Accept/i;
+        const line = lines.find((l) => re.test(l));
+        const numbered = line?.match(/^\s*[›❯]?\s*(\d+)\.\s+(.+)$/);
         if (numbered) {
             // Cursor starts on option 1, so move (target - 1) rows down, then submit.
             for (let i = 1; i < Number(numbered[1]); i++) {
@@ -86,22 +78,18 @@ export abstract class TuiSessionBase implements AgentSession {
             await this.terminal.keyboard.press("Enter");
             return;
         }
-        // Clickable form (claude): click the decline option, then submit.
-        const clickText = target?.match(/(No, I do not confirm|Decline)/)?.[0] ?? option;
-        await this.terminal.mouse.click(null, null, { onText: clickText });
-        await this.terminal.keyboard.press("Enter");
+        const label = line?.match(re)?.[0];
+        if (label) {
+            await this.terminal.mouse.click(null, null, { onText: label });
+            await this.terminal.keyboard.press("Enter");
+        }
     }
 
-    /**
-     * Heuristic for an agent-native tool-permission prompt (e.g. codex's
-     * "Allow the ... MCP server to run tool") that precedes the server's
-     * elicitation. Approve it so the call reaches the server.
-     */
+    /** Codex interposes its own tool-approval prompt before the server's elicitation. */
     protected isToolApproval(text: string): boolean {
         return /Allow the .* MCP server to run tool/.test(text);
     }
 
-    /** Submit the default choice of a tool-permission prompt (codex's "1. Allow"). */
     protected async approveTool(): Promise<void> {
         await this.terminal.keyboard.press("Enter");
     }
@@ -150,11 +138,8 @@ export abstract class TuiSessionBase implements AgentSession {
             }
             prevDeltaLength = delta.length;
 
-            // Answer a mid-turn confirmation (e.g. an MCP elicitation prompt) or
-            // auto-approve an agent tool-permission prompt. The agent is waiting at
-            // a choice when it is no longer working but the composer is not idle;
-            // require that state to persist a couple of polls so we do not fire
-            // during the working→idle transition.
+            // Agent is awaiting input when not working and not idle; require that
+            // state to persist a couple of polls so we do not fire mid-transition.
             const onConfirmation = options?.onConfirmation;
             if (
                 onConfirmation &&
@@ -166,16 +151,12 @@ export abstract class TuiSessionBase implements AgentSession {
                 confirmationPendingSinceMs ??= state.elapsedMs;
                 if (state.elapsedMs - confirmationPendingSinceMs >= CONFIRMATION_PENDING_GRACE_MS) {
                     if (this.isToolApproval(viewport)) {
-                        // Agent-native tool approval (e.g. codex) precedes the MCP
-                        // elicitation; approve it so the call reaches the server.
-                        this.log.debug(`${this.label} approving tool call`);
                         await this.approveTool();
                         confirmationPendingSinceMs = undefined;
                         continue;
                     }
-                    this.log.debug(`${this.label} awaiting confirmation; selecting the chosen option`);
-                    const option = await onConfirmation({ text: viewport });
-                    await this.chooseOption(option);
+                    const choice = await onConfirmation({ text: viewport });
+                    await this.chooseOption(choice);
                     handledConfirmationAtLength = delta.length;
                     confirmationPendingSinceMs = undefined;
                     continue;
@@ -219,7 +200,7 @@ export abstract class TuiSessionBase implements AgentSession {
                 break;
             }
             lastError = "";
-            await sleep(2000);
+            await sleep(500);
         }
 
         const text = await this.transcriptText();

--- a/packages/harness-tester/src/harness/tuiSession.ts
+++ b/packages/harness-tester/src/harness/tuiSession.ts
@@ -1,7 +1,7 @@
 import type { TuiTest } from "@microsoft/tui-test";
 import { DEFAULT_PROMPT_TIMEOUT_MS, diffTranscript, sleep } from "./shared.js";
 import { HarnessLogger } from "./logger.js";
-import type { AgentHarnessOptions, AgentSession, AgentTurn, ToolCallRecord } from "./types.js";
+import type { AgentHarnessOptions, AgentSession, AgentTurn, PromptOptions, ToolCallRecord } from "./types.js";
 
 /** Delay between typing a prompt and pressing Enter (agents drop a same-tick Enter). */
 const TYPE_TO_ENTER_DELAY_MS = 800;
@@ -9,6 +9,9 @@ const TYPE_TO_ENTER_DELAY_MS = 800;
 /** How long an idle+not-working composer may persist before we accept a turn as complete
  * even without observing the turn start (guard against pathological no-activity hangs). */
 const IDLE_BAIL_GRACE_MS = 30_000;
+
+/** How long the not-working+not-idle state must persist before we treat it as an awaited confirmation. */
+const CONFIRMATION_PENDING_GRACE_MS = 6_000;
 
 /** Per-poll state shared by both agent TUI sessions. */
 export interface TuiState {
@@ -58,7 +61,18 @@ export abstract class TuiSessionBase implements AgentSession {
         await this.waitIdleComposer(30_000);
     }
 
-    async prompt(prompt: string): Promise<AgentTurn> {
+    /**
+     * Select an option in a confirmation prompt (e.g. an MCP elicitation) by
+     * typing it into the composer and submitting. Subclasses may override for
+     * agent-specific menus.
+     */
+    async chooseOption(option: string): Promise<void> {
+        await this.terminal.type(option);
+        await sleep(TYPE_TO_ENTER_DELAY_MS);
+        await this.terminal.keyboard.press("Enter");
+    }
+
+    async prompt(prompt: string, options?: PromptOptions): Promise<AgentTurn> {
         const startText = await this.transcriptText();
         // Enter after a short settle: agents drop a same-tick Enter, leaving the prompt in the composer.
         await this.terminal.type(prompt);
@@ -75,6 +89,8 @@ export abstract class TuiSessionBase implements AgentSession {
         // has rendered anything) satisfies `!working && composerIdle` and returns a
         // bogus empty turn.
         let sawTurnActivity = false;
+        let answeredConfirmation = false;
+        let confirmationPendingSinceMs: number | undefined;
         let prevDeltaLength: number | undefined;
         let idleSinceMs: number | undefined;
 
@@ -99,6 +115,25 @@ export abstract class TuiSessionBase implements AgentSession {
                 sawTurnActivity = true;
             }
             prevDeltaLength = delta.length;
+
+            // Answer a mid-turn confirmation (e.g. an MCP elicitation prompt). The
+            // agent is waiting at a choice when it is no longer working but the
+            // composer is not idle; require that state to persist a couple of polls
+            // so we do not fire during the working→idle transition. `onConfirmation`
+            // returns the option to select.
+            const onConfirmation = options?.onConfirmation;
+            if (onConfirmation && !answeredConfirmation && sawTurnActivity && !state.working && !state.composerIdle) {
+                confirmationPendingSinceMs ??= state.elapsedMs;
+                if (state.elapsedMs - confirmationPendingSinceMs >= CONFIRMATION_PENDING_GRACE_MS) {
+                    this.log.debug(`${this.label} awaiting confirmation; selecting the chosen option`);
+                    const option = await onConfirmation({ text: viewport });
+                    await this.chooseOption(option);
+                    answeredConfirmation = true;
+                    continue;
+                }
+            } else {
+                confirmationPendingSinceMs = undefined;
+            }
 
             // Turn done when the in-progress marker is gone and the composer is idle.
             if (!state.working && state.composerIdle) {

--- a/packages/harness-tester/src/harness/tuiSession.ts
+++ b/packages/harness-tester/src/harness/tuiSession.ts
@@ -62,14 +62,12 @@ export abstract class TuiSessionBase implements AgentSession {
     }
 
     /**
-     * Select an option in a confirmation prompt (e.g. an MCP elicitation) by
-     * typing it into the composer and submitting. Subclasses may override for
-     * agent-specific menus.
+     * Select an option in a confirmation prompt (e.g. an MCP elicitation): the
+     * prompt is a multiple-choice list, so we click the option by its text.
+     * Subclasses may override for agent-specific menus.
      */
     async chooseOption(option: string): Promise<void> {
-        await this.terminal.type(option);
-        await sleep(TYPE_TO_ENTER_DELAY_MS);
-        await this.terminal.keyboard.press("Enter");
+        await this.terminal.mouse.click(null, null, { onText: option });
     }
 
     async prompt(prompt: string, options?: PromptOptions): Promise<AgentTurn> {

--- a/packages/harness-tester/src/harness/tuiSession.ts
+++ b/packages/harness-tester/src/harness/tuiSession.ts
@@ -1,7 +1,7 @@
 import type { TuiTest } from "@microsoft/tui-test";
 import { DEFAULT_PROMPT_TIMEOUT_MS, diffTranscript, sleep } from "./shared.js";
 import { HarnessLogger } from "./logger.js";
-import type { AgentHarnessOptions, AgentSession, AgentTurn, PromptOptions, ToolCallRecord } from "./types.js";
+import type { AgentHarnessOptions, AgentSession, AgentTurn, AgentTurnState, ToolCallRecord } from "./types.js";
 
 /** Delay between typing a prompt and pressing Enter (agents drop a same-tick Enter). */
 const TYPE_TO_ENTER_DELAY_MS = 800;
@@ -37,6 +37,13 @@ export abstract class TuiSessionBase implements AgentSession {
     private _log: HarnessLogger | undefined;
     /** Length of the turn delta already streamed to stdout (debug streaming). */
     private lastShownDeltaLength: number | undefined;
+    /** Transcript snapshot the current turn started from (so chooseOption can continue it). */
+    private currentTurnStartText = "";
+    private currentState: AgentTurnState = "completed";
+
+    get state(): AgentTurnState {
+        return this.currentState;
+    }
 
     protected constructor(terminal: TuiTest, options: AgentHarnessOptions, onState?: (state: TuiState) => void) {
         this.terminal = terminal;
@@ -62,27 +69,14 @@ export abstract class TuiSessionBase implements AgentSession {
     }
 
     /**
-     * Select "confirm" or "decline" in a confirmation prompt. Agents render the
-     * options differently (codex: numbered list; claude: clickable Accept/Decline).
+     * Answer a pending elicitation and run the turn to completion, returning the
+     * completed {@link AgentTurn}. `option` is the option label to send, e.g.
+     * "No, I do not confirm" or "Accept".
      */
-    async chooseOption(choice: "confirm" | "decline"): Promise<void> {
-        const lines = (await this.terminal.text({ full: true })).split("\n");
-        const re = choice === "decline" ? /No, I do not confirm|Decline/i : /Yes, I confirm|Accept/i;
-        const line = lines.find((l) => re.test(l));
-        const numbered = line?.match(/^\s*[›❯]?\s*(\d+)\.\s+(.+)$/);
-        if (numbered) {
-            // Cursor starts on option 1, so move (target - 1) rows down, then submit.
-            for (let i = 1; i < Number(numbered[1]); i++) {
-                await this.terminal.keyboard.press("ArrowDown");
-            }
-            await this.terminal.keyboard.press("Enter");
-            return;
-        }
-        const label = line?.match(re)?.[0];
-        if (label) {
-            await this.terminal.mouse.click(null, null, { onText: label });
-            await this.terminal.keyboard.press("Enter");
-        }
+    async chooseOption(option: string): Promise<AgentTurn> {
+        await this.terminal.type(option);
+        await this.terminal.keyboard.press("Enter");
+        return this.pollTurn(false);
     }
 
     /** Codex interposes its own tool-approval prompt before the server's elicitation. */
@@ -94,13 +88,21 @@ export abstract class TuiSessionBase implements AgentSession {
         await this.terminal.keyboard.press("Enter");
     }
 
-    async prompt(prompt: string, options?: PromptOptions): Promise<AgentTurn> {
-        const startText = await this.transcriptText();
+    async prompt(prompt: string): Promise<AgentTurn> {
         // Enter after a short settle: agents drop a same-tick Enter, leaving the prompt in the composer.
+        this.currentTurnStartText = await this.transcriptText();
         await this.terminal.type(prompt);
         await sleep(TYPE_TO_ENTER_DELAY_MS);
         await this.terminal.keyboard.press("Enter");
+        return this.pollTurn(true);
+    }
 
+    /**
+     * Poll until the turn completes or, when `stopOnElicitation`, the agent is
+     * awaiting a confirmation (auto-approving codex's tool-permission prompt).
+     */
+    private async pollTurn(stopOnElicitation: boolean): Promise<AgentTurn> {
+        const startText = this.currentTurnStartText;
         const timeoutMs = this.options.promptTimeoutMs ?? DEFAULT_PROMPT_TIMEOUT_MS;
         const deadline = Date.now() + timeoutMs;
         const startedAt = Date.now();
@@ -112,7 +114,6 @@ export abstract class TuiSessionBase implements AgentSession {
         // bogus empty turn.
         let sawTurnActivity = false;
         let confirmationPendingSinceMs: number | undefined;
-        let handledConfirmationAtLength = 0;
         let prevDeltaLength: number | undefined;
         let idleSinceMs: number | undefined;
 
@@ -140,14 +141,7 @@ export abstract class TuiSessionBase implements AgentSession {
 
             // Agent is awaiting input when not working and not idle; require that
             // state to persist a couple of polls so we do not fire mid-transition.
-            const onConfirmation = options?.onConfirmation;
-            if (
-                onConfirmation &&
-                sawTurnActivity &&
-                !state.working &&
-                !state.composerIdle &&
-                delta.length > handledConfirmationAtLength
-            ) {
+            if (sawTurnActivity && !state.working && !state.composerIdle) {
                 confirmationPendingSinceMs ??= state.elapsedMs;
                 if (state.elapsedMs - confirmationPendingSinceMs >= CONFIRMATION_PENDING_GRACE_MS) {
                     if (this.isToolApproval(viewport)) {
@@ -155,11 +149,11 @@ export abstract class TuiSessionBase implements AgentSession {
                         confirmationPendingSinceMs = undefined;
                         continue;
                     }
-                    const choice = await onConfirmation({ text: viewport });
-                    await this.chooseOption(choice);
-                    handledConfirmationAtLength = delta.length;
-                    confirmationPendingSinceMs = undefined;
-                    continue;
+                    if (stopOnElicitation) {
+                        this.currentState = "elicitation";
+                        this.lastShownDeltaLength = delta.length;
+                        return { text: delta, toolCalls: [], state: "elicitation", confirmation: viewport };
+                    }
                 }
             } else {
                 confirmationPendingSinceMs = undefined;
@@ -167,9 +161,6 @@ export abstract class TuiSessionBase implements AgentSession {
 
             // Turn done when the in-progress marker is gone and the composer is idle.
             if (!state.working && state.composerIdle) {
-                // Require evidence the turn actually started so we don't return an empty
-                // turn on the first poll before the agent renders anything. Bail out if
-                // the composer stays idle+not-working with no activity for too long.
                 if (
                     sawTurnActivity ||
                     (idleSinceMs !== undefined && state.elapsedMs - idleSinceMs >= IDLE_BAIL_GRACE_MS)
@@ -207,10 +198,12 @@ export abstract class TuiSessionBase implements AgentSession {
         const delta = diffTranscript(text, startText);
         const message = lastError || `${this.label} TUI turn timed out after ${timeoutMs}ms`;
         this.log.debug(`<<aborting: ${message}>>\n${delta}`);
+        this.currentState = "completed";
         // Fail loudly with the raw transcript attached for diagnosis.
         return {
             text: `ERROR: ${message}${text ? "\n\n--- terminal content ---\n" + text : ""}`,
             toolCalls: [],
+            state: "completed",
         };
     }
 
@@ -244,9 +237,11 @@ export abstract class TuiSessionBase implements AgentSession {
         if (viewport && !delta.includes(viewport.replace(/\s+$/, ""))) {
             delta = delta + "\n" + viewport;
         }
+        this.currentState = "completed";
         return {
             text: delta,
             toolCalls: this.extractToolCalls(delta),
+            state: "completed",
         };
     }
 

--- a/packages/harness-tester/src/harness/tuiSession.ts
+++ b/packages/harness-tester/src/harness/tuiSession.ts
@@ -62,12 +62,48 @@ export abstract class TuiSessionBase implements AgentSession {
     }
 
     /**
-     * Select an option in a confirmation prompt (e.g. an MCP elicitation): the
-     * prompt is a multiple-choice list, so we click the option by its text.
+     * Select an option in a confirmation prompt (e.g. an MCP elicitation). The
+     * prompt is a multiple-choice list rendering either as a numbered list with
+     * "enter to submit" (codex) or as a clickable Accept/Decline form (claude),
+     * so we locate the option by label and pick the right interaction.
      * Subclasses may override for agent-specific menus.
      */
     async chooseOption(option: string): Promise<void> {
-        await this.terminal.mouse.click(null, null, { onText: option });
+        const text = await this.terminal.text({ full: true });
+        const lines = text.split("\n");
+        // Locate the option: prefer the given label, else fall back to a decline
+        // keyword so one response works across agent renderings (codex's
+        // "No, I do not confirm" vs claude's "Decline").
+        const declineRe = /No, I do not confirm|Decline/i;
+        const target =
+            lines.find((l) => l.toLowerCase().includes(option.toLowerCase())) ?? lines.find((l) => declineRe.test(l));
+        const numbered = target?.match(/^\s*[›❯]?\s*(\d+)\.\s+(.+)$/);
+        if (numbered) {
+            // Cursor starts on option 1, so move (target - 1) rows down, then submit.
+            for (let i = 1; i < Number(numbered[1]); i++) {
+                await this.terminal.keyboard.press("ArrowDown");
+            }
+            await this.terminal.keyboard.press("Enter");
+            return;
+        }
+        // Clickable form (claude): click the decline option, then submit.
+        const clickText = target?.match(/(No, I do not confirm|Decline)/)?.[0] ?? option;
+        await this.terminal.mouse.click(null, null, { onText: clickText });
+        await this.terminal.keyboard.press("Enter");
+    }
+
+    /**
+     * Heuristic for an agent-native tool-permission prompt (e.g. codex's
+     * "Allow the ... MCP server to run tool") that precedes the server's
+     * elicitation. Approve it so the call reaches the server.
+     */
+    protected isToolApproval(text: string): boolean {
+        return /Allow the .* MCP server to run tool/.test(text);
+    }
+
+    /** Submit the default choice of a tool-permission prompt (codex's "1. Allow"). */
+    protected async approveTool(): Promise<void> {
+        await this.terminal.keyboard.press("Enter");
     }
 
     async prompt(prompt: string, options?: PromptOptions): Promise<AgentTurn> {
@@ -87,8 +123,8 @@ export abstract class TuiSessionBase implements AgentSession {
         // has rendered anything) satisfies `!working && composerIdle` and returns a
         // bogus empty turn.
         let sawTurnActivity = false;
-        let answeredConfirmation = false;
         let confirmationPendingSinceMs: number | undefined;
+        let handledConfirmationAtLength = 0;
         let prevDeltaLength: number | undefined;
         let idleSinceMs: number | undefined;
 
@@ -114,19 +150,34 @@ export abstract class TuiSessionBase implements AgentSession {
             }
             prevDeltaLength = delta.length;
 
-            // Answer a mid-turn confirmation (e.g. an MCP elicitation prompt). The
-            // agent is waiting at a choice when it is no longer working but the
-            // composer is not idle; require that state to persist a couple of polls
-            // so we do not fire during the working→idle transition. `onConfirmation`
-            // returns the option to select.
+            // Answer a mid-turn confirmation (e.g. an MCP elicitation prompt) or
+            // auto-approve an agent tool-permission prompt. The agent is waiting at
+            // a choice when it is no longer working but the composer is not idle;
+            // require that state to persist a couple of polls so we do not fire
+            // during the working→idle transition.
             const onConfirmation = options?.onConfirmation;
-            if (onConfirmation && !answeredConfirmation && sawTurnActivity && !state.working && !state.composerIdle) {
+            if (
+                onConfirmation &&
+                sawTurnActivity &&
+                !state.working &&
+                !state.composerIdle &&
+                delta.length > handledConfirmationAtLength
+            ) {
                 confirmationPendingSinceMs ??= state.elapsedMs;
                 if (state.elapsedMs - confirmationPendingSinceMs >= CONFIRMATION_PENDING_GRACE_MS) {
+                    if (this.isToolApproval(viewport)) {
+                        // Agent-native tool approval (e.g. codex) precedes the MCP
+                        // elicitation; approve it so the call reaches the server.
+                        this.log.debug(`${this.label} approving tool call`);
+                        await this.approveTool();
+                        confirmationPendingSinceMs = undefined;
+                        continue;
+                    }
                     this.log.debug(`${this.label} awaiting confirmation; selecting the chosen option`);
                     const option = await onConfirmation({ text: viewport });
                     await this.chooseOption(option);
-                    answeredConfirmation = true;
+                    handledConfirmationAtLength = delta.length;
+                    confirmationPendingSinceMs = undefined;
                     continue;
                 }
             } else {

--- a/packages/harness-tester/src/harness/tuiSession.ts
+++ b/packages/harness-tester/src/harness/tuiSession.ts
@@ -69,15 +69,19 @@ export abstract class TuiSessionBase implements AgentSession {
     }
 
     /**
-     * Answer a pending elicitation and run the turn to completion, returning the
-     * completed {@link AgentTurn}. `option` is the option label to send, e.g.
-     * "No, I do not confirm" or "Accept".
+     * Answer a pending elicitation (`confirm`/`decline`) and run the turn to
+     * completion, returning the completed {@link AgentTurn}.
      */
-    async chooseOption(option: string): Promise<AgentTurn> {
-        await this.terminal.type(option);
-        await this.terminal.keyboard.press("Enter");
+    async chooseOption(choice: "confirm" | "decline"): Promise<AgentTurn> {
+        await this.sendChoice(choice);
         return this.pollTurn(false);
     }
+
+    /**
+     * Submit `choice` in the confirmation prompt currently on screen. Each agent
+     * renders it with different labels/controls, so subclasses implement this.
+     */
+    protected abstract sendChoice(choice: "confirm" | "decline"): Promise<void>;
 
     /** Codex interposes its own tool-approval prompt before the server's elicitation. */
     protected isToolApproval(text: string): boolean {

--- a/packages/harness-tester/src/harness/types.ts
+++ b/packages/harness-tester/src/harness/types.ts
@@ -14,28 +14,17 @@ export interface AgentTurn {
     toolCalls: ToolCallRecord[];
 }
 
-/**
- * An interactive confirmation the agent surfaced mid-turn (e.g. an MCP
- * elicitation prompt for a confirmation-required tool). `text` is the raw
- * terminal content so tests can inspect the message/options.
- */
+/** A mid-turn confirmation the agent surfaced (e.g. an MCP elicitation prompt). */
 export interface AgentConfirmation {
-    /** Raw terminal content at the confirmation prompt. */
     text: string;
 }
 
-/**
- * Chooses an option when the agent pauses mid-turn for a confirmation.
- * Receives the confirmation and returns the option to select.
- */
-export type ConfirmationResponder = (confirmation: AgentConfirmation) => Promise<string> | string;
+export type ConfirmationResponder = (
+    confirmation: AgentConfirmation
+) => Promise<"confirm" | "decline"> | "confirm" | "decline";
 
 export interface PromptOptions {
-    /**
-     * Responds to an interactive confirmation the agent surfaces mid-turn (e.g.
-     * an MCP elicitation). The returned string is the option to select. When
-     * omitted, the harness waits for the turn to finish without answering.
-     */
+    /** Answer a mid-turn confirmation the agent surfaces (e.g. an MCP elicitation). */
     onConfirmation?: ConfirmationResponder;
 }
 
@@ -75,11 +64,8 @@ export interface AgentHarness {
 export interface AgentSession {
     /** Run one turn: submit the prompt, wait for the composer to return to idle, parse the transcript. */
     prompt(prompt: string, options?: PromptOptions): Promise<AgentTurn>;
-    /**
-     * Select an option in a confirmation prompt (e.g. an MCP elicitation). The
-     * prompt is a multiple-choice list; `option` is the label to select.
-     */
-    chooseOption(option: string): Promise<void>;
+    /** Select "confirm" or "decline" in a mid-turn confirmation prompt. */
+    chooseOption(choice: "confirm" | "decline"): Promise<void>;
     /** Release any resources. */
     dispose(): Promise<void>;
 }

--- a/packages/harness-tester/src/harness/types.ts
+++ b/packages/harness-tester/src/harness/types.ts
@@ -76,8 +76,8 @@ export interface AgentSession {
     /** Run one turn: submit the prompt, wait for the composer to return to idle, parse the transcript. */
     prompt(prompt: string, options?: PromptOptions): Promise<AgentTurn>;
     /**
-     * Select an option in a confirmation prompt (e.g. an MCP elicitation).
-     * `option` is rendered into the composer and submitted.
+     * Select an option in a confirmation prompt (e.g. an MCP elicitation). The
+     * prompt is a multiple-choice list; `option` is the label to select.
      */
     chooseOption(option: string): Promise<void>;
     /** Release any resources. */

--- a/packages/harness-tester/src/harness/types.ts
+++ b/packages/harness-tester/src/harness/types.ts
@@ -12,21 +12,14 @@ export interface AgentTurn {
     text: string;
     /** Tool calls observed during the turn, deduplicated. */
     toolCalls: ToolCallRecord[];
+    /** "elicitation" when the turn paused for a confirmation; otherwise "completed". */
+    state: AgentTurnState;
+    /** Raw confirmation screen when `state` is "elicitation". */
+    confirmation?: string;
 }
 
-/** A mid-turn confirmation the agent surfaced (e.g. an MCP elicitation prompt). */
-export interface AgentConfirmation {
-    text: string;
-}
-
-export type ConfirmationResponder = (
-    confirmation: AgentConfirmation
-) => Promise<"confirm" | "decline"> | "confirm" | "decline";
-
-export interface PromptOptions {
-    /** Answer a mid-turn confirmation the agent surfaces (e.g. an MCP elicitation). */
-    onConfirmation?: ConfirmationResponder;
-}
+/** How a turn ended: completed normally, or paused for an elicitation confirmation. */
+export type AgentTurnState = "completed" | "elicitation";
 
 export interface AgentHarnessOptions {
     /**
@@ -62,10 +55,19 @@ export interface AgentHarness {
 }
 
 export interface AgentSession {
-    /** Run one turn: submit the prompt, wait for the composer to return to idle, parse the transcript. */
-    prompt(prompt: string, options?: PromptOptions): Promise<AgentTurn>;
-    /** Select "confirm" or "decline" in a mid-turn confirmation prompt. */
-    chooseOption(choice: "confirm" | "decline"): Promise<void>;
+    /**
+     * Run one turn: submit the prompt and wait. Resolves with
+     * `state: "elicitation"` when the agent is awaiting a confirmation
+     * (call {@link AgentSession.chooseOption}), else `state: "completed"`.
+     */
+    prompt(prompt: string): Promise<AgentTurn>;
+    /**
+     * Answer a pending elicitation (`confirm`/`decline`) and run the turn to
+     * completion, returning the completed `AgentTurn`.
+     */
+    chooseOption(choice: "confirm" | "decline"): Promise<AgentTurn>;
+    /** Current state of the last turn: "completed" or "elicitation". */
+    readonly state: AgentTurnState;
     /** Release any resources. */
     dispose(): Promise<void>;
 }

--- a/packages/harness-tester/src/harness/types.ts
+++ b/packages/harness-tester/src/harness/types.ts
@@ -14,6 +14,31 @@ export interface AgentTurn {
     toolCalls: ToolCallRecord[];
 }
 
+/**
+ * An interactive confirmation the agent surfaced mid-turn (e.g. an MCP
+ * elicitation prompt for a confirmation-required tool). `text` is the raw
+ * terminal content so tests can inspect the message/options.
+ */
+export interface AgentConfirmation {
+    /** Raw terminal content at the confirmation prompt. */
+    text: string;
+}
+
+/**
+ * Chooses an option when the agent pauses mid-turn for a confirmation.
+ * Receives the confirmation and returns the option to select.
+ */
+export type ConfirmationResponder = (confirmation: AgentConfirmation) => Promise<string> | string;
+
+export interface PromptOptions {
+    /**
+     * Responds to an interactive confirmation the agent surfaces mid-turn (e.g.
+     * an MCP elicitation). The returned string is the option to select. When
+     * omitted, the harness waits for the turn to finish without answering.
+     */
+    onConfirmation?: ConfirmationResponder;
+}
+
 export interface AgentHarnessOptions {
     /**
      * URL of the MongoDB MCP server (streamable HTTP), e.g.
@@ -49,7 +74,12 @@ export interface AgentHarness {
 
 export interface AgentSession {
     /** Run one turn: submit the prompt, wait for the composer to return to idle, parse the transcript. */
-    prompt(prompt: string): Promise<AgentTurn>;
+    prompt(prompt: string, options?: PromptOptions): Promise<AgentTurn>;
+    /**
+     * Select an option in a confirmation prompt (e.g. an MCP elicitation).
+     * `option` is rendered into the composer and submitted.
+     */
+    chooseOption(option: string): Promise<void>;
     /** Release any resources. */
     dispose(): Promise<void>;
 }

--- a/packages/harness-tester/src/index.ts
+++ b/packages/harness-tester/src/index.ts
@@ -4,11 +4,14 @@ import { CodexTuiHarness } from "./harness/codex/codexHarness.js";
 export { useAgent, type AgentContext } from "./useAgent.js";
 export { AGENT_HARNESSES } from "./harnesses.js";
 export type {
+    AgentConfirmation,
     AgentHarness,
     AgentHarnessConfig,
     AgentHarnessOptions,
     AgentSession,
     AgentTurn,
+    ConfirmationResponder,
+    PromptOptions,
     ToolCallRecord,
 } from "./harness/types.js";
 export { ClaudeTuiHarness, CodexTuiHarness };

--- a/packages/harness-tester/src/index.ts
+++ b/packages/harness-tester/src/index.ts
@@ -4,14 +4,12 @@ import { CodexTuiHarness } from "./harness/codex/codexHarness.js";
 export { useAgent, type AgentContext } from "./useAgent.js";
 export { AGENT_HARNESSES } from "./harnesses.js";
 export type {
-    AgentConfirmation,
     AgentHarness,
     AgentHarnessConfig,
     AgentHarnessOptions,
     AgentSession,
     AgentTurn,
-    ConfirmationResponder,
-    PromptOptions,
+    AgentTurnState,
     ToolCallRecord,
 } from "./harness/types.js";
 export { ClaudeTuiHarness, CodexTuiHarness };


### PR DESCRIPTION
Adds an elicitation end-to-end test that drives a real agent to call a confirmation-required tool (`drop-database`) and answer the elicited confirmation by declining, asserting the destructive tool does not run.

To support this, the agent harness gained a minimal way to choose an option at a mid-turn confirmation (e.g. an MCP elicitation prompt): `AgentSession.chooseOption` and an optional `onConfirmation` responder on `prompt`.