### PR TITLE
fix: shut down stdio server on EOF

### DIFF
--- a/packages/cli/src/startRunner.ts
+++ b/packages/cli/src/startRunner.ts
@@ -1,5 +1,4 @@
-import { LogId } from "@mongodb-js/mcp-core";
-import type { StdioRunner } from "@mongodb-js/mcp-core";
+import { LogId, StdioRunner } from "@mongodb-js/mcp-core";
 import type { StreamableHttpRunner } from "@mongodb-js/mcp-http-runners";
 import type { CompositeLogger } from "@mongodb-js/mcp-core";
 import type { OnExit } from "./types.js";
@@ -47,6 +46,9 @@ export async function startRunner({ transportRunner, logger, onExit }: StartRunn
     process.on("SIGABRT", () => void shutdown());
     process.on("SIGTERM", () => void shutdown());
     process.on("SIGQUIT", () => void shutdown());
+    if (transportRunner instanceof StdioRunner) {
+        process.stdin.once("end", () => void shutdown());
+    }
 
     try {
         await transportRunner.start();

--- a/packages/integration-tests/src/transports/stdioEof.test.ts
+++ b/packages/integration-tests/src/transports/stdioEof.test.ts
@@ -1,0 +1,69 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
+import { once } from "events";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const currentDir = import.meta.dirname;
+const projectRoot = path.resolve(currentDir, "../../../..");
+const serverPath = path.resolve(projectRoot, "packages/mongodb-mcp-server/dist/esm/index.js");
+const PROCESS_TIMEOUT_MS = 10_000;
+
+function cleanEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of Object.keys(env)) {
+        if (key.startsWith("MDB_MCP_")) {
+            delete env[key];
+        }
+    }
+    return env;
+}
+
+describe("stdio EOF lifecycle", () => {
+    let child: ChildProcessWithoutNullStreams | undefined;
+
+    afterEach(() => {
+        if (child?.exitCode === null && child.signalCode === null) {
+            child.kill("SIGKILL");
+        }
+    });
+
+    it("exits cleanly after an initialized client closes stdin", async () => {
+        child = spawn(process.execPath, [serverPath, "--telemetry", "disabled", "--disabledTools", "atlas-local"], {
+            env: {
+                ...cleanEnv(),
+                MDB_MCP_TRANSPORT: "stdio",
+                MDB_MCP_CONNECTION_STRING: "",
+            },
+        });
+
+        child.stdin.write(
+            `${JSON.stringify({
+                jsonrpc: "2.0",
+                id: 1,
+                method: "initialize",
+                params: {
+                    protocolVersion: "2025-03-26",
+                    capabilities: {},
+                    clientInfo: { name: "stdio-eof-test", version: "1.0.0" },
+                },
+            })}\n`
+        );
+
+        const [response] = (await once(child.stdout, "data", {
+            signal: AbortSignal.timeout(PROCESS_TIMEOUT_MS),
+        })) as [Buffer];
+        expect(response.toString()).toContain('"id":1');
+
+        const exited = once(child, "exit", { signal: AbortSignal.timeout(PROCESS_TIMEOUT_MS) });
+        child.stdin.end(
+            `${JSON.stringify({
+                jsonrpc: "2.0",
+                method: "notifications/initialized",
+                params: {},
+            })}\n`
+        );
+
+        const [exitCode] = (await exited) as [number | null, NodeJS.Signals | null];
+        expect(exitCode).toBe(0);
+    });
+});


### PR DESCRIPTION
## Proposed changes

Fixes #1515.

When an MCP client closes stdin, the stdio server remains alive and retains memory. Repeated sessions can therefore accumulate orphaned Node processes.

Handle stdin EOF by invoking the existing graceful shutdown path, which closes the transport and shared services, flushes logs, and exits. HTTP behaviour is unchanged.

Adds a regression test that initialises a real server process, closes stdin, and verifies exit code `0`.

### Live verification

Compared the fixed build with the same build loading the exact upstream `startRunner` source from `0738bcb1`.

| Version | Run | RSS before EOF | Result after EOF |
| --- | --- | ---: | --- |
| Upstream | 1 | 177.5 MiB | Still running after 10 s; 177.5 MiB RSS |
| Upstream | 2 | 177.3 MiB | Still running after 10 s; 177.3 MiB RSS |
| Upstream | 3 | 176.7 MiB | Still running after 10 s; 142.9 MiB RSS |
| Fixed | 1 | 175.1 MiB | Exit `0` within 16 ms; PID gone |
| Fixed | 2 | 176.4 MiB | Exit `0` within 16 ms; PID gone |
| Fixed | 3 | 177.0 MiB | Exit `0` within 14 ms; PID gone |

All upstream test processes required `SIGTERM` for cleanup. Fixed processes exited without an external signal, releasing their process-owned memory.

These checks used stdio initialisation without an active MongoDB connection; live database connection cleanup was not exercised.

### Tests

- Repository build passed.
- Repository tests: 1,142 passed, 2 skipped.
- EOF integration regression passed.
- Affected TypeScript, ESLint, Prettier and diff checks passed.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
