### PR TITLE
feat(http): restore externally managed sessions on the legacy 2025 path

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -1106,6 +1106,7 @@ export const UserConfigSchema: z.ZodObject<{
     idleTimeoutMs: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
     notificationTimeoutMs: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
     evictionIdleGraceMS: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
+    externallyManagedSessions: z.ZodDefault<z.ZodBoolean>;
     maxBytesPerQuery: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
     maxDocumentsPerQuery: z.ZodDefault<z.ZodCoercedNumber<unknown>>;
     maxTimeMS: z.ZodOptional<z.ZodCoercedNumber<unknown>>;

--- a/packages/cli/src/cliMcpHttpServer.ts
+++ b/packages/cli/src/cliMcpHttpServer.ts
@@ -72,6 +72,7 @@ export function createHttpTransportRunnerFromConfig(sharedServices: SharedServer
                 idleTimeoutMS: config.idleTimeoutMs,
                 notificationTimeoutMS: config.notificationTimeoutMs,
                 evictionIdleGraceMS: config.evictionIdleGraceMS,
+                externallyManagedSessions: config.externallyManagedSessions,
             },
         },
     });

--- a/packages/cli/src/config/configOverrides.test.ts
+++ b/packages/cli/src/config/configOverrides.test.ts
@@ -224,6 +224,7 @@ describe("configOverrides", () => {
                         "allowRequestOverrides",
                         "dryRun",
                         "httpResponseType",
+                        "externallyManagedSessions",
                         "healthCheckHost",
                         "healthCheckPort",
                         "monitoringServerHost",

--- a/packages/cli/src/config/userConfig.ts
+++ b/packages/cli/src/config/userConfig.ts
@@ -214,6 +214,13 @@ const ServerConfigSchema = z.object({
             "How long a session must be idle before it becomes eligible for least-recently-used eviction when the HTTP transport is at its maxSessions cap (only used when transport is 'http'). Swept back to idleTimeoutMs when larger."
         )
         .register(configRegistry, { overrideBehavior: "not-allowed" }),
+    externallyManagedSessions: z
+        .boolean()
+        .default(false)
+        .describe(
+            "When true, the 2025-era HTTP transport accepts a session ID supplied externally through the 'mcp-session-id' header. When an external ID is supplied, the initialization request is optional, and an implicitly re-initialized session restores the client's previously negotiated capabilities from the session store."
+        )
+        .register(configRegistry, { overrideBehavior: "not-allowed" }),
     maxBytesPerQuery: z.coerce
         .number()
         .default(16_777_216)

--- a/packages/http-runners/src/legacyMcpHttpHandler.ts
+++ b/packages/http-runners/src/legacyMcpHttpHandler.ts
@@ -1,4 +1,4 @@
-import { isInitializeRequest } from "@modelcontextprotocol/server";
+import { isInitializeRequest, type ClientCapabilities, type Implementation } from "@modelcontextprotocol/server";
 import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
 import type express from "express";
 import type {
@@ -7,6 +7,7 @@ import type {
     RequestAuthInfo,
     HttpServerOptions,
     BaseServer,
+    NegotiatedClientState,
 } from "@mongodb-js/mcp-types";
 import { LogId, getRandomUUID, requestIdAttr } from "@mongodb-js/mcp-core";
 import { SessionLimitExceededError, type ISessionStore } from "@mongodb-js/mcp-core";
@@ -42,6 +43,16 @@ export type LegacySessionOptions = {
     idleTimeoutMS?: number;
     notificationTimeoutMS?: number;
     evictionIdleGraceMS?: number;
+    /**
+     * When true, the legacy (2025-era) HTTP transport accepts a client-supplied
+     * `mcp-session-id` header on `initialize` instead of rejecting it, and
+     * reuses that id for the session. When no session is found for a supplied
+     * id, the handler attempts an implicit re-initialization and restores the
+     * client's previously negotiated capabilities from the session store (see
+     * {@link ISessionStore.saveNegotiatedClientState}); a store without durable
+     * storage restores nothing. Defaults to `false`.
+     */
+    externallyManagedSessions?: boolean;
 };
 
 export type LegacyMcpHttpHandlerOptions = {
@@ -51,6 +62,12 @@ export type LegacyMcpHttpHandlerOptions = {
     http: HttpServerOptions;
     /** Session store backing the legacy sessionful path (auth-aware or durable). */
     sessionStore: ISessionStore<NodeStreamableHTTPServerTransport>;
+    /**
+     * When true, accept a client-supplied `mcp-session-id` on `initialize` and
+     * restore negotiated client state for implicitly re-initialized sessions.
+     * Defaults to `false`.
+     */
+    externallyManagedSessions?: boolean;
 };
 
 /**
@@ -89,12 +106,22 @@ export class LegacyMcpHttpHandler implements LegacyMcpHandler {
     private readonly logger: ILogger;
     private readonly http: HttpServerOptions;
     private readonly sessions: ISessionStore<NodeStreamableHTTPServerTransport>;
+    private readonly externallyManagedSessions: boolean;
+    /** Serializes concurrent initialization of the same session id (see {@link createSession}). */
+    private readonly pendingInitializations = new Map<string, Promise<NodeStreamableHTTPServerTransport>>();
 
-    constructor({ createServer, logger, http, sessionStore }: LegacyMcpHttpHandlerOptions) {
+    constructor({
+        createServer,
+        logger,
+        http,
+        sessionStore,
+        externallyManagedSessions = false,
+    }: LegacyMcpHttpHandlerOptions) {
         this.createServer = createServer;
         this.logger = logger;
         this.http = http;
         this.sessions = sessionStore;
+        this.externallyManagedSessions = externallyManagedSessions;
     }
 
     /** Closes every live session (e.g. on server shutdown). */
@@ -215,12 +242,76 @@ export class LegacyMcpHttpHandler implements LegacyMcpHandler {
      * the transport so later requests and the SSE idle stream reuse it (the
      * return channel the legacy elicitation shim needs).
      */
-    private async createSession(req: express.Request): Promise<NodeStreamableHTTPServerTransport> {
-        const sessionId = getRandomUUID();
+    /**
+     * Creates a fresh session (or returns the existing / in-flight one for an
+     * externally managed id). Concurrent initializations of the same session id
+     * are serialized so they don't race on `addSession` (see
+     * {@link createSessionInstance}).
+     */
+    private async createSession(
+        req: express.Request,
+        providedSessionId?: string,
+        isImplicitInitialization = false
+    ): Promise<NodeStreamableHTTPServerTransport> {
+        const sessionId = providedSessionId ?? getRandomUUID();
+
+        // An externally managed session may already exist in the store (e.g. a
+        // client re-sends `initialize` for the same id). Reuse it rather than
+        // creating a duplicate, which would throw "Session already exists".
+        const existingTransport = await this.sessions.getSession(sessionId, req.headers);
+        if (existingTransport) {
+            return existingTransport;
+        }
+
+        // Another request is already initializing this id; wait for it and reuse
+        // its transport instead of racing it.
+        const pendingInit = this.pendingInitializations.get(sessionId);
+        if (pendingInit) {
+            this.logger.debug({
+                id: LogId.streamableHttpTransportSessionNotFound,
+                context: "streamableHttpTransport",
+                message: `Session with ID ${sessionId} is already being initialized, waiting`,
+                attributes: { ...requestIdAttr(req.headers) },
+            });
+            try {
+                return await pendingInit;
+            } catch {
+                // The initializer handles its own error; fall through to retry.
+            }
+        }
+
+        const initPromise = this.createSessionInstance(req, sessionId, isImplicitInitialization);
+        this.pendingInitializations.set(sessionId, initPromise);
+        try {
+            return await initPromise;
+        } finally {
+            this.pendingInitializations.delete(sessionId);
+        }
+    }
+
+    /** Builds the server/transport pair and registers it in the session store. */
+    private async createSessionInstance(
+        req: express.Request,
+        sessionId: string,
+        isImplicitInitialization: boolean
+    ): Promise<NodeStreamableHTTPServerTransport> {
         const transport = new NodeStreamableHTTPServerTransport({
             sessionIdGenerator: (): string => sessionId,
             enableJsonResponse: this.http.responseType === "json",
         });
+
+        // HACK: When we're implicitly re-initializing an externally managed
+        // session, mark the transport as already initialized so the SDK does
+        // not reject follow-up requests with "transport not initialized".
+        if (isImplicitInitialization) {
+            const internalTransport = transport["_webStandardTransport"] as unknown as {
+                _initialized: boolean;
+                sessionId: string;
+            };
+            internalTransport._initialized = true;
+            internalTransport.sessionId = sessionId;
+        }
+
         const server = (await this.createServer(this.buildTransportContext(req))) as unknown as SessionfulServer;
 
         // Admit (check cap, evict LRU idle victim). A rejection admits nothing.
@@ -274,6 +365,12 @@ export class LegacyMcpHttpHandler implements LegacyMcpHandler {
             throw error;
         }
 
+        if (isImplicitInitialization) {
+            await this.restoreNegotiatedClientState(server, sessionId, req.headers);
+        } else {
+            this.captureNegotiatedClientStateOnInitialize(server, sessionId, req.headers);
+        }
+
         return transport;
     }
 
@@ -308,13 +405,15 @@ export class LegacyMcpHttpHandler implements LegacyMcpHandler {
         }
 
         if (isInitializeRequest(req.body)) {
-            if (sessionId) {
-                // This shim has no externally managed sessions; a client-provided
-                // session id on initialize is rejected as on main.
+            const resolvedSessionId =
+                typeof sessionId === "string" && this.externallyManagedSessions ? sessionId : undefined;
+            if (sessionId && !resolvedSessionId) {
+                // A client-supplied session id is only honored when externally
+                // managed sessions are enabled; otherwise it is rejected.
                 this.logger.debug({
                     id: LogId.streamableHttpTransportDisallowedExternalSessionError,
                     context: "streamableHttpTransport",
-                    message: `Client provided session ID ${sessionId} on initialize, but externally managed sessions are not supported`,
+                    message: `Client provided session ID ${sessionId}, but externallyManagedSessions is disabled`,
                     attributes: { ...requestIdAttr(req.headers) },
                 });
                 this.reportSessionError(res, JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION);
@@ -323,7 +422,7 @@ export class LegacyMcpHttpHandler implements LegacyMcpHandler {
 
             let transport: NodeStreamableHTTPServerTransport;
             try {
-                transport = await this.createSession(req);
+                transport = await this.createSession(req, resolvedSessionId);
             } catch (error) {
                 if (error instanceof SessionLimitExceededError) {
                     this.logger.warning({
@@ -363,17 +462,105 @@ export class LegacyMcpHttpHandler implements LegacyMcpHandler {
             this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_INVALID);
             return;
         }
-        const transport = await this.sessions.getSession(sessionId, req.headers);
+        let transport = await this.sessions.getSession(sessionId, req.headers);
         if (!transport) {
+            if (!this.externallyManagedSessions) {
+                this.logger.debug({
+                    id: LogId.streamableHttpTransportSessionNotFound,
+                    context: "streamableHttpTransport",
+                    message: `Session with ID ${sessionId} not found`,
+                    attributes: { ...requestIdAttr(req.headers) },
+                });
+                this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND);
+                return;
+            }
+
+            // Externally managed sessions may be implicitly re-initialized: a
+            // session held externally can arrive at this pod without being in
+            // the store. Build a fresh session under the supplied id and
+            // restore the client's previously negotiated capabilities (if the
+            // store persists them) instead of rejecting the request.
             this.logger.debug({
                 id: LogId.streamableHttpTransportSessionNotFound,
                 context: "streamableHttpTransport",
-                message: `Session with ID ${sessionId} not found`,
+                message: `Session with ID ${sessionId} not found, implicitly re-initializing`,
                 attributes: { ...requestIdAttr(req.headers) },
             });
-            this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_NOT_FOUND);
-            return;
+            transport = await this.createSession(req, sessionId, true);
         }
         await transport.handleRequest(req, res, req.body);
+    }
+
+    /**
+     * Restores the client state negotiated during the session's original
+     * `initialize` onto an implicitly re-initialized server. The session's
+     * server on this pod never saw the client's `initialize` request, so
+     * without this it would treat the client as capability-less — e.g.
+     * skipping confirmation elicitation for destructive tools. No-op when the
+     * session store does not persist negotiated client state.
+     */
+    private async restoreNegotiatedClientState(
+        server: SessionfulServer,
+        sessionId: string,
+        headers: Record<string, unknown>
+    ): Promise<void> {
+        let state: NegotiatedClientState | undefined;
+        try {
+            state = await this.sessions.loadNegotiatedClientState(sessionId, headers);
+        } catch (error) {
+            // The restored session stays usable; it just behaves as if the
+            // client had no optional capabilities.
+            this.logger.warning({
+                id: LogId.streamableHttpTransportClientStateRestoreFailure,
+                context: "streamableHttpTransport",
+                message: `Failed to restore negotiated client state for session ${sessionId}: ${error instanceof Error ? error.message : String(error)}`,
+                attributes: { ...requestIdAttr(headers) },
+            });
+            return;
+        }
+        if (!state) {
+            return;
+        }
+
+        // HACK: the SDK offers no supported way to seed a Server with a
+        // previously negotiated initialization, so we write the private fields
+        // the initialize handler would have populated.
+        const protocolServer = server.mcpServer.server as unknown as {
+            _clientCapabilities?: ClientCapabilities;
+            _clientVersion?: Implementation;
+        };
+        protocolServer._clientCapabilities = state.clientCapabilities;
+        protocolServer._clientVersion = state.clientInfo;
+    }
+
+    /**
+     * Arranges for the client state negotiated by a real `initialize` exchange
+     * to be persisted through the session store, so implicit re-initializations
+     * of this session can restore it. Wraps the `oninitialized` callback
+     * installed by `server.connect`, hence must run after it.
+     */
+    private captureNegotiatedClientStateOnInitialize(
+        server: SessionfulServer,
+        sessionId: string,
+        headers: Record<string, unknown>
+    ): void {
+        const protocolServer = server.mcpServer.server;
+        const originalOnInitialized = protocolServer.oninitialized;
+        protocolServer.oninitialized = (): void => {
+            originalOnInitialized?.();
+
+            const state: NegotiatedClientState = {
+                clientCapabilities: protocolServer.getClientCapabilities(),
+                clientInfo: protocolServer.getClientVersion(),
+            };
+            this.sessions.saveNegotiatedClientState(sessionId, state, headers).catch((error: unknown) => {
+                this.logger.warning({
+                    id: LogId.streamableHttpTransportClientStateSaveFailure,
+                    context: "streamableHttpTransport",
+                    message: `Failed to save negotiated client state for session ${sessionId}: ${error instanceof Error ? error.message : String(error)}`,
+                    attributes: { ...requestIdAttr(headers) },
+                });
+            });
+        };
     }
 }

--- a/packages/http-runners/src/legacyMcpHttpHandler.ts
+++ b/packages/http-runners/src/legacyMcpHttpHandler.ts
@@ -25,6 +25,9 @@ const JSON_RPC_ERROR_CODE_INVALID_REQUEST = -32004;
 const JSON_RPC_ERROR_CODE_DISALLOWED_EXTERNAL_SESSION = -32005;
 const JSON_RPC_ERROR_CODE_SESSION_LIMIT_EXCEEDED = -32006;
 
+/** Guards against oversized `mcp-session-id` headers (e.g. an abusive client). */
+const MAX_SESSION_ID_LENGTH = 512;
+
 /** The per-request server contract the sessionful legacy path relies on in
  * addition to {@link BaseServer}: it must be connectable to a transport so a
  * session can hold a live server/transport pair — the return channel the
@@ -236,13 +239,6 @@ export class LegacyMcpHttpHandler implements LegacyMcpHandler {
     }
 
     /**
-     * Creates a fresh session: builds a request-scoped server, connects it to a
-     * sessionful streamable HTTP transport (so `initialize` negotiates and the
-     * SDK keeps the client's capabilities on the connected server), and stores
-     * the transport so later requests and the SSE idle stream reuse it (the
-     * return channel the legacy elicitation shim needs).
-     */
-    /**
      * Creates a fresh session (or returns the existing / in-flight one for an
      * externally managed id). Concurrent initializations of the same session id
      * are serialized so they don't race on `addSession` (see
@@ -303,13 +299,19 @@ export class LegacyMcpHttpHandler implements LegacyMcpHandler {
         // HACK: When we're implicitly re-initializing an externally managed
         // session, mark the transport as already initialized so the SDK does
         // not reject follow-up requests with "transport not initialized".
+        // Guard the internal field: if the SDK's transport shape changes, the
+        // session degrades gracefully rather than throwing before the request
+        // can be answered.
         if (isImplicitInitialization) {
-            const internalTransport = transport["_webStandardTransport"] as unknown as {
-                _initialized: boolean;
-                sessionId: string;
-            };
-            internalTransport._initialized = true;
-            internalTransport.sessionId = sessionId;
+            const internalTransport = (
+                transport as unknown as {
+                    _webStandardTransport?: { _initialized?: boolean; sessionId?: string };
+                }
+            )._webStandardTransport;
+            if (internalTransport) {
+                internalTransport._initialized = true;
+                internalTransport.sessionId = sessionId;
+            }
         }
 
         const server = (await this.createServer(this.buildTransportContext(req))) as unknown as SessionfulServer;
@@ -400,6 +402,16 @@ export class LegacyMcpHttpHandler implements LegacyMcpHandler {
 
         // POST /mcp.
         if (sessionId && typeof sessionId !== "string") {
+            this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_INVALID);
+            return;
+        }
+        if (typeof sessionId === "string" && sessionId.length > MAX_SESSION_ID_LENGTH) {
+            this.logger.debug({
+                id: LogId.streamableHttpTransportSessionNotFound,
+                context: "streamableHttpTransport",
+                message: `Session ID exceeds maximum length ${MAX_SESSION_ID_LENGTH}`,
+                attributes: { ...requestIdAttr(req.headers) },
+            });
             this.reportSessionError(res, JSON_RPC_ERROR_CODE_SESSION_ID_INVALID);
             return;
         }

--- a/packages/http-runners/src/mcpHttpServer.test.ts
+++ b/packages/http-runners/src/mcpHttpServer.test.ts
@@ -452,6 +452,7 @@ describe("MCPHttpServer stateless serving", () => {
                 headers: {
                     "content-type": "application/json",
                     accept: "application/json, text/event-stream",
+                    "mcp-protocol-version": "2025-11-25",
                     "mcp-session-id": "external-id",
                 },
                 body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 4, params: {} }),

--- a/packages/http-runners/src/mcpHttpServer.test.ts
+++ b/packages/http-runners/src/mcpHttpServer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import type express from "express";
 import { MCPHttpServer } from "./mcpHttpServer.js";
-import type { LegacyMcpHandler } from "./legacyMcpHttpHandler.js";
+import type { LegacyMcpHandler, LegacySessionOptions } from "./legacyMcpHttpHandler.js";
 import { RedactingLoggerBase, Keychain } from "@mongodb-js/mcp-core";
 import { PrometheusMetrics, createDefaultMetrics } from "@mongodb-js/mcp-metrics";
 import type {
@@ -91,11 +91,12 @@ function makeFakeServer(): BaseServer & { connect: (t: unknown) => Promise<void>
 }
 
 class TestMCPHttpServer extends MCPHttpServer<BaseServer> {
-    constructor({ logger }: { logger: InMemoryLogger }) {
+    constructor({ logger, sessionOptions }: { logger: InMemoryLogger; sessionOptions?: LegacySessionOptions }) {
         super({
             options: { http: httpOptions },
             logger,
             metrics: new MockMetrics(),
+            sessionOptions,
         });
     }
 
@@ -399,6 +400,64 @@ describe("MCPHttpServer stateless serving", () => {
             await expect(initWithSession.json()).resolves.toMatchObject({
                 error: { code: -32005 },
             });
+        });
+
+        it("accepts a client-supplied session id on initialize when externally managed sessions are enabled", async () => {
+            const myLogger = new InMemoryLogger();
+            class ExternalServer extends TestMCPHttpServer {
+                constructor() {
+                    super({
+                        logger: myLogger,
+                        sessionOptions: { externallyManagedSessions: true },
+                    });
+                }
+            }
+            server = new ExternalServer();
+            await server.start();
+
+            const res = await fetch(`${server.serverAddress}/mcp`, {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    accept: "application/json, text/event-stream",
+                    "mcp-protocol-version": "2025-11-25",
+                    "mcp-session-id": "external-id",
+                },
+                body: LEGACY_INIT_BODY,
+            });
+
+            expect(res.status).toBe(200);
+            // The client-supplied id is honored, not rejected.
+            expect(res.headers.get("mcp-session-id")).toBe("external-id");
+        });
+
+        it("implicitly re-initializes a missing session for an externally managed session id", async () => {
+            const myLogger = new InMemoryLogger();
+            class ExternalServer extends TestMCPHttpServer {
+                constructor() {
+                    super({
+                        logger: myLogger,
+                        sessionOptions: { externallyManagedSessions: true },
+                    });
+                }
+            }
+            server = new ExternalServer();
+            await server.start();
+
+            // A session-carrying request (non-initialize) whose id is not in the
+            // store. With externally managed sessions enabled the handler attempts
+            // an implicit re-initialization instead of rejecting with 404.
+            const res = await fetch(`${server.serverAddress}/mcp`, {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    accept: "application/json, text/event-stream",
+                    "mcp-session-id": "external-id",
+                },
+                body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 4, params: {} }),
+            });
+
+            expect(res.status).toBe(200);
         });
     });
 });

--- a/packages/http-runners/src/mcpHttpServer.ts
+++ b/packages/http-runners/src/mcpHttpServer.ts
@@ -116,6 +116,7 @@ export abstract class MCPHttpServer<
             createServer: async (request): Promise<TServer> => this.createServerForRequest(request),
             logger,
             http,
+            externallyManagedSessions: sessionOptions?.externallyManagedSessions ?? false,
             sessionStore: new SessionStore<NodeStreamableHTTPServerTransport>({
                 options: {
                     idleTimeoutMS: sessionOptions?.idleTimeoutMS ?? 600_000,

--- a/packages/integration-tests/src/config/userConfig.test.ts
+++ b/packages/integration-tests/src/config/userConfig.test.ts
@@ -49,6 +49,7 @@ const expectedDefaults = {
     idleTimeoutMs: 600000,
     notificationTimeoutMs: 540000,
     evictionIdleGraceMS: 120000,
+    externallyManagedSessions: false,
     httpHeaders: {},
     httpBodyLimit: TRANSPORT_PAYLOAD_LIMITS.http,
     maxDocumentsPerQuery: 100,

--- a/packages/mongodb-mcp-server/server.json
+++ b/packages/mongodb-mcp-server/server.json
@@ -406,6 +406,13 @@
         },
         {
           "type": "named",
+          "name": "--externallyManagedSessions",
+          "description": "When true, the 2025-era HTTP transport accepts a session ID supplied externally through the 'mcp-session-id' header. When an external ID is supplied, the initialization request is optional.",
+          "isRequired": false,
+          "format": "boolean"
+        },
+        {
+          "type": "named",
           "name": "--exportCleanupIntervalMs",
           "description": "Time in milliseconds between export cleanup cycles that remove expired export files.",
           "isRequired": false,
@@ -996,6 +1003,13 @@
           "description": "How long a session must be idle before it becomes eligible for least-recently-used eviction when the HTTP transport is at its maxSessions cap (only used when transport is 'http'). Swept back to idleTimeoutMs when larger.",
           "isRequired": false,
           "format": "number"
+        },
+        {
+          "type": "named",
+          "name": "--externallyManagedSessions",
+          "description": "When true, the 2025-era HTTP transport accepts a session ID supplied externally through the 'mcp-session-id' header. When an external ID is supplied, the initialization request is optional.",
+          "isRequired": false,
+          "format": "boolean"
         },
         {
           "type": "named",


### PR DESCRIPTION
## What

Restores `externallyManagedSessions` support for the legacy (2025-era) HTTP transport, which was dropped by the sessionless refactor (#1474). Adds a config option and threads it to `LegacyMcpHttpHandler`.

## Why

The sessionless change made `LegacyMcpHttpHandler` reject any client-supplied `mcp-session-id` on `initialize` and own an in-memory-only session store. Deployments that manage sessions externally (e.g. a gateway/K8s ingress asserting the session id) lost that capability, so this restores it, matching the pre-sessionless implementation.

## Behavior

- **Enabled** (`--externallyManagedSessions`): accepts a client-supplied `mcp-session-id` on `initialize`, reuses an existing session for that id, and implicitly re-initializes a missing session while restoring the client's previously negotiated capabilities via the session store's `save/loadNegotiatedClientState`.
- **Disabled (default)**: rejects external session ids exactly as before — no behavior change.

## Notes

- Restart only applies to the 2025-era path; the modern 2026-07-28 stateless path has no sessions.
- Restoring negotiated state requires a durable `ISessionStore` (the default `SessionStore`'s `save/loadNegotiatedClientState` are no-ops); otherwise restore is a no-op. Inject a custom store via the `createLegacyHandler` override to persist across pods.