### PR TITLE
chore(types): add TransportRequestContext protocol marker for legacy vs 2026-07-28

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -922,6 +922,7 @@ export type TelemetryCommonProperties = {
     config_connection_string?: TelemetryBoolSet;
     hosting_mode?: string;
     has_docker?: TelemetryBoolSet;
+    protocol?: McpProtocol;
 } & TelemetryCommonStaticProperties;
 
 // @public
@@ -1046,6 +1047,7 @@ export type TransportRequestContext = {
     headers?: Record<string, string | string[] | undefined>;
     query?: Record<string, string | string[] | undefined>;
     authInfo?: RequestAuthState;
+    protocol?: McpProtocol;
 };
 
 // @public

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -703,6 +703,7 @@ export type TelemetryCommonProperties = {
     config_connection_string?: TelemetryBoolSet;
     hosting_mode?: string;
     has_docker?: TelemetryBoolSet;
+    protocol?: McpProtocol;
 } & TelemetryCommonStaticProperties;
 
 // @public (undocumented)
@@ -841,6 +842,7 @@ export type TransportRequestContext = {
     headers?: Record<string, string | string[] | undefined>;
     query?: Record<string, string | string[] | undefined>;
     authInfo?: RequestAuthState;
+    protocol?: McpProtocol;
 };
 
 // @public

--- a/packages/http-runners/src/legacyMcpHttpHandler.ts
+++ b/packages/http-runners/src/legacyMcpHttpHandler.ts
@@ -112,6 +112,7 @@ export class LegacyMcpHttpHandler implements LegacyMcpHandler {
             authInfo: (req as express.Request & { auth?: RequestAuthInfo }).auth
                 ? { mode: "authenticated", state: (req as express.Request & { auth: RequestAuthInfo }).auth }
                 : { mode: "unauthenticated" },
+            protocol: "legacy",
         };
     }
 

--- a/packages/http-runners/src/mcpHttpServer.ts
+++ b/packages/http-runners/src/mcpHttpServer.ts
@@ -161,6 +161,7 @@ export abstract class MCPHttpServer<
                     authInfo: ctx.authInfo
                         ? { mode: "authenticated", state: ctx.authInfo }
                         : { mode: "unauthenticated" },
+                    protocol: "2026-07-28",
                 };
                 const server = await this.createServerForRequest(request);
                 await server.register();

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -1,3 +1,5 @@
+import type { McpProtocol } from "./transport.js";
+
 export type TelemetryEvents = {
     "events-emitted": [];
     "events-send-failed": [];
@@ -33,6 +35,7 @@ export type TelemetryCommonProperties = {
     config_connection_string?: TelemetryBoolSet;
     hosting_mode?: string;
     has_docker?: TelemetryBoolSet;
+    protocol?: McpProtocol;
 } & TelemetryCommonStaticProperties;
 
 export type TelemetryEvent<T> = {

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -26,6 +26,8 @@ export type RequestAuthInfo = {
  */
 export type RequestAuthState = { mode: "unauthenticated" } | { mode: "authenticated"; state: RequestAuthInfo };
 
+export type McpProtocol = "legacy" | "2026-07-28";
+
 export type TransportRequestContext = {
     headers?: Record<string, string | string[] | undefined>;
     query?: Record<string, string | string[] | undefined>;
@@ -35,6 +37,7 @@ export type TransportRequestContext = {
      * isolated from authenticated clients.
      */
     authInfo?: RequestAuthState;
+    protocol?: McpProtocol;
 };
 
 export interface ITransportRunner {


### PR DESCRIPTION
## Proposed changes

Adds a transport-level `protocol` marker so per-request servers and telemetry can tell the two MCP usage kinds apart:

- `TransportRequestContext.protocol?: McpProtocol` where `McpProtocol = "legacy" | "2026-07-28"` — set to `"legacy"` by the sessionful legacy handler, `"2026-07-28"` by the modern stateless handler.
- `TelemetryCommonProperties.protocol?: McpProtocol` — the matching OSS telemetry common property, so downstream analytics can attribute session-telemetry vs session-free events even when a `session_id` is absent.

This is the transport/telemetry hook a hosted server needs to keep per-session telemetry for legacy traffic while emitting session-free telemetry for modern/stateless requests.

- `packages/types/src/transport.ts`
- `packages/types/src/telemetry.ts`
- `packages/http-runners/src/legacyMcpHttpHandler.ts`
- `packages/http-runners/src/mcpHttpServer.ts`

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)