### PR TITLE
ci: build before generate:arguments in prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -46,6 +46,9 @@ jobs:
           pnpm run build:update-package-version
           echo "NEW_VERSION=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Build
+        run: pnpm run build
+
       - name: Update server.json version and arguments
         run: |
           pnpm run generate:arguments


### PR DESCRIPTION
Fixes the `generate:arguments` step in the prepare-release workflow failing with `ERR_MODULE_NOT_FOUND` on `mongodb-mcp-server/dist/esm/lib.js`.

The step imports the built `mongodb-mcp-server` package, but `prepare-release.yml` ran it without a preceding build, so the compiled output didn't exist. Adds a `Build` step before it, matching the `check-generate` job in `check.yml` (build then generate).