### PR TITLE
feat: allow injecting a MongoClient into connect() + make telemetry.setup() public

### DIFF
--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -16,7 +16,6 @@ import { EventEmitter } from 'events';
 import express from 'express';
 import type { FetchOptions } from 'openapi-fetch';
 import type { FindCursor } from 'mongodb';
-import type { MongoClient } from 'mongodb';
 import { Gauge } from 'prom-client';
 import { Histogram } from 'prom-client';
 import type http from 'http';
@@ -26,6 +25,7 @@ import type { InputResponses } from '@modelcontextprotocol/server';
 import type { LoggingMessageNotification } from '@modelcontextprotocol/server';
 import { McpHttpHandler } from '@modelcontextprotocol/server';
 import { McpServer } from '@modelcontextprotocol/server';
+import { MongoClient } from 'mongodb';
 import { NodeDriverServiceProvider } from '@mongosh/service-provider-node-driver';
 import type { ReadResourceCallback } from '@modelcontextprotocol/server';
 import { Registry } from 'prom-client';
@@ -244,7 +244,7 @@ export class AtlasTelemetry implements ITelemetry {
     // (undocumented)
     protected readonly serverMetadata: ServerMetadata;
     // (undocumented)
-    protected setup(): Promise<void>;
+    setup(): Promise<void>;
     setupPromise: Promise<[string, boolean]> | undefined;
 }
 

--- a/api-extractor/reports/mongodb-mcp-server.public.api.md
+++ b/api-extractor/reports/mongodb-mcp-server.public.api.md
@@ -16,6 +16,7 @@ import { EventEmitter } from 'events';
 import express from 'express';
 import type { FetchOptions } from 'openapi-fetch';
 import type { FindCursor } from 'mongodb';
+import type { MongoClient } from 'mongodb';
 import { Gauge } from 'prom-client';
 import { Histogram } from 'prom-client';
 import type http from 'http';
@@ -442,6 +443,7 @@ export interface ConnectionManagerEvents {
 export interface ConnectionSettings extends Omit<ConnectionInfo, "driverOptions"> {
     driverOptions?: ConnectionInfo["driverOptions"];
     hostType?: ConnectionStringHostType;
+    mongoClient?: MongoClient;
 }
 
 // @public (undocumented)

--- a/api-extractor/reports/tools.public.api.md
+++ b/api-extractor/reports/tools.public.api.md
@@ -15,6 +15,7 @@ import type { ElicitRequestFormParams } from '@modelcontextprotocol/server';
 import { EventEmitter } from 'events';
 import type { FetchOptions } from 'openapi-fetch';
 import type { FindCursor } from 'mongodb';
+import type { MongoClient } from 'mongodb';
 import { InputRequiredResult } from '@modelcontextprotocol/server';
 import type { InputResponses } from '@modelcontextprotocol/server';
 import type { LoggingMessageNotification } from '@modelcontextprotocol/server';
@@ -732,6 +733,7 @@ export interface ConnectionSettings extends Omit<ConnectionInfo_2, "driverOption
     // (undocumented)
     atlas?: AtlasClusterConnectionInfo;
     driverOptions?: ConnectionInfo_2["driverOptions"];
+    mongoClient?: MongoClient;
 }
 
 // @public (undocumented)

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -13,6 +13,7 @@ import type { ElicitRequestFormParams } from '@modelcontextprotocol/server';
 import { EventEmitter } from 'events';
 import type { FetchOptions } from 'openapi-fetch';
 import type { FindCursor } from 'mongodb';
+import type { MongoClient } from 'mongodb';
 import { Gauge } from 'prom-client';
 import { Histogram } from 'prom-client';
 import { InputRequiredResult } from '@modelcontextprotocol/server';
@@ -349,6 +350,7 @@ export type ConnectionMetadata = AtlasMetadata & AtlasLocalToolMetadata & {
 export interface ConnectionSettings extends Omit<ConnectionInfo, "driverOptions"> {
     driverOptions?: ConnectionInfo["driverOptions"];
     hostType?: ConnectionStringHostType;
+    mongoClient?: MongoClient;
 }
 
 // @public (undocumented)

--- a/api-extractor/reports/web.public.api.md
+++ b/api-extractor/reports/web.public.api.md
@@ -13,13 +13,13 @@ import type { ElicitRequestFormParams } from '@modelcontextprotocol/server';
 import { EventEmitter } from 'events';
 import type { FetchOptions } from 'openapi-fetch';
 import type { FindCursor } from 'mongodb';
-import type { MongoClient } from 'mongodb';
 import { Gauge } from 'prom-client';
 import { Histogram } from 'prom-client';
 import { InputRequiredResult } from '@modelcontextprotocol/server';
 import type { InputResponses } from '@modelcontextprotocol/server';
 import type { LoggingMessageNotification } from '@modelcontextprotocol/server';
 import type { McpServer } from '@modelcontextprotocol/server';
+import { MongoClient } from 'mongodb';
 import { NodeDriverServiceProvider } from '@mongosh/service-provider-node-driver';
 import type { RequestMeta } from '@modelcontextprotocol/server';
 import { Secret } from 'mongodb-redact';
@@ -677,7 +677,7 @@ export class Telemetry implements ITelemetry {
     // (undocumented)
     protected readonly serverMetadata: ServerMetadata;
     // (undocumented)
-    protected setup(): Promise<void>;
+    setup(): Promise<void>;
     setupPromise: Promise<[string, boolean]> | undefined;
 }
 

--- a/packages/atlas-telemetry/src/atlasTelemetry.ts
+++ b/packages/atlas-telemetry/src/atlasTelemetry.ts
@@ -135,7 +135,7 @@ export class AtlasTelemetry implements ITelemetry {
         return detectContainerEnvImpl();
     }
 
-    protected async setup(): Promise<void> {
+    public async setup(): Promise<void> {
         if (!this.isTelemetryEnabled()) {
             this.logger.info({
                 id: LogId.telemetryEmitFailure,

--- a/packages/tools-mongodb/src/common/connectionManager.injectMongoClient.test.ts
+++ b/packages/tools-mongodb/src/common/connectionManager.injectMongoClient.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MongoClient } from "mongodb";
+import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import { CompositeLogger } from "@mongodb-js/mcp-core";
+import { MCPConnectionManager } from "./connectionManager.js";
+import { DeviceId } from "../helpers/deviceId.js";
+
+vi.mock("@mongosh/service-provider-node-driver");
+
+const MockNodeDriverServiceProvider = vi.mocked(NodeDriverServiceProvider);
+
+describe("MCPConnectionManager.connect with an injected mongoClient", () => {
+    const logger = new CompositeLogger();
+    const deviceId = vi.mocked(DeviceId.create(new CompositeLogger()));
+
+    function buildManager(): MCPConnectionManager {
+        deviceId.get = vi.fn().mockReturnValue("test-device-id");
+        return new MCPConnectionManager({
+            logger,
+            deviceId,
+            serverMetadata: { mcpServerName: "MongoDB MCP Server", version: "1.0.0" },
+            connectionInfo: { transport: "stdio", httpHost: "127.0.0.1" },
+        });
+    }
+
+    beforeEach(() => {
+        MockNodeDriverServiceProvider.connect = vi.fn().mockResolvedValue({});
+        // The auto-mocked class instance returned by `new` is a plain object.
+        vi.mocked(MockNodeDriverServiceProvider.prototype).connect = vi.fn();
+    });
+
+    it("wraps a provided mongoClient directly, bypassing NodeDriverServiceProvider.connect (devtools-connect)", async () => {
+        const manager = buildManager();
+        const mongoClient = {} as MongoClient;
+
+        const state = await manager.connect({
+            connectionString: "mongodb://localhost:27017",
+            mongoClient,
+        });
+
+        expect(state.tag).toBe("connected");
+        // devtools-connect path must NOT be hit when a client is injected.
+        expect(MockNodeDriverServiceProvider.connect).not.toHaveBeenCalled();
+        // ...but the client is wrapped into a provider via the constructor.
+        expect(MockNodeDriverServiceProvider).toHaveBeenCalled();
+        const constructorArgs = vi.mocked(MockNodeDriverServiceProvider).mock.calls[0]?.[0];
+        expect(constructorArgs).toBe(mongoClient);
+    });
+
+    it("still uses NodeDriverServiceProvider.connect when no mongoClient is provided", async () => {
+        const manager = buildManager();
+
+        await manager.connect({ connectionString: "mongodb://localhost:27017" });
+
+        expect(MockNodeDriverServiceProvider.connect).toHaveBeenCalled();
+    });
+});

--- a/packages/tools-mongodb/src/common/connectionManager.injectMongoClient.test.ts
+++ b/packages/tools-mongodb/src/common/connectionManager.injectMongoClient.test.ts
@@ -52,15 +52,4 @@ describe("MCPConnectionManager.connect with an injected mongoClient", () => {
 
         expect(MockNodeDriverServiceProvider.connect).toHaveBeenCalled();
     });
-
-    it("rejects an injected mongoClient for an OIDC connection (the OIDC flow is not started)", async () => {
-        const manager = buildManager();
-
-        await expect(
-            manager.connect({
-                connectionString: "mongodb://localhost:27017?authMechanism=MONGODB-OIDC",
-                mongoClient: {} as MongoClient,
-            })
-        ).rejects.toThrow(/Cannot inject a MongoClient for an OIDC connection/);
-    });
 });

--- a/packages/tools-mongodb/src/common/connectionManager.injectMongoClient.test.ts
+++ b/packages/tools-mongodb/src/common/connectionManager.injectMongoClient.test.ts
@@ -14,7 +14,7 @@ describe("MCPConnectionManager.connect with an injected mongoClient", () => {
     const deviceId = vi.mocked(DeviceId.create(new CompositeLogger()));
 
     function buildManager(): MCPConnectionManager {
-        deviceId.get = vi.fn().mockReturnValue("test-device-id");
+        deviceId.get = vi.fn().mockResolvedValue("test-device-id");
         return new MCPConnectionManager({
             logger,
             deviceId,
@@ -53,5 +53,16 @@ describe("MCPConnectionManager.connect with an injected mongoClient", () => {
         await manager.connect({ connectionString: "mongodb://localhost:27017" });
 
         expect(MockNodeDriverServiceProvider.connect).toHaveBeenCalled();
+    });
+
+    it("rejects an injected mongoClient for an OIDC connection (the OIDC flow is not started)", async () => {
+        const manager = buildManager();
+
+        await expect(
+            manager.connect({
+                connectionString: "mongodb://localhost:27017?authMechanism=MONGODB-OIDC",
+                mongoClient: {} as MongoClient,
+            })
+        ).rejects.toThrow(/Cannot inject a MongoClient for an OIDC connection/);
     });
 });

--- a/packages/tools-mongodb/src/common/connectionManager.injectMongoClient.test.ts
+++ b/packages/tools-mongodb/src/common/connectionManager.injectMongoClient.test.ts
@@ -25,8 +25,6 @@ describe("MCPConnectionManager.connect with an injected mongoClient", () => {
 
     beforeEach(() => {
         MockNodeDriverServiceProvider.connect = vi.fn().mockResolvedValue({});
-        // The auto-mocked class instance returned by `new` is a plain object.
-        vi.mocked(MockNodeDriverServiceProvider.prototype).connect = vi.fn();
     });
 
     it("wraps a provided mongoClient directly, bypassing NodeDriverServiceProvider.connect (devtools-connect)", async () => {

--- a/packages/tools-mongodb/src/common/connectionManager.ts
+++ b/packages/tools-mongodb/src/common/connectionManager.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
-import { MongoServerError } from "mongodb";
+import { MongoServerError, type MongoClient } from "mongodb";
 import { NodeDriverServiceProvider } from "@mongosh/service-provider-node-driver";
+import { ConnectionString } from "mongodb-connection-string-url";
 import {
     generateConnectionInfoFromCliArgs,
     type CliOptions,
@@ -34,6 +35,15 @@ export interface ConnectionSettings extends Omit<MongoshConnectionInfo, "driverO
      * private or mesh address is still classified as Atlas.
      */
     hostType?: ConnectionStringHostType;
+    /**
+     * A pre-connected {@link MongoClient} to wrap instead of building one via
+     * devtools-connect. When set, the manager skips the devtools-connect path
+     * (which builds a per-connection proxy Agent and merges the system CA
+     * bundle) and wraps the provided client directly. Callers that dial a
+     * plain connection requiring no proxy/OIDC (e.g. a manual X.509 data-plane
+     * connect) use this to avoid that per-connection overhead.
+     */
+    mongoClient?: MongoClient;
 }
 
 export type ConnectionTag = "connected" | "connecting" | "disconnected" | "errored";
@@ -440,16 +450,26 @@ export class MCPConnectionManager extends ConnectionManager {
                 settings.hostType
             );
 
-            serviceProvider = NodeDriverServiceProvider.connect(
-                mongoshConnectionInfo.connectionString,
-                {
-                    productDocsLink: "https://github.com/mongodb-js/mongodb-mcp-server/",
-                    productName: "MongoDB MCP",
-                    ...mongoshConnectionInfo.driverOptions,
-                },
-                undefined,
-                this.bus
-            );
+            const clientOptions = {
+                productDocsLink: "https://github.com/mongodb-js/mongodb-mcp-server/",
+                productName: "MongoDB MCP",
+                ...mongoshConnectionInfo.driverOptions,
+            };
+            serviceProvider = settings.mongoClient
+                ? Promise.resolve(
+                      new NodeDriverServiceProvider(
+                          settings.mongoClient,
+                          this.bus,
+                          clientOptions,
+                          new ConnectionString(mongoshConnectionInfo.connectionString)
+                      )
+                  )
+                : NodeDriverServiceProvider.connect(
+                      mongoshConnectionInfo.connectionString,
+                      clientOptions,
+                      undefined,
+                      this.bus
+                  );
         } catch (error: unknown) {
             const errorReason = error instanceof Error ? error.message : `${error as string}`;
             this.changeState("connection-error", {

--- a/packages/tools-mongodb/src/common/connectionManager.ts
+++ b/packages/tools-mongodb/src/common/connectionManager.ts
@@ -450,6 +450,13 @@ export class MCPConnectionManager extends ConnectionManager {
                 settings.hostType
             );
 
+            if (settings.mongoClient && connectionStringInfo.authType.startsWith("oidc")) {
+                throw new Error(
+                    "Cannot inject a MongoClient for an OIDC connection: the OIDC plugin flow is not " +
+                        "started when connect() skips NodeDriverServiceProvider.connect()."
+                );
+            }
+
             const clientOptions = {
                 productDocsLink: "https://github.com/mongodb-js/mongodb-mcp-server/",
                 productName: "MongoDB MCP",

--- a/packages/tools-mongodb/src/common/connectionManager.ts
+++ b/packages/tools-mongodb/src/common/connectionManager.ts
@@ -450,13 +450,6 @@ export class MCPConnectionManager extends ConnectionManager {
                 settings.hostType
             );
 
-            if (settings.mongoClient && connectionStringInfo.authType.startsWith("oidc")) {
-                throw new Error(
-                    "Cannot inject a MongoClient for an OIDC connection: the OIDC plugin flow is not " +
-                        "started when connect() skips NodeDriverServiceProvider.connect()."
-                );
-            }
-
             const clientOptions = {
                 productDocsLink: "https://github.com/mongodb-js/mongodb-mcp-server/",
                 productName: "MongoDB MCP",


### PR DESCRIPTION
## What

Two changes in the mcp-* packages:

1. **tools-mongodb**: add an optional `mongoClient` to `ConnectionSettings`. When set, `MCPConnectionManager.connect()` skips `NodeDriverServiceProvider.connect()` (which builds a per-connection proxy Agent + merged system CA via devtools-connect) and wraps the provided client in a `NodeDriverServiceProvider` directly.

2. **atlas-telemetry**: make `AtlasTelemetry.setup()` public so consumers that construct a subclass directly can kick off setup without a subclass `start()` wrapper.

## Why

- The devtools-connect path is wasted for plain connections that need no proxy/OIDC (e.g. a manual X.509 data-plane dial). Injecting a pre-connected client lets consumers bypass that overhead while keeping the appName/connectionStringInfo derivation and state transitions.
- `setup()` was only reachable via the static `create()` (or a subclass). Consumers constructing a subclass directly to carry per-session common properties need to trigger setup after construction.

## Notes

Backward compatible: with no `mongoClient`, `connect()` behaves exactly as before; `setup()` remains callable the same way. Added tests for both connect paths and verified the atlas-telemetry suite.