### PR TITLE
fix: cover additional WASM/optional platform deps in licenses config

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -7,7 +7,11 @@
     "@esbuild",
     "@braintrust",
     "@csstools",
-    "@microsoft"
+    "@microsoft",
+    "@emnapi",
+    "@napi-rs",
+    "@rolldown",
+    "@tybys"
   ],
   "ignoredPackages": [
     "bindings@1.5.0",
@@ -26,7 +30,9 @@
     "lightningcss-linux-x64-gnu@1.32.0",
     "lightningcss-linux-x64-musl@1.32.0",
     "lightningcss-win32-arm64-msvc@1.32.0",
-    "lightningcss-win32-x64-msvc@1.32.0"
+    "lightningcss-win32-x64-msvc@1.32.0",
+    "fsevents@2.3.2",
+    "fsevents@2.3.3"
   ],
   "licenseOverrides": {
     "node-addon-api@8.9.0": "MIT"


### PR DESCRIPTION
Fixes the `update-third-party-notices` step failing with `Generation failed, found N invalid packages`.

#1500 fixed the path resolution (`licenses.json` ENOENT) and added the initial license config. This PR adds the remaining packages that were still reported as invalid on CI — scoped WASM/optional platform-binary orgs and `fsevents` that weren't covered yet:

- add `@emnapi`, `@napi-rs`, `@rolldown`, `@tybys` to `ignoredOrgs`
- add `fsevents@2.3.2`, `fsevents@2.3.3` to `ignoredPackages`

Verified with `pnpm run build` + `pnpm run check` and `pnpm run create-dependency-sbom-lists` + `pnpm run update-third-party-notices` (all pass). `THIRD_PARTY_NOTICES.md` is a generated artifact regenerated by the workflows, so it is intentionally left out.
