### PR TITLE
fix(tools-mongodb): export ConnectionStateConnected as a value

### DIFF
--- a/packages/tools-mongodb/src/index.ts
+++ b/packages/tools-mongodb/src/index.ts
@@ -10,7 +10,6 @@ export {
 export type {
     ConnectionSettings,
     ConnectionState,
-    ConnectionStateConnected,
     ConnectionStateConnecting,
     ConnectionStateDisconnected,
     ConnectionStateErrored,
@@ -20,7 +19,7 @@ export type {
     ConnectionTag,
     OIDCConnectionAuthType,
 } from "./common/connectionManager.js";
-export { MCPConnectionManager, ConnectionManager } from "./common/connectionManager.js";
+export { MCPConnectionManager, ConnectionManager, ConnectionStateConnected } from "./common/connectionManager.js";
 export type {
     ConnectionStringInfo,
     ConnectionStringAuthType,


### PR DESCRIPTION
External connection managers (e.g. AtlasConnectionManager.connectWithX509, which bypasses devtools-connect) need to construct the connected state directly, but ConnectionStateConnected was only re-exported as a type from the package root, so the class isn't constructible at runtime. Promote it to a value export alongside MCPConnectionManager.

No behavior change; makes the class available as a value to consumers.