### PR TITLE
fix: redact connection-string secrets from ConnectionEntry.lastError

### DIFF
--- a/packages/tools-mongodb/src/common/connectionEntry.test.ts
+++ b/packages/tools-mongodb/src/common/connectionEntry.test.ts
@@ -134,9 +134,6 @@ describe("ConnectionEntry with MCPConnectionManager", () => {
 
     describe("lastError", () => {
         it("should not contain the raw connection string when the connect attempt fails", async () => {
-            // No mock needed here: a connection string with credentials but no host
-            // fails inside @mongosh/arg-parser before the driver is ever called, and
-            // the real arg-parser embeds the string verbatim in the thrown error.
             const entry = new ConnectionEntry({
                 connectionId: "preconfigured",
                 name: "preconfigured",

--- a/packages/tools-mongodb/src/common/connectionEntry.test.ts
+++ b/packages/tools-mongodb/src/common/connectionEntry.test.ts
@@ -5,7 +5,7 @@ import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver
 import { CompositeLogger } from "@mongodb-js/mcp-core";
 import { MCPConnectionManager, type ConnectionManager } from "./connectionManager.js";
 import { MCPConnectionStore, type ConnectionStoreConfig } from "./connectionStore.js";
-import type { ConnectionEntry, ConnectionRegistry } from "./connectionRegistry.js";
+import { ConnectionEntry, type ConnectionRegistry } from "./connectionRegistry.js";
 import { DeviceId } from "../helpers/deviceId.js";
 import { ErrorCodes, MongoDBError } from "./errors.js";
 
@@ -129,6 +129,33 @@ describe("ConnectionEntry with MCPConnectionManager", () => {
 
             // Should use 'unknown' for client name when it was not provided
             expect(connectionString).toContain("--test-device-id--unknown");
+        });
+    });
+
+    describe("lastError", () => {
+        it("should not contain the raw connection string when the connect attempt fails", async () => {
+            // No mock needed here: a connection string with credentials but no host
+            // fails inside @mongosh/arg-parser before the driver is ever called, and
+            // the real arg-parser embeds the string verbatim in the thrown error.
+            const entry = new ConnectionEntry({
+                connectionId: "preconfigured",
+                name: "preconfigured",
+                source: "preconfigured",
+                manager: new MCPConnectionManager({
+                    logger,
+                    deviceId: mockDeviceId,
+                    serverMetadata: { mcpServerName: "MongoDB MCP Server", version: "1.0.0" },
+                    connectionInfo: { transport: "stdio", httpHost: "127.0.0.1" },
+                }),
+            });
+
+            await expect(
+                entry.connect({ connectionString: "mongodb+srv://dbadmin:Real$ecretPass9@" })
+            ).rejects.toThrow();
+
+            expect(entry.lastError).toBeDefined();
+            expect(entry.lastError).not.toContain("Real$ecretPass9");
+            expect(entry.lastError).toContain("<mongodb uri>");
         });
     });
 

--- a/packages/tools-mongodb/src/common/connectionRegistry.ts
+++ b/packages/tools-mongodb/src/common/connectionRegistry.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "crypto";
 import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
-import type { LoggerBase } from "@mongodb-js/mcp-core";
+import { Keychain, type LoggerBase } from "@mongodb-js/mcp-core";
 import type { AnyConnectionState, ConnectionManager, ConnectionSettings } from "./connectionManager.js";
 import { ErrorCodes, MongoDBError } from "./errors.js";
 
@@ -166,7 +166,12 @@ export class ConnectionEntry {
             this.lastError = undefined;
             return state;
         } catch (error: unknown) {
-            this.lastError = error instanceof Error ? error.message : String(error);
+            const message = error instanceof Error ? error.message : String(error);
+            // The driver/arg-parser error can embed the connection string verbatim (e.g. a
+            // malformed URI), which may contain credentials. lastError is read back later by
+            // list-connections, so it has to be redacted here at the point of capture, not
+            // only where the response for this call happens to be built.
+            this.lastError = Keychain.root.redact(message);
             throw error;
         }
     }


### PR DESCRIPTION
`ConnectionEntry.lastError` is set from the raw driver/arg-parser error message when a connect attempt fails. That message can embed the connection string verbatim (for example, `mongodb+srv://user:pass@` with no host, which throws `Protocol and host list are required in "..."` with the credentials still in it). `lastError` gets read back unredacted by `summarizeConnection()` and returned by `list-connections`, which takes no arguments and needs no confirmation.

The redaction in `MongoDBToolBase.handleError()` only covers the response for the call that's currently failing — it never touches `ConnectionEntry.lastError`, which is written one layer earlier in `ConnectionEntry.connect()`.

This mostly matters for the preconfigured connection: it dials lazily, sits outside per-session scoping, and isn't removed from the store when a dial fails, so if `MDB_MCP_CONNECTION_STRING` is malformed this way, the raw string stays in `lastError` until the config is fixed — visible to any client calling `list-connections`, including other sessions in a shared HTTP deployment.

**Fix:** redact at the point of capture in `ConnectionEntry.connect()`, using `Keychain.root.redact()` — same pattern already used elsewhere in this codebase for driver errors that might carry secrets.

**Test:** added a regression test that fails a connect with a real (unmocked) `@mongosh/arg-parser` call against a truncated `mongodb+srv://` string and asserts `lastError` doesn't contain the credential. Confirmed it fails without the fix, passes with it.

Related to GHSA-grqv-8942-f78m.