### PR TITLE
fix: disallow write stages in export aggregations MCP-651

### DIFF
--- a/packages/integration-tests/src/tools/mongodb/read/export.test.ts
+++ b/packages/integration-tests/src/tools/mongodb/read/export.test.ts
@@ -577,27 +577,57 @@ describeWithMongoDB(
                 integration.mcpServer().userConfig.disabledTools = [];
             });
 
+            // No configuration lets export run a write stage, so the rejection
+            // reason must not vary with the write-related settings.
+            const writeConfigs: { name: string; apply: () => void }[] = [
+                { name: "write operations are allowed", apply: (): void => {} },
+                {
+                    name: "in readOnly mode",
+                    apply: (): void => {
+                        integration.mcpServer().userConfig.readOnly = true;
+                    },
+                },
+                {
+                    name: "when write operations are disabled",
+                    apply: (): void => {
+                        integration.mcpServer().userConfig.disabledTools = ["create", "update", "delete"];
+                    },
+                },
+            ];
+
             for (const stage of [{ $out: "outpeople" }, { $merge: "outpeople" }]) {
                 const operator = Object.keys(stage)[0];
 
-                it(`rejects aggregate targets using ${operator} in readOnly mode`, async function () {
-                    integration.mcpServer().userConfig.readOnly = true;
-                    const response = await integration.mcpClient().callTool({
-                        name: "export",
-                        arguments: {
-                            connectionId,
-                            database: integration.randomDbName(),
-                            collection: "foo",
-                            exportTitle: `Export with ${operator}`,
-                            exportTarget: [{ name: "aggregate", arguments: { pipeline: [stage] } }],
-                        },
-                    });
-                    const content = getResponseContent(response.content);
-                    expect(content).toContain("In readOnly mode you can not run pipelines with $out or $merge stages.");
-                });
+                for (const { name, apply } of writeConfigs) {
+                    it(`rejects aggregate targets using ${operator} ${name}`, async function () {
+                        apply();
+                        const response = await integration.mcpClient().callTool({
+                            name: "export",
+                            arguments: {
+                                connectionId,
+                                database: integration.randomDbName(),
+                                collection: "foo",
+                                exportTitle: `Export with ${operator}`,
+                                exportTarget: [{ name: "aggregate", arguments: { pipeline: [stage] } }],
+                            },
+                        });
+                        const content = getResponseContent(response.content);
+                        expect(content).toContain(
+                            "The export tool can not run pipelines with $out or $merge stages. Use the aggregate tool to run a pipeline that writes to a collection."
+                        );
 
-                it(`rejects aggregate targets using ${operator} when write operations are disabled`, async function () {
-                    integration.mcpServer().userConfig.disabledTools = ["create", "update", "delete"];
+                        // The rejection happens before the pipeline runs, so the
+                        // targeted collection must not have been created.
+                        const collections = await integration
+                            .mongoClient()
+                            .db(integration.randomDbName())
+                            .listCollections({ name: "outpeople" })
+                            .toArray();
+                        expect(collections).toHaveLength(0);
+                    });
+                }
+
+                it(`rejects aggregate targets using ${operator} that are not the last stage`, async function () {
                     const response = await integration.mcpClient().callTool({
                         name: "export",
                         arguments: {
@@ -605,15 +635,47 @@ describeWithMongoDB(
                             database: integration.randomDbName(),
                             collection: "foo",
                             exportTitle: `Export with ${operator}`,
-                            exportTarget: [{ name: "aggregate", arguments: { pipeline: [stage] } }],
+                            exportTarget: [
+                                { name: "aggregate", arguments: { pipeline: [stage, { $match: { age: 5 } }] } },
+                            ],
                         },
                     });
                     const content = getResponseContent(response.content);
-                    expect(content).toContain(
-                        "When 'create', 'update', or 'delete' operations are disabled, you can not run pipelines with $out or $merge stages."
-                    );
+                    expect(content).toContain("The export tool can not run pipelines with $out or $merge stages.");
                 });
             }
+
+            it("allows aggregate targets without write stages", async function () {
+                const response = await integration.mcpClient().callTool({
+                    name: "export",
+                    arguments: {
+                        connectionId,
+                        database: integration.randomDbName(),
+                        collection: "foo",
+                        exportTitle: "Export without write stages",
+                        exportTarget: [
+                            { name: "aggregate", arguments: { pipeline: [{ $match: { age: { $gt: 8 } } }] } },
+                        ],
+                    },
+                });
+                const content = response.content as CallToolResult["content"];
+                expect(contentWithResourceURILink(content)).toBeDefined();
+            });
+
+            it("allows find targets while write stages are forbidden", async function () {
+                const response = await integration.mcpClient().callTool({
+                    name: "export",
+                    arguments: {
+                        connectionId,
+                        database: integration.randomDbName(),
+                        collection: "foo",
+                        exportTitle: "Export find target",
+                        exportTarget: [{ name: "find", arguments: { filter: {} } }],
+                    },
+                });
+                const content = response.content as CallToolResult["content"];
+                expect(contentWithResourceURILink(content)).toBeDefined();
+            });
         });
     },
     {

--- a/packages/tools-mongodb/src/helpers/mqlGuards.test.ts
+++ b/packages/tools-mongodb/src/helpers/mqlGuards.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { assertNoServerSideJS, getWriteStageTargets, isWriteStage } from "./mqlGuards.js";
+import { assertNoServerSideJS, assertNoWriteStages, getWriteStageTargets, isWriteStage } from "./mqlGuards.js";
 import { ErrorCodes, MongoDBError } from "../common/errors.js";
 
 function expectForbiddenOperator(value: unknown, operator: string): void {
@@ -79,6 +79,34 @@ describe("mqlGuards", () => {
             expect(isWriteStage({ $match: { age: 5 } })).toBe(false);
             expect(isWriteStage({ $group: { _id: null } })).toBe(false);
             expect(isWriteStage({})).toBe(false);
+        });
+    });
+
+    describe("assertNoWriteStages", () => {
+        it("does not throw for pipelines without write stages", () => {
+            expect(() =>
+                assertNoWriteStages([{ $match: { age: 5 } }, { $sort: { name: 1 } }], "not allowed")
+            ).not.toThrow();
+            expect(() => assertNoWriteStages([], "not allowed")).not.toThrow();
+        });
+
+        it("throws a MongoDBError with the ForbiddenWriteOperation code and the given message", () => {
+            for (const stage of [{ $out: "results" }, { $merge: { into: "results" } }]) {
+                try {
+                    assertNoWriteStages([{ $match: { age: 5 } }, stage], "not allowed");
+                    expect.unreachable(`Expected assertNoWriteStages to throw for ${Object.keys(stage)[0]}`);
+                } catch (error) {
+                    expect(error).toBeInstanceOf(MongoDBError);
+                    expect((error as MongoDBError).code).toBe(ErrorCodes.ForbiddenWriteOperation);
+                    expect((error as MongoDBError).message).toBe("not allowed");
+                }
+            }
+        });
+
+        it("only inspects top-level stages", () => {
+            expect(() =>
+                assertNoWriteStages([{ $unionWith: { pipeline: [{ $out: "results" }] } }], "not allowed")
+            ).not.toThrow();
         });
     });
 

--- a/packages/tools-mongodb/src/helpers/mqlGuards.ts
+++ b/packages/tools-mongodb/src/helpers/mqlGuards.ts
@@ -77,6 +77,23 @@ export function isWriteStage(stage: Record<string, unknown>): boolean {
     return writeStageOperator(stage) !== undefined;
 }
 
+/**
+ * Throws a {@link MongoDBError} with the given message when any top-level stage
+ * of the pipeline writes to a collection. Only top-level stages are inspected,
+ * matching {@link isWriteStage}.
+ *
+ * The message is supplied by the caller because the reason a write stage is
+ * forbidden differs per call site (read-only mode, disabled write operations, or
+ * a tool that never permits them).
+ */
+export function assertNoWriteStages(pipeline: Record<string, unknown>[], message: string): void {
+    for (const stage of pipeline) {
+        if (isWriteStage(stage)) {
+            throw new MongoDBError(ErrorCodes.ForbiddenWriteOperation, message);
+        }
+    }
+}
+
 /** The collection a write stage targets, along with how it will write to it. */
 export type WriteStageTarget = { namespace: string | undefined } & (
     | { operator: "$out" }

--- a/packages/tools-mongodb/src/mongodbTool.ts
+++ b/packages/tools-mongodb/src/mongodbTool.ts
@@ -16,7 +16,7 @@ import type { ConnectionMetadata } from "@mongodb-js/mcp-atlas-telemetry";
 import type { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
 import { ErrorCodes, MongoDBError } from "./common/errors.js";
 import type { ConnectionEntry, ConnectionRegistry } from "./common/connectionRegistry.js";
-import { assertNoServerSideJS, isWriteStage, type WriteStageTarget } from "./helpers/mqlGuards.js";
+import { assertNoServerSideJS, assertNoWriteStages, type WriteStageTarget } from "./helpers/mqlGuards.js";
 import { buildWriteStageConfirmationMessage } from "./helpers/writeStageConfirmation.js";
 import { EXPORT_TOOL_NAME } from "./helpers/constants.js";
 import type { AvailableExport, CreateJSONExportParams } from "./common/exportsManager.js";
@@ -211,11 +211,7 @@ export abstract class MongoDBToolBase extends ToolBase<MongoDBToolServer> {
             }
 
             if (writeStageForbiddenErrorMessage) {
-                for (const stage of value) {
-                    if (isWriteStage(stage)) {
-                        throw new MongoDBError(ErrorCodes.ForbiddenWriteOperation, writeStageForbiddenErrorMessage);
-                    }
-                }
+                assertNoWriteStages(value, writeStageForbiddenErrorMessage);
             }
         }
     }

--- a/packages/tools-mongodb/src/tools/read/export.ts
+++ b/packages/tools-mongodb/src/tools/read/export.ts
@@ -9,6 +9,7 @@ import { FindArgs } from "./find.js";
 import { jsonExportFormat } from "../../common/exportsManager.js";
 import { AggregateArgs } from "./aggregate.js";
 import { EXPORT_TOOL_NAME } from "../../helpers/constants.js";
+import { assertNoWriteStages } from "../../helpers/mqlGuards.js";
 
 export class ExportTool extends MongoDBToolBase {
     static toolName = EXPORT_TOOL_NAME;
@@ -91,6 +92,10 @@ export class ExportTool extends MongoDBToolBase {
             });
         } else {
             const { pipeline } = exportTarget.arguments;
+            assertNoWriteStages(
+                pipeline,
+                "The export tool can not run pipelines with $out or $merge stages. Use the aggregate tool to run a pipeline that writes to a collection."
+            );
             this.assertMqlIsAllowed(this.server.config, pipeline);
             cursor = provider.aggregate(database, collection, pipeline, {
                 promoteValues: false,


### PR DESCRIPTION
## Proposed changes

Rejects $out and $merge in export aggs.