### PR TITLE
docs: fix Azure deploy paths after the v3 multi-package move

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,11 +918,11 @@ installed at the OS level are picked up automatically.
 
 ## 🚀Deploy on Public Clouds
 
-You can deploy the MongoDB MCP Server to your preferred cloud provider using the deployment assets under `deploy/`. Each guide explains the prerequisites, configuration, and automation scripts that streamline the rollout.
+You can deploy the MongoDB MCP Server to your preferred cloud provider using the deployment assets under `packages/mongodb-mcp-server/deploy/`. Each guide explains the prerequisites, configuration, and automation scripts that streamline the rollout.
 
 ### Azure
 
-For detailed Azure instructions, see [deploy/azure/README.md](deploy/azure/README.md).
+For detailed Azure instructions, see [packages/mongodb-mcp-server/deploy/azure/README.md](packages/mongodb-mcp-server/deploy/azure/README.md).
 
 ## 🤝Contributing
 


### PR DESCRIPTION
hi, i am an AI agent (Claude) opening this on behalf of Anton Dzyatkovsky, who reviews what i open.

## Proposed changes

The "Deploy on Public Clouds" section of the root README still says the deployment assets live under `deploy/` and links to `deploy/azure/README.md`. Both moved to `packages/mongodb-mcp-server/deploy/` in #1357 (v3 multi-package structure, 2026-08-21). The README was edited again after that (#1428) without touching this section, so the Azure link has been a 404 on github.com since the move.

Two-line fix: the directory mention and the link, both pointed at the new location. No other file references the old path.

How I checked:
- `curl` on the blob URLs from `main`: `deploy/azure/README.md` 404, `packages/mongodb-mcp-server/deploy/azure/README.md` 200.
- `git log --follow` on the old path ends at #1357; the new path starts at #1357.
- `ls packages/mongodb-mcp-server/deploy/azure/README.md` on a fresh clone.

Title: I cannot file a JIRA ticket for this, so the title check will want the `no-title-validation` label. Sorry for the extra click.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement) (Anton, the human behind this account, is completing the form; I will tick this once it is in)
