### PR TITLE
fix(release): sync server/test package versions to v3.0.0-prerelease.3

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -40,11 +40,7 @@ jobs:
           set -euo pipefail
           npm version "$INPUTS_VERSION" --no-git-tag-version --allow-same-version
           NEW_VERSION=$(npm pkg get version | tr -d '"')
-          # Version-sync the scoped @mongodb-js/mcp-* packages AND the published mongodb-mcp-server
-          # package with the server. mongodb-mcp-server is unscoped so it isn't caught by the scope
-          # filter above; it is the package the publish workflow reads its version from, so it must be
-          # bumped here or publish would ship a stale version. mongodb-atlas-mcp-remote is intentionally
-          # unscoped so it versions independently and is excluded.
+          # mongodb-mcp-server is unscoped, so it isn't caught by the @mongodb-js/mcp-* filter below.
           pnpm -r --filter '@mongodb-js/mcp-*' exec npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
           pnpm --filter 'mongodb-mcp-server' exec npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
           pnpm run build:update-package-version

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -40,7 +40,6 @@ jobs:
           set -euo pipefail
           npm version "$INPUTS_VERSION" --no-git-tag-version --allow-same-version
           NEW_VERSION=$(npm pkg get version | tr -d '"')
-          # mongodb-mcp-server is unscoped, so it isn't caught by the @mongodb-js/mcp-* filter below.
           pnpm -r --filter '@mongodb-js/mcp-*' exec npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
           pnpm --filter 'mongodb-mcp-server' exec npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
           pnpm run build:update-package-version

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -42,6 +42,7 @@ jobs:
           NEW_VERSION=$(npm pkg get version | tr -d '"')
           pnpm -r --filter '@mongodb-js/mcp-*' exec npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
           pnpm --filter 'mongodb-mcp-server' exec npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
+          pnpm --filter '@mongodb-js/harness-tester' exec npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
           pnpm run build:update-package-version
           echo "NEW_VERSION=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -40,9 +40,13 @@ jobs:
           set -euo pipefail
           npm version "$INPUTS_VERSION" --no-git-tag-version --allow-same-version
           NEW_VERSION=$(npm pkg get version | tr -d '"')
-          # Only version-sync the scoped @mongodb-js/mcp-* packages with the server.
-          # mongodb-atlas-mcp-remote is intentionally unscoped so it versions independently and is excluded here.
+          # Version-sync the scoped @mongodb-js/mcp-* packages AND the published mongodb-mcp-server
+          # package with the server. mongodb-mcp-server is unscoped so it isn't caught by the scope
+          # filter above; it is the package the publish workflow reads its version from, so it must be
+          # bumped here or publish would ship a stale version. mongodb-atlas-mcp-remote is intentionally
+          # unscoped so it versions independently and is excluded.
           pnpm -r --filter '@mongodb-js/mcp-*' exec npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
+          pnpm --filter 'mongodb-mcp-server' exec npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version
           pnpm run build:update-package-version
           echo "NEW_VERSION=v${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@mongodb-js/e2e-tests",
-  "version": "3.0.0-prerelease.2",
+  "name": "@mongodb-js/mcp-e2e-tests",
+  "version": "3.0.0-prerelease.3",
   "private": true,
   "type": "module",
   "description": "End-to-end tests driving the MongoDB MCP server through a real LLM coding agent",

--- a/packages/harness-tester/package.json
+++ b/packages/harness-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-js/harness-tester",
-  "version": "3.0.0-prerelease.2",
+  "version": "3.0.0-prerelease.3",
   "private": true,
   "type": "module",
   "description": "Tooling to drive real LLM coding-agent CLIs (codex, claude) interactively through their TUIs for end-to-end tests",

--- a/packages/mongodb-mcp-server/package.json
+++ b/packages/mongodb-mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongodb-mcp-server",
   "description": "MongoDB Model Context Protocol Server",
-  "version": "3.0.0-prerelease.2",
+  "version": "3.0.0-prerelease.3",
   "type": "module",
   "mcpName": "io.github.mongodb-js/mongodb-mcp-server",
   "exports": {

--- a/packages/mongodb-mcp-server/packaging/mcpb/manifest.json
+++ b/packages/mongodb-mcp-server/packaging/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.1",
   "name": "mongodb-mcp-server",
   "display_name": "MongoDB",
-  "version": "3.0.0-prerelease.2",
+  "version": "3.0.0-prerelease.3",
   "description": "Official MongoDB desktop extension (MCP Server). Connect to databases, explore data, manage collections, optimize queries, generate reliable code, implement best practices, develop advanced features, and more.",
   "long_description": "Connect Claude Desktop to MongoDB Atlas and self-managed MongoDB deployments.\n\nManage your Atlas resources — clusters, projects, network access, and database users — directly from Claude. Query and inspect your data using find and aggregation, explore schemas, and manage indexes. Spin up local Atlas environments via Docker with Atlas Local, and add semantic search to your workflows using Vector Search with Voyage AI embeddings.\n\nFull documentation at [mongodb.com/docs/mcp-server](https://www.mongodb.com/docs/mcp-server/).",
   "author": {

--- a/packages/mongodb-mcp-server/server.json
+++ b/packages/mongodb-mcp-server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/mongodb-js/mongodb-mcp-server",
     "source": "github"
   },
-  "version": "3.0.0-prerelease.2",
+  "version": "3.0.0-prerelease.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "mongodb-mcp-server",
-      "version": "3.0.0-prerelease.2",
+      "version": "3.0.0-prerelease.3",
       "transport": {
         "type": "stdio"
       },
@@ -604,7 +604,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/mongodb/mongodb-mcp-server:3.0.0-prerelease.2",
+      "identifier": "docker.io/mongodb/mongodb-mcp-server:3.0.0-prerelease.3",
       "transport": {
         "type": "stdio"
       },

--- a/packages/mongodb-mcp-server/src/common/packageInfo.ts
+++ b/packages/mongodb-mcp-server/src/common/packageInfo.ts
@@ -4,7 +4,7 @@ export const packageInfo: {
     mcpServerName: string;
     engines: { node: string };
 } = {
-    version: "3.0.0-prerelease.2",
+    version: "3.0.0-prerelease.3",
     mcpServerName: "MongoDB MCP Server",
     engines: {
         node: "^20.19.0 || ^22.13.0 || >= 24.0.0",


### PR DESCRIPTION
## What
Bring the published `mongodb-mcp-server` and the two test packages into lockstep with the `v3.0.0-prerelease.3` release, and make `prepare-release.yml` bump them automatically going forward.

- Bump `mongodb-mcp-server` to `v3.0.0-prerelease.3` and sync its derived version fields (`packageInfo.ts`, mcpb `manifest.json`, `server.json`).
- Rename `@mongodb-js/e2e-tests` → `@mongodb-js/mcp-e2e-tests` (package name only; the `packages/e2e-tests` directory is unchanged) so it's caught by the `@mongodb-js/mcp-*` glob.
- Bump `mcp-e2e-tests` and `@mongodb-js/harness-tester` to `v3.0.0-prerelease.3`.

## Why
#1506 bumped the monorepo root + scoped `@mongodb-js/mcp-*` packages to `v3.0.0-prerelease.3`, but the published `mongodb-mcp-server` package was never bumped — it's unscoped, so the prepare-release `--filter '@mongodb-js/mcp-*'` doesn't match it. Because the publish workflow reads the version from `packages/mongodb-mcp-server/package.json`, run 34342866085 saw the still-existing `v3.0.0-prerelease.2` tag, set `VERSION_EXISTS=true`, and skipped the release.

## How
`prepare-release.yml` now explicitly bumps `mongodb-mcp-server` and `@mongodb-js/harness-tester` in addition to the `@mongodb-js/mcp-*` glob. `e2e-tests` became `mcp-e2e-tests` so the glob covers it too.
